### PR TITLE
Perf/hotpath optimization

### DIFF
--- a/ansible/measure_usage.yml
+++ b/ansible/measure_usage.yml
@@ -341,6 +341,63 @@
     sample_dir: /tmp/metrics
     haproxy_host: "{{ (groups.get('haproxy', []) | length > 0) | ternary(groups['haproxy'][0], '') }}"
   tasks:
+    # Stop perf FIRST (before any other cleanup) to ensure the target
+    # process is still alive when perf flushes its data.
+    - name: Stop perf and generate reports (lineairdb) [early]
+      when: (enable_perf | bool) and inventory_hostname in groups.get('lineairdb', [])
+      shell: |
+        if [ -f {{ sample_dir }}/perf-server-{{ run_id }}.pid ]; then
+          PID=$(cat {{ sample_dir }}/perf-server-{{ run_id }}.pid)
+          if kill -0 "$PID" 2>/dev/null; then
+            kill -INT "$PID"
+            # Wait for perf to finish writing
+            for i in $(seq 1 30); do
+              kill -0 "$PID" 2>/dev/null || break
+              sleep 1
+            done
+          fi
+        fi
+        if [ -f {{ sample_dir }}/perf-server-{{ run_id }}.data ] && \
+           [ "$(stat -c%s {{ sample_dir }}/perf-server-{{ run_id }}.data 2>/dev/null)" -gt 1000 ]; then
+          {{ perf_bin | default('perf') }} report -i {{ sample_dir }}/perf-server-{{ run_id }}.data \
+            --stdio --no-children -g none --percent-limit 0.1 \
+            > {{ sample_dir }}/perf-report-server-{{ run_id }}.txt 2>&1
+          {{ perf_bin | default('perf') }} report -i {{ sample_dir }}/perf-server-{{ run_id }}.data \
+            --stdio --no-children -g flat,0,caller --percent-limit 0.5 \
+            > {{ sample_dir }}/perf-callers-server-{{ run_id }}.txt 2>&1
+          rm -f {{ sample_dir }}/perf-server-{{ run_id }}.data
+        fi
+      args:
+        executable: /bin/bash
+      failed_when: false
+
+    - name: Stop perf and generate reports (mysql) [early]
+      when: (enable_perf | bool) and inventory_hostname in groups.get('mysql', [])
+      shell: |
+        if [ -f {{ sample_dir }}/perf-proxy-{{ run_id }}.pid ]; then
+          PID=$(cat {{ sample_dir }}/perf-proxy-{{ run_id }}.pid)
+          if kill -0 "$PID" 2>/dev/null; then
+            kill -INT "$PID"
+            for i in $(seq 1 30); do
+              kill -0 "$PID" 2>/dev/null || break
+              sleep 1
+            done
+          fi
+        fi
+        if [ -f {{ sample_dir }}/perf-proxy-{{ run_id }}.data ] && \
+           [ "$(stat -c%s {{ sample_dir }}/perf-proxy-{{ run_id }}.data 2>/dev/null)" -gt 1000 ]; then
+          {{ perf_bin | default('perf') }} report -i {{ sample_dir }}/perf-proxy-{{ run_id }}.data \
+            --stdio --no-children -g none --percent-limit 0.1 \
+            > {{ sample_dir }}/perf-report-proxy-{{ run_id }}.txt 2>&1
+          {{ perf_bin | default('perf') }} report -i {{ sample_dir }}/perf-proxy-{{ run_id }}.data \
+            --stdio --no-children -g flat,0,caller --percent-limit 0.5 \
+            > {{ sample_dir }}/perf-callers-proxy-{{ run_id }}.txt 2>&1
+          rm -f {{ sample_dir }}/perf-proxy-{{ run_id }}.data
+        fi
+      args:
+        executable: /bin/bash
+      failed_when: false
+
     - name: Stop mpstat sampling
       when: inventory_hostname not in groups.get('haproxy', [])
       shell: |
@@ -483,46 +540,6 @@
       when: (enable_perf | bool) and (inventory_hostname in groups.get('lineairdb', []) + groups.get('mysql', []))
       set_fact:
         perf_bin: "{{ perf_bin_report.stdout | default('perf') }}"
-
-    - name: Stop perf and generate reports (lineairdb)
-      when: (enable_perf | bool) and inventory_hostname in groups.get('lineairdb', [])
-      shell: |
-        if [ -f {{ sample_dir }}/perf-server-{{ run_id }}.pid ]; then
-          kill -INT "$(cat {{ sample_dir }}/perf-server-{{ run_id }}.pid)" || true
-          sleep 5
-        fi
-        if [ -f {{ sample_dir }}/perf-server-{{ run_id }}.data ]; then
-          {{ perf_bin }} report -i {{ sample_dir }}/perf-server-{{ run_id }}.data \
-            --stdio --no-children -g none --percent-limit 0.1 \
-            > {{ sample_dir }}/perf-report-server-{{ run_id }}.txt 2>&1
-          {{ perf_bin }} report -i {{ sample_dir }}/perf-server-{{ run_id }}.data \
-            --stdio --no-children -g flat,0,caller --percent-limit 0.5 \
-            > {{ sample_dir }}/perf-callers-server-{{ run_id }}.txt 2>&1
-          rm -f {{ sample_dir }}/perf-server-{{ run_id }}.data
-        fi
-      args:
-        executable: /bin/bash
-      failed_when: false
-
-    - name: Stop perf and generate reports (mysql)
-      when: (enable_perf | bool) and inventory_hostname in groups.get('mysql', [])
-      shell: |
-        if [ -f {{ sample_dir }}/perf-proxy-{{ run_id }}.pid ]; then
-          kill -INT "$(cat {{ sample_dir }}/perf-proxy-{{ run_id }}.pid)" || true
-          sleep 5
-        fi
-        if [ -f {{ sample_dir }}/perf-proxy-{{ run_id }}.data ]; then
-          {{ perf_bin }} report -i {{ sample_dir }}/perf-proxy-{{ run_id }}.data \
-            --stdio --no-children -g none --percent-limit 0.1 \
-            > {{ sample_dir }}/perf-report-proxy-{{ run_id }}.txt 2>&1
-          {{ perf_bin }} report -i {{ sample_dir }}/perf-proxy-{{ run_id }}.data \
-            --stdio --no-children -g flat,0,caller --percent-limit 0.5 \
-            > {{ sample_dir }}/perf-callers-proxy-{{ run_id }}.txt 2>&1
-          rm -f {{ sample_dir }}/perf-proxy-{{ run_id }}.data
-        fi
-      args:
-        executable: /bin/bash
-      failed_when: false
 
     - name: Package bench logs
       when: inventory_hostname in groups['benchbase']

--- a/ansible/measure_usage.yml
+++ b/ansible/measure_usage.yml
@@ -9,6 +9,8 @@
     run_id: "run"
     sample_dir: /tmp/metrics
     haproxy_stats_interval: 5
+    enable_perf: false
+    perf_freq: 99
     haproxy_stats_auth: "admin:password"
     haproxy_host: "{{ (groups.get('haproxy', []) | length > 0) | ternary(groups['haproxy'][0], '') }}"
   tasks:
@@ -227,6 +229,66 @@
       args:
         executable: /bin/bash
 
+    - name: Install perf and configure sysctl (lineairdb + mysql)
+      when: (enable_perf | bool) and (inventory_hostname in groups.get('lineairdb', []) + groups.get('mysql', []))
+      become: yes
+      shell: |
+        apt-get install -y -qq linux-tools-aws 2>/dev/null || true
+        sysctl -w kernel.perf_event_paranoid=0
+        sysctl -w kernel.kptr_restrict=0
+      args:
+        executable: /bin/bash
+
+    - name: Detect perf binary path (lineairdb + mysql)
+      when: (enable_perf | bool) and (inventory_hostname in groups.get('lineairdb', []) + groups.get('mysql', []))
+      shell: |
+        find /usr/lib/linux-*-tools-* -name perf -type f 2>/dev/null | head -1
+      register: perf_bin_result
+      args:
+        executable: /bin/bash
+
+    - name: Set perf binary fact
+      when: (enable_perf | bool) and (inventory_hostname in groups.get('lineairdb', []) + groups.get('mysql', []))
+      set_fact:
+        perf_bin: "{{ perf_bin_result.stdout | default('') }}"
+
+    - name: Warn if perf not found
+      when: (enable_perf | bool) and (inventory_hostname in groups.get('lineairdb', []) + groups.get('mysql', [])) and (perf_bin is not defined or perf_bin == '')
+      debug:
+        msg: "WARNING: perf binary not found on {{ inventory_hostname }}, skipping profiling"
+
+    - name: Start perf record on lineairdb server
+      when: (enable_perf | bool) and inventory_hostname in groups.get('lineairdb', []) and (perf_bin is defined and perf_bin != '')
+      shell: |
+        mkdir -p {{ sample_dir }}
+        pid=$(pgrep -f '/build/server/lineairdb-server' | head -n1 || true)
+        if [ -z "$pid" ]; then
+          echo "lineairdb-server not running, skipping perf" > {{ sample_dir }}/perf-server-{{ run_id }}.log
+          exit 0
+        fi
+        nohup {{ perf_bin }} record -g -F {{ perf_freq }} -p "$pid" \
+          -o {{ sample_dir }}/perf-server-{{ run_id }}.data \
+          -- sleep 3600 > {{ sample_dir }}/perf-server-{{ run_id }}.log 2>&1 &
+        echo $! > {{ sample_dir }}/perf-server-{{ run_id }}.pid
+      args:
+        executable: /bin/bash
+
+    - name: Start perf record on mysqld
+      when: (enable_perf | bool) and inventory_hostname in groups.get('mysql', []) and (perf_bin is defined and perf_bin != '')
+      shell: |
+        mkdir -p {{ sample_dir }}
+        pid=$(pgrep -f 'mysqld.*lineairdb' | head -n1 || true)
+        if [ -z "$pid" ]; then
+          echo "mysqld not running, skipping perf" > {{ sample_dir }}/perf-proxy-{{ run_id }}.log
+          exit 0
+        fi
+        nohup {{ perf_bin }} record -g -F {{ perf_freq }} -p "$pid" \
+          -o {{ sample_dir }}/perf-proxy-{{ run_id }}.data \
+          -- sleep 3600 > {{ sample_dir }}/perf-proxy-{{ run_id }}.log 2>&1 &
+        echo $! > {{ sample_dir }}/perf-proxy-{{ run_id }}.pid
+      args:
+        executable: /bin/bash
+
 - hosts: mysql
   gather_facts: false
   vars:
@@ -407,6 +469,60 @@
         fi
       args:
         executable: /bin/bash
+
+    - name: Detect perf binary path for report (lineairdb + mysql)
+      when: (enable_perf | bool) and (inventory_hostname in groups.get('lineairdb', []) + groups.get('mysql', []))
+      shell: |
+        find /usr/lib/linux-*-tools-* -name perf -type f 2>/dev/null | head -1
+      register: perf_bin_report
+      args:
+        executable: /bin/bash
+      failed_when: false
+
+    - name: Set perf binary fact for report
+      when: (enable_perf | bool) and (inventory_hostname in groups.get('lineairdb', []) + groups.get('mysql', []))
+      set_fact:
+        perf_bin: "{{ perf_bin_report.stdout | default('perf') }}"
+
+    - name: Stop perf and generate reports (lineairdb)
+      when: (enable_perf | bool) and inventory_hostname in groups.get('lineairdb', [])
+      shell: |
+        if [ -f {{ sample_dir }}/perf-server-{{ run_id }}.pid ]; then
+          kill -INT "$(cat {{ sample_dir }}/perf-server-{{ run_id }}.pid)" || true
+          sleep 5
+        fi
+        if [ -f {{ sample_dir }}/perf-server-{{ run_id }}.data ]; then
+          {{ perf_bin }} report -i {{ sample_dir }}/perf-server-{{ run_id }}.data \
+            --stdio --no-children -g none --percent-limit 0.1 \
+            > {{ sample_dir }}/perf-report-server-{{ run_id }}.txt 2>&1
+          {{ perf_bin }} report -i {{ sample_dir }}/perf-server-{{ run_id }}.data \
+            --stdio --no-children -g flat,0,caller --percent-limit 0.5 \
+            > {{ sample_dir }}/perf-callers-server-{{ run_id }}.txt 2>&1
+          rm -f {{ sample_dir }}/perf-server-{{ run_id }}.data
+        fi
+      args:
+        executable: /bin/bash
+      failed_when: false
+
+    - name: Stop perf and generate reports (mysql)
+      when: (enable_perf | bool) and inventory_hostname in groups.get('mysql', [])
+      shell: |
+        if [ -f {{ sample_dir }}/perf-proxy-{{ run_id }}.pid ]; then
+          kill -INT "$(cat {{ sample_dir }}/perf-proxy-{{ run_id }}.pid)" || true
+          sleep 5
+        fi
+        if [ -f {{ sample_dir }}/perf-proxy-{{ run_id }}.data ]; then
+          {{ perf_bin }} report -i {{ sample_dir }}/perf-proxy-{{ run_id }}.data \
+            --stdio --no-children -g none --percent-limit 0.1 \
+            > {{ sample_dir }}/perf-report-proxy-{{ run_id }}.txt 2>&1
+          {{ perf_bin }} report -i {{ sample_dir }}/perf-proxy-{{ run_id }}.data \
+            --stdio --no-children -g flat,0,caller --percent-limit 0.5 \
+            > {{ sample_dir }}/perf-callers-proxy-{{ run_id }}.txt 2>&1
+          rm -f {{ sample_dir }}/perf-proxy-{{ run_id }}.data
+        fi
+      args:
+        executable: /bin/bash
+      failed_when: false
 
     - name: Package bench logs
       when: inventory_hostname in groups['benchbase']
@@ -613,4 +729,26 @@
         src: "{{ sample_dir }}/vmstat-{{ run_id }}.log"
         dest: "{{ result_dir }}/vmstat/{{ inventory_hostname }}/"
         flat: yes
+      failed_when: false
+
+    - name: Fetch perf reports (lineairdb)
+      when: (enable_perf | bool) and inventory_hostname in groups.get('lineairdb', [])
+      fetch:
+        src: "{{ item }}"
+        dest: "{{ result_dir }}/lineairdb/{{ inventory_hostname }}/"
+        flat: yes
+      loop:
+        - "{{ sample_dir }}/perf-report-server-{{ run_id }}.txt"
+        - "{{ sample_dir }}/perf-callers-server-{{ run_id }}.txt"
+      failed_when: false
+
+    - name: Fetch perf reports (mysql)
+      when: (enable_perf | bool) and inventory_hostname in groups.get('mysql', [])
+      fetch:
+        src: "{{ item }}"
+        dest: "{{ result_dir }}/mysql/{{ inventory_hostname }}/"
+        flat: yes
+      loop:
+        - "{{ sample_dir }}/perf-report-proxy-{{ run_id }}.txt"
+        - "{{ sample_dir }}/perf-callers-proxy-{{ run_id }}.txt"
       failed_when: false

--- a/ansible/py/bench_aws.py
+++ b/ansible/py/bench_aws.py
@@ -344,6 +344,8 @@ def run_benchmarks(args, run_id):
         exec_vars += f" bench_serial={'true' if args.bench_serial else 'false'}"
     if args.bench_profile:
         exec_vars += f" bench_profile={args.bench_profile}"
+    if args.perf:
+        exec_vars += " enable_perf=true"
 
     log(f"Running benchmark: {exec_vars}")
     run_playbook("measure_usage.yml", extra_vars=exec_vars)
@@ -476,6 +478,7 @@ Examples:
     parser.add_argument("--bench-profile", default=None, help="YCSB profile: a,b,c,e,f")
     parser.add_argument("--bench-serial", default=None, type=lambda x: x.lower() == "true",
                         help="TPC-H serial mode (true/false)")
+    parser.add_argument("--perf", action="store_true", help="Enable perf profiling on lineairdb + mysql nodes")
 
     # AWS options
     parser.add_argument("--region", default=AWS_DEFAULTS["region"])

--- a/ansible/py/bench_aws.py
+++ b/ansible/py/bench_aws.py
@@ -73,7 +73,7 @@ AWS_DEFAULTS = {
 # vCPU count for EC2 instance sizes (used to build machine_spec locally)
 _VCPU_BY_SIZE = {
     "xlarge": 4, "2xlarge": 8, "4xlarge": 16, "8xlarge": 32,
-    "12xlarge": 48, "16xlarge": 64, "24xlarge": 96, "metal": 128,
+    "12xlarge": 48, "16xlarge": 64, "24xlarge": 96, "32xlarge": 128, "metal": 128,
 }
 
 

--- a/ansible/py/plot_perf.py
+++ b/ansible/py/plot_perf.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""
+Parse perf report --stdio output and generate breakdown charts.
+Usage: python3 plot_perf.py <perf-report.txt> [--output <output.png>]
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import matplotlib
+matplotlib.use("Agg")
+
+
+def parse_perf_report(path):
+    """Parse perf report --stdio --no-children -g none output."""
+    entries = []
+    with open(path) as f:
+        for line in f:
+            m = re.match(r'\s+(\d+\.\d+)%\s+\S+\s+(\S+)\s+\[([.\w])\]\s+(.*)', line)
+            if m:
+                pct = float(m.group(1))
+                lib = m.group(2)
+                kind = m.group(3)
+                symbol = m.group(4).strip()
+                entries.append((pct, lib, kind, symbol))
+    return entries
+
+
+SCHED_YIELD_SYMBOLS = {
+    "clear_bhb_loop", "entry_SYSCALL_64", "update_curr", "__schedule",
+    "pvclock_clocksource_read_nowd", "__calc_delta.constprop.0",
+    "pick_task_fair", "update_min_vruntime", "__sched_yield",
+    "arch_exit_to_user_mode_prepare.isra.0", "pick_eevdf",
+    "update_curr_se", "do_syscall_64", "its_return_thunk",
+    "syscall_return_via_sysret", "native_queued_spin_lock_slowpath",
+    "update_rq_clock", "do_sched_yield", "x64_sys_call",
+    "syscall_exit_to_user_mode", "entry_SYSCALL_64_after_hwframe",
+    "raw_spin_rq_lock_nested", "pick_next_task_fair", "cpuacct_charge",
+    "__pick_next_task", "pick_next_task", "syscall_exit_to_user_mode_prepare",
+    "native_write_msr", "cgroup_rstat_updated", "schedule",
+    "fpregs_assert_state_consistent", "update_curr_dl_se",
+    "raw_spin_rq_unlock_irq", "__cgroup_account_cputime",
+    "entry_SYSCALL_64_safe_stack", "rcu_note_context_switch",
+    "vruntime_eligible", "sched_clock_cpu", "available_idle_cpu",
+    "yield_task_fair", "kvm_sched_clock_read", "dl_server_update",
+    "update_sg_lb_stats", "psi_group_change", "entry_SYSRETQ_unsafe_stack",
+    "rcu_qs", "__x64_sys_sched_yield", "sched_clock",
+    "raw_spin_rq_unlock", "restore_fpregs_from_fpstate",
+    "sched_clock_noinstr", "read_tsc", "dequeue_entity",
+    "__update_load_avg_se", "finish_task_switch.isra.0",
+    "__update_load_avg_cfs_rq", "dequeue_entities",
+    "sched_update_worker", "update_load_avg",
+    "__raw_spin_lock_irqsave", "_raw_spin_lock_bh",
+    "_raw_spin_lock", "arch_scale_cpu_capacity",
+}
+
+NETWORK_SYMBOLS_SUBSTR = [
+    "tcp_", "ena_", "recv", "send", "skb_", "ip_finish",
+    "__dev_xmit", "vfs_writev", "fdget", "__sys_recvfrom",
+    "__sys_sendto", "softirq", "aa_inet_msg_perm",
+    "kmem_cache_alloc", "skb_release", "check_heap_object",
+    "ip_output", "__irqentry",
+]
+
+SCHED_SUBCATEGORIES = {
+    "CFS scheduler": {
+        "update_curr", "__schedule", "__calc_delta.constprop.0",
+        "pick_task_fair", "update_min_vruntime", "pick_eevdf",
+        "update_curr_se", "pick_next_task_fair", "__pick_next_task",
+        "pick_next_task", "update_curr_dl_se", "vruntime_eligible",
+        "yield_task_fair", "dequeue_entity", "dequeue_entities",
+        "update_load_avg", "__update_load_avg_se", "__update_load_avg_cfs_rq",
+        "dl_server_update", "update_sg_lb_stats", "schedule",
+    },
+    "syscall entry": {
+        "clear_bhb_loop", "entry_SYSCALL_64", "entry_SYSCALL_64_after_hwframe",
+        "entry_SYSCALL_64_safe_stack", "do_syscall_64", "x64_sys_call",
+        "__x64_sys_sched_yield", "do_sched_yield",
+    },
+    "syscall return": {
+        "arch_exit_to_user_mode_prepare.isra.0", "syscall_return_via_sysret",
+        "syscall_exit_to_user_mode", "syscall_exit_to_user_mode_prepare",
+        "entry_SYSRETQ_unsafe_stack", "its_return_thunk",
+        "restore_fpregs_from_fpstate", "fpregs_assert_state_consistent",
+    },
+    "run-queue spinlock": {
+        "_raw_spin_lock", "native_queued_spin_lock_slowpath",
+        "raw_spin_rq_lock_nested", "raw_spin_rq_unlock_irq",
+        "raw_spin_rq_unlock", "_raw_spin_lock_bh",
+        "__raw_spin_lock_irqsave",
+    },
+    "clock read": {
+        "pvclock_clocksource_read_nowd", "update_rq_clock",
+        "kvm_sched_clock_read", "sched_clock_cpu", "sched_clock",
+        "sched_clock_noinstr", "read_tsc",
+    },
+    "accounting": {
+        "cpuacct_charge", "__cgroup_account_cputime", "cgroup_rstat_updated",
+        "native_write_msr", "rcu_note_context_switch", "rcu_qs",
+        "psi_group_change", "available_idle_cpu", "sched_update_worker",
+        "finish_task_switch.isra.0", "arch_scale_cpu_capacity",
+    },
+}
+
+
+def classify(symbol, lib, kind):
+    if symbol == "__sched_yield":
+        return "sched_yield"
+    clean = symbol.split("(")[0].strip()
+    if clean in SCHED_YIELD_SYMBOLS:
+        return "sched_yield"
+    if lib == "libc.so.6" and symbol.startswith("0x"):
+        return "sched_yield"
+    for substr in NETWORK_SYMBOLS_SUBSTR:
+        if substr in symbol.lower():
+            return "network"
+    if kind == "k":
+        return "kernel_other"
+    if "jemalloc" in lib:
+        return "alloc"
+    if "protobuf" in lib:
+        return "protobuf"
+    if lib == "lineairdb-server":
+        return "lineairdb"
+    if "libstdc++" in lib:
+        return "libstdcpp"
+    return "other_user"
+
+
+def classify_sched_sub(symbol):
+    clean = symbol.split("(")[0].strip()
+    for subcat, syms in SCHED_SUBCATEGORIES.items():
+        if clean in syms:
+            return subcat
+    if symbol == "__sched_yield":
+        return "__sched_yield (libc)"
+    return "other"
+
+
+# --- Proxy-specific classification ---
+PROXY_CATEGORIES = {
+    "context_switch": {"finish_task_switch.isra.0"},
+    "mysql_parser": {"MYSQLparse", "lex_one_token", "Lex_hash::get_hash_symbol",
+                     "digest_add_token", "MYSQLlex"},
+    "mysql_optimizer": {"fold_condition", "JOIN::optimize", "open_table", "open_tables",
+                        "find_field_in_table", "setup_fields", "Item_field::set_field",
+                        "Item_field::fix_fields", "Item::itemize",
+                        "Query_block::add_table_to_list", "check_stack_overrun",
+                        "dispatch_sql_command", "Sql_cmd_dml::execute",
+                        "Sql_cmd_update::update_single_table", "mysql_execute_command"},
+    "mysql_executor": {"dispatch_command", "THD::store_cached_properties",
+                       "pfs_end_statement_vc", "cleanup_items",
+                       "insert_events_statements_history", "pfs_start_stage_v1",
+                       "pfs_start_statement_vc", "THD::enter_stage",
+                       "decimal2bin", "my_well_formed_len_utf8mb4",
+                       "PFS_buffer_scalable_container"},
+    "mysql_other": {"my_lfind", "my_strcasecmp_utf8mb3", "my_malloc", "my_free"},
+}
+
+
+def classify_proxy(symbol, lib, kind):
+    clean = symbol.split("(")[0].strip()
+    # ha_lineairdb
+    if "ha_lineairdb" in lib:
+        return "ha_lineairdb"
+    # protobuf
+    if "protobuf" in lib:
+        return "protobuf"
+    # jemalloc
+    if "jemalloc" in lib:
+        return "alloc"
+    # Network
+    for substr in NETWORK_SYMBOLS_SUBSTR:
+        if substr in symbol.lower():
+            return "network"
+    # Proxy-specific categories
+    for cat, syms in PROXY_CATEGORIES.items():
+        for s in syms:
+            if s in clean:
+                return cat
+    # pthread
+    if "pthread" in symbol:
+        return "pthread"
+    # kernel
+    if kind == "k":
+        return "kernel_other"
+    # libstdc++
+    if "libstdc++" in lib:
+        return "libstdcpp"
+    # mysqld binary (uncategorized)
+    if lib == "mysqld":
+        return "mysql_other"
+    return "other_user"
+
+
+CATEGORY_LABELS = {
+    "sched_yield": "sched_yield (EpochFramework Sync)",
+    "network": "Network (TCP + ENA)",
+    "kernel_other": "Kernel (other)",
+    "lineairdb": "LineairDB processing",
+    "alloc": "Allocator (jemalloc)",
+    "protobuf": "Protobuf",
+    "libstdcpp": "libstdc++",
+    "other_user": "Other",
+    "unresolved": "Other (unresolved)",
+    # proxy
+    "ha_lineairdb": "ha_lineairdb (SE plugin)",
+    "mysql_parser": "MySQL parser + lexer",
+    "mysql_optimizer": "MySQL optimizer",
+    "mysql_executor": "MySQL executor + PFS",
+    "mysql_other": "MySQL other",
+    "context_switch": "Context switch",
+    "pthread": "pthread",
+}
+
+CATEGORY_COLORS = {
+    "sched_yield": "#e74c3c",
+    "network": "#3498db",
+    "kernel_other": "#95a5a6",
+    "lineairdb": "#2ecc71",
+    "alloc": "#f39c12",
+    "protobuf": "#9b59b6",
+    "libstdcpp": "#1abc9c",
+    "other_user": "#bdc3c7",
+    "unresolved": "#ecf0f1",
+    # proxy
+    "ha_lineairdb": "#2ecc71",
+    "mysql_parser": "#e67e22",
+    "mysql_optimizer": "#d35400",
+    "mysql_executor": "#e74c3c",
+    "mysql_other": "#f39c12",
+    "context_switch": "#c0392b",
+    "pthread": "#8e44ad",
+}
+
+SCHED_SUB_COLORS = {
+    "CFS scheduler": "#c0392b",
+    "syscall entry": "#e74c3c",
+    "syscall return": "#ff6b6b",
+    "run-queue spinlock": "#ee5a24",
+    "clock read": "#f8a5a5",
+    "accounting": "#fab1a0",
+    "__sched_yield (libc)": "#d63031",
+    "other": "#e17055",
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Plot perf report breakdown")
+    parser.add_argument("input", help="perf report --stdio text file")
+    parser.add_argument("--output", "-o", default=None, help="Output PNG path")
+    parser.add_argument("--vcpu", type=int, default=64, help="vCPU count")
+    parser.add_argument("--mode", default="server", choices=["server", "proxy"],
+                        help="server (lineairdb) or proxy (mysqld)")
+    args = parser.parse_args()
+
+    entries = parse_perf_report(args.input)
+    if not entries:
+        print("No entries parsed.", file=sys.stderr)
+        return 1
+
+    classifier = classify if args.mode == "server" else classify_proxy
+
+    # Aggregate
+    categories = {}
+    sched_subs = {}
+    for pct, lib, kind, symbol in entries:
+        cat = classifier(symbol, lib, kind)
+        categories[cat] = categories.get(cat, 0.0) + pct
+        if cat == "sched_yield":
+            sub = classify_sched_sub(symbol)
+            sched_subs[sub] = sched_subs.get(sub, 0.0) + pct
+
+    # Add unresolved remainder to reach 100%
+    total_parsed = sum(categories.values())
+    if total_parsed < 100.0:
+        categories["unresolved"] = 100.0 - total_parsed
+
+    ordered = sorted(categories.items(), key=lambda x: -x[1])
+    sched_ordered = sorted(sched_subs.items(), key=lambda x: -x[1])
+    has_sched = "sched_yield" in categories and categories["sched_yield"] > 5
+
+    # Print table
+    total = sum(v for _, v in ordered)
+    print(f"{'Category':<30} {'CPU%':>8} {'vCPU':>8}")
+    print("-" * 48)
+    for cat, pct in ordered:
+        vcpu = args.vcpu * pct / 100
+        print(f"{cat:<30} {pct:>7.1f}% {vcpu:>7.1f}")
+        if cat == "sched_yield":
+            for sub, spct in sched_ordered:
+                svcpu = args.vcpu * spct / 100
+                print(f"  {sub:<28} {spct:>7.1f}% {svcpu:>7.1f}")
+    print("-" * 48)
+    print(f"{'Total':<30} {total:>7.1f}% {args.vcpu * total / 100:>7.1f}")
+
+    # --- Figure ---
+    ncols = 2 if has_sched else 1
+    fig, axes = plt.subplots(1, ncols + 1, figsize=(6 * (ncols + 1), 6),
+                             gridspec_kw={"width_ratios": [1.2] + [1] * ncols})
+
+    # Panel 1: Pie chart (categories)
+    ax_pie = axes[0]
+    labels = [CATEGORY_LABELS.get(c, c) for c, _ in ordered]
+    sizes = [v for _, v in ordered]
+    colors = [CATEGORY_COLORS.get(c, "#cccccc") for c, _ in ordered]
+
+    wedges, texts, autotexts = ax_pie.pie(
+        sizes, labels=None,
+        autopct=lambda p: '',  # we add custom labels below
+        colors=colors, startangle=90, pctdistance=0.78,
+        textprops={"fontsize": 10, "fontweight": "bold"},
+        wedgeprops=dict(edgecolor="white", linewidth=1.5),
+    )
+    # Add original % as text on each wedge
+    for wedge, pct in zip(wedges, sizes):
+        if pct < 2:
+            continue
+        ang = (wedge.theta2 + wedge.theta1) / 2
+        import numpy as np
+        x = 0.65 * np.cos(np.deg2rad(ang))
+        y = 0.65 * np.sin(np.deg2rad(ang))
+        ax_pie.text(x, y, f"{pct:.1f}%", ha="center", va="center",
+                    fontsize=9, fontweight="bold",
+                    color="white" if pct > 10 else "black")
+    ax_pie.legend(wedges, [f"{l} ({s:.1f}%)" for l, s in zip(labels, sizes)],
+                  loc="center left", bbox_to_anchor=(-0.45, 0.5), fontsize=7.5)
+
+    mode_label = "LineairDB Server" if args.mode == "server" else "MySQL Proxy"
+    ax_pie.set_title(f"{mode_label}\nCPU Breakdown ({args.vcpu} vCPU)", fontsize=12)
+
+    # Panel 2: Top functions bar chart (all categories)
+    ax_top = axes[1]
+    top_n = 20
+    top_entries = sorted(entries, key=lambda x: -x[0])[:top_n]
+    func_names = []
+    func_pcts = []
+    func_colors = []
+    for pct, lib, kind, symbol in top_entries:
+        cat = classifier(symbol, lib, kind)
+        # Shorten symbol name
+        name = symbol.split("(")[0].strip()
+        if len(name) > 35:
+            name = name[:32] + "..."
+        func_names.append(name)
+        func_pcts.append(pct)
+        func_colors.append(CATEGORY_COLORS.get(cat, "#cccccc"))
+
+    bars = ax_top.barh(range(len(func_names) - 1, -1, -1), func_pcts[::-1],
+                       color=func_colors[::-1], edgecolor="white", linewidth=0.5)
+    ax_top.set_yticks(range(len(func_names) - 1, -1, -1))
+    ax_top.set_yticklabels(func_names[::-1], fontsize=7)
+    ax_top.set_xlabel("CPU %", fontsize=10)
+    ax_top.set_title(f"Top {top_n} Functions", fontsize=12)
+    for bar, pct in zip(bars, func_pcts[::-1]):
+        if pct > 0.5:
+            ax_top.text(bar.get_width() + 0.1, bar.get_y() + bar.get_height() / 2,
+                        f"{pct:.1f}%", va="center", fontsize=7)
+
+    # Panel 3: sched_yield sub-breakdown (server only)
+    if has_sched:
+        ax_sub = axes[2]
+        sub_names = [s for s, _ in sched_ordered]
+        sub_pcts = [p for _, p in sched_ordered]
+        sub_vcpus = [args.vcpu * p / 100 for p in sub_pcts]
+        sub_colors = [SCHED_SUB_COLORS.get(s, "#e74c3c") for s in sub_names]
+
+        bars = ax_sub.barh(range(len(sub_names) - 1, -1, -1), sub_vcpus[::-1],
+                           color=sub_colors[::-1], edgecolor="white", linewidth=0.5)
+        ax_sub.set_yticks(range(len(sub_names) - 1, -1, -1))
+        ax_sub.set_yticklabels(sub_names[::-1], fontsize=9)
+        ax_sub.set_xlabel("vCPU", fontsize=10)
+        ax_sub.set_title(f"sched_yield Breakdown\n({categories['sched_yield']:.1f}% = {args.vcpu * categories['sched_yield'] / 100:.1f} vCPU)",
+                         fontsize=12, color="#c0392b")
+        for bar, v, p in zip(bars, sub_vcpus[::-1], sub_pcts[::-1]):
+            if v > 0.5:
+                ax_sub.text(bar.get_width() + 0.2, bar.get_y() + bar.get_height() / 2,
+                            f"{v:.1f} vCPU ({p:.1f}%)", va="center", fontsize=8)
+
+    plt.tight_layout()
+    output = args.output or str(Path(args.input).with_suffix(".png"))
+    plt.savefig(output, dpi=150, bbox_inches="tight")
+    print(f"\nSaved: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/bin/benchrun.py
+++ b/bench/bin/benchrun.py
@@ -267,8 +267,14 @@ def _start_metrics(metrics_dir):
         p = subprocess.Popen(["pidstat", "-t", "-u", "-p", server_pid, "5"], stdout=f, stderr=subprocess.DEVNULL)
         samplers.append(("pidstat-server-threads", p, f))
 
-    # pidstat for mysqld
-    mysql_pid = _find_pid("mysqld.*lineairdb")
+    # pidstat for mysqld — use PID file to get the actual mysqld process,
+    # not the wrapper script that pgrep might pick up first.
+    mysql_pid = None
+    mysql_pidfile = Path("/tmp/mysql.pid")
+    if mysql_pidfile.exists():
+        mysql_pid = mysql_pidfile.read_text().strip()
+    if not mysql_pid:
+        mysql_pid = _find_pid("mysqld.*lineairdb")
     if mysql_pid:
         f = open(metrics_dir / "pidstat-mysql.log", "w")
         p = subprocess.Popen(["pidstat", "-u", "-w", "-p", mysql_pid, interval], stdout=f, stderr=subprocess.DEVNULL)

--- a/bench/bin/benchrun.py
+++ b/bench/bin/benchrun.py
@@ -13,9 +13,14 @@ Usage:
   python3 bench/bin/benchrun.py ycsb --profile a --terminals 8 --scalefactor 100
 
 Prerequisites:
-  - Ordo server running (scripts/start_server.sh)
-  - MySQL running with LineairDB plugin (scripts/start_mysql.sh)
   - BenchBase patched and built (bench/bin/patch_benchbase.py)
+
+Server lifecycle:
+  By default, this script auto-starts lineairdb-server + mysqld at the
+  beginning and stops them at the end. Pass --external-server to opt out
+  (e.g. when running against a remote MySQL or when servers are already
+  managed externally). Auto-detection: if mysqld is already listening on
+  --mysql-port, the script falls back to external mode automatically.
 """
 
 import argparse
@@ -23,11 +28,14 @@ import json
 import os
 import re
 import shutil
+import socket
 import subprocess
 import sys
 import time
 from datetime import datetime
 from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
 
 ROOT = Path(__file__).resolve().parents[2]
 BENCHBASE_DIR = ROOT / "third_party" / "benchbase" / "benchbase-mysql"
@@ -42,6 +50,104 @@ YCSB_PROFILES = {
 }
 
 os.environ["LD_PRELOAD"] = "/lib/x86_64-linux-gnu/libjemalloc.so.2"
+
+
+def _is_port_open(host, port, timeout=1.0):
+    """Return True if a TCP listener is accepting connections on host:port."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except (ConnectionRefusedError, socket.timeout, OSError):
+        return False
+
+
+def _wait_for_port(host, port, timeout=30):
+    """Block until host:port is open or timeout expires. Returns True on success."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if _is_port_open(host, port):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def _run_script(argv, timeout):
+    """Run a launcher script with stdin closed and a hard timeout.
+
+    The launcher scripts spawn long-lived background daemons that previously
+    inherited our pipe and blocked subprocess drainage forever. The scripts now
+    redirect those daemons to a log file, but we still close stdin and apply a
+    timeout here as defense in depth.
+    """
+    try:
+        return subprocess.run(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as e:
+        print(f"  ERROR: launcher timed out after {timeout}s: {' '.join(argv)}", file=sys.stderr)
+        if e.stdout:
+            print(e.stdout[-1000:], file=sys.stderr)
+        return None
+
+
+def start_lineairdb_server():
+    """Start lineairdb-server via scripts/start_server.sh and wait for port 9999."""
+    if _is_port_open("127.0.0.1", 9999):
+        print("  lineairdb-server already running on port 9999, reusing")
+        return True
+    print("  Starting lineairdb-server...")
+    result = _run_script([str(SCRIPTS_DIR / "start_server.sh")], timeout=30)
+    if result is None or result.returncode != 0:
+        if result is not None:
+            print(f"  ERROR starting lineairdb-server:\n{result.stdout}", file=sys.stderr)
+        return False
+    if not _wait_for_port("127.0.0.1", 9999, timeout=30):
+        print("  ERROR: lineairdb-server did not become ready within 30s", file=sys.stderr)
+        return False
+    print("  lineairdb-server ready (port 9999)")
+    return True
+
+
+def start_mysql_server(mysqld_port=3307, server_host="127.0.0.1", server_port=9999):
+    """Start mysqld via scripts/start_mysql.sh."""
+    if _is_port_open("127.0.0.1", mysqld_port):
+        print(f"  mysqld already running on port {mysqld_port}, reusing")
+        return True
+    print(f"  Starting mysqld (port {mysqld_port})...")
+    result = _run_script(
+        [str(SCRIPTS_DIR / "start_mysql.sh"),
+         "--mysqld-port", str(mysqld_port),
+         "--server-host", server_host,
+         "--server-port", str(server_port)],
+        timeout=120,  # initialize-insecure on first run can be slow
+    )
+    if result is None or result.returncode != 0:
+        if result is not None:
+            print(f"  ERROR starting mysqld:\n{result.stdout[-1000:]}", file=sys.stderr)
+        return False
+    if not _wait_for_port("127.0.0.1", mysqld_port, timeout=30):
+        print(f"  ERROR: mysqld did not become ready within 30s", file=sys.stderr)
+        return False
+    print(f"  mysqld ready (port {mysqld_port})")
+    return True
+
+
+def stop_all_servers():
+    """Stop mysqld and lineairdb-server via the stop scripts."""
+    print("  Stopping mysqld + lineairdb-server...")
+    subprocess.run([str(SCRIPTS_DIR / "stop_mysql.sh")], capture_output=True)
+    subprocess.run([str(SCRIPTS_DIR / "stop_server.sh")], capture_output=True)
+    time.sleep(2)
+    for f in ["/tmp/lineairdb_server.pid", "/tmp/mysql.pid"]:
+        try:
+            Path(f).unlink()
+        except FileNotFoundError:
+            pass
 
 
 def mysql_cmd(port, host, sql):
@@ -499,6 +605,8 @@ def main():
     parser.add_argument("--no-setup", action="store_true", help="Skip setup (DROP+CREATE+LOAD), assume data exists")
     parser.add_argument("--no-load", action="store_true", help="Run setup with CREATE only, skip LOAD")
     parser.add_argument("--no-exec", action="store_true", help="Run setup only, skip execute phase")
+    parser.add_argument("--external-server", action="store_true",
+                        help="Skip auto start/stop of lineairdb-server and mysqld (assume already running)")
     args = parser.parse_args()
 
     # Validate
@@ -583,6 +691,34 @@ def main():
     print(f"SF={args.scalefactor}, Time={args.time}s, MySQL={args.mysql_host}:{args.mysql_port}")
     print(f"Results:   {result_base}")
 
+    # Decide whether to manage server lifecycle.
+    # Skip management when --external-server is set, when targeting a remote
+    # mysqld (--mysql-host != localhost), or when something is already
+    # listening on the configured mysql port.
+    managed = not args.external_server
+    if managed and args.mysql_host not in ("127.0.0.1", "localhost"):
+        print(f"  --mysql-host={args.mysql_host} is not local, switching to external mode")
+        managed = False
+    if managed and _is_port_open("127.0.0.1", args.mysql_port):
+        print(f"  mysqld already listening on port {args.mysql_port}, switching to external mode")
+        managed = False
+
+    if managed:
+        if not start_lineairdb_server():
+            sys.exit(1)
+        if not start_mysql_server(args.mysql_port, "127.0.0.1", 9999):
+            stop_all_servers()
+            sys.exit(1)
+
+    try:
+        _run_bench(args, config_work, thread_list, result_base)
+    finally:
+        if managed:
+            stop_all_servers()
+
+
+def _run_bench(args, config_work, thread_list, result_base):
+    """Setup + execute sweep + summary + plots. Extracted so main() can wrap it."""
     # Setup phase
     load_time = None
     if args.no_setup:

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -3268,9 +3268,9 @@ int ha_lineairdb::set_fields_from_lineairdb(uchar *buf,
    * if you want to make the first potentially null column to show a non-null
    * value, store 0xfe, or b11111110, in buf
    */
-  auto nullFlags = ldbField.get_null_flags();
+  const auto nullFlags = ldbField.get_null_flags();
   for (size_t i = 0; i < nullFlags.size(); i++) {
-    buf[i] = nullFlags[i];
+    buf[i] = static_cast<uchar>(nullFlags[i]);
   }
 
   /* Avoid asserts in ::store() for columns that are not going to be updated
@@ -3285,7 +3285,7 @@ int ha_lineairdb::set_fields_from_lineairdb(uchar *buf,
     if ((*field)->is_nullable() && (*field)->is_null_in_record(buf)) {
       (*field)->set_null();
     } else {
-      (*field)->store(mysqlFieldValue.c_str(), mysqlFieldValue.length(),
+      (*field)->store(mysqlFieldValue.data(), mysqlFieldValue.size(),
                       &my_charset_bin, CHECK_FIELD_WARN);
       if (store_blob_to_field(field))
         return HA_ERR_OUT_OF_MEM;

--- a/proxy/lineairdb_field.cc
+++ b/proxy/lineairdb_field.cc
@@ -73,7 +73,10 @@ void LineairDBField::set_lineairdb_field(
 
 void LineairDBField::make_mysql_table_row(const std::byte *const ldbRawData,
                                           const size_t length) {
+  // Zero-copy parse: record each field as a string_view pointing into
+  // ldbRawData. No per-field allocations, no string copies.
   row.clear();
+  nullFlagView = {};
 
   for (size_t offset = 0; offset < length;) {
     const auto ldbField = ldbRawData + offset;
@@ -82,10 +85,8 @@ void LineairDBField::make_mysql_table_row(const std::byte *const ldbRawData,
         static_cast<char>(convert_bytes_to_numeric(ldbField, sizeof(byteSize)));
 
     if (byteSize == noValue) {
-      if (offset == 0) {
-        nullFlag.clear();
-      } else {
-        row.emplace_back("");
+      if (offset != 0) {
+        row.emplace_back();  // empty field
       }
       offset += sizeof(byteSize);
       continue;
@@ -100,17 +101,13 @@ void LineairDBField::make_mysql_table_row(const std::byte *const ldbRawData,
     assert(valueLength <= maxValueLength);
     const auto valueData = ldbField + byteSizeForRead + sizeof(byteSize);
 
-    value.assign(reinterpret_cast<const char *>(valueData), valueLength);
-    if (offset == 0)
-      nullFlag = value;
-    else
-      row.emplace_back(value);
+    std::string_view field_view(reinterpret_cast<const char *>(valueData),
+                                valueLength);
+    if (offset == 0) {
+      nullFlagView = field_view;
+    } else {
+      row.emplace_back(field_view);
+    }
     offset += sizeof(byteSize) + byteSizeForRead + valueLength;
   }
-}
-
-const std::string &LineairDBField::get_null_flags() const { return nullFlag; }
-
-const std::string &LineairDBField::get_column_of_row(const size_t i) const {
-  return row[i];
 }

--- a/proxy/lineairdb_field.hh
+++ b/proxy/lineairdb_field.hh
@@ -3,6 +3,7 @@
 
 #include <climits>
 #include <string>
+#include <string_view>
 #include <variant>
 #include <vector>
 
@@ -44,11 +45,16 @@ class LineairDBField {
 
   /**
    * @brief These methods are called for SELECT statements.
+   *
+   * make_mysql_table_row parses the LineairDB-encoded row and records each
+   * field as a (pointer, length) pair into ldbRawData. No allocations or
+   * copies are performed — the caller MUST keep ldbRawData alive while
+   * iterating via get_column_of_row().
    */
   void make_mysql_table_row(const std::byte* const ldbRawData,
                             const size_t length);
-  const std::string& get_null_flags() const;
-  const std::string& get_column_of_row(const size_t i) const;
+  std::string_view get_null_flags() const { return nullFlagView; }
+  std::string_view get_column_of_row(const size_t i) const { return row[i]; }
 
   LineairDBField() = default;
 
@@ -60,8 +66,9 @@ class LineairDBField {
   std::string valueLength;
   std::string value;
 
-  std::string nullFlag;
-  std::vector<std::string> row;
+  // Zero-copy row parsing: views point into the caller-owned ldbRawData.
+  std::string_view nullFlagView;
+  std::vector<std::string_view> row;
 
   void set_header(const size_t num);
   char convert_numeric_to_a_byte(const size_t num) const;

--- a/scripts/start_mysql.sh
+++ b/scripts/start_mysql.sh
@@ -26,7 +26,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/build"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR/build"
 
 # jemalloc: use LD_PRELOAD to replace glibc malloc
 JEMALLOC="/lib/x86_64-linux-gnu/libjemalloc.so.2"
@@ -45,6 +46,13 @@ if [ "$MYSQLD_PORT" != "3307" ]; then
   PID_FILE="/tmp/mysql_${MYSQLD_PORT}.pid"
 fi
 
+# Per-instance log so the background mysqld does not inherit the caller's
+# stdout/stderr (otherwise subprocess.run() in benchrun.py blocks forever
+# waiting for the inherited pipe to close).
+MYSQL_LOG_DIR="$ROOT_DIR/lineairdb_logs"
+mkdir -p "$MYSQL_LOG_DIR"
+MYSQL_LOG_FILE="$MYSQL_LOG_DIR/mysqld_${MYSQLD_PORT}_$(date +%Y%m%d_%H%M%S).log"
+
 # Step 1: Initialize if data directory doesn't exist
 if [ ! -d "$DATA_DIR" ] || [ ! -f "$DATA_DIR/ibdata1" ]; then
   echo "Step 1/5: Initializing MySQL data directory..."
@@ -57,7 +65,7 @@ echo "Step 2/5: Starting MySQL with InnoDB..."
   --max-connections=16384 \
   --open-files-limit=65535 \
   --table-open-cache=8192 \
-  --disable-log-bin &
+  --disable-log-bin >> "$MYSQL_LOG_FILE" 2>&1 &
 BOOT_PID=$!
 
 echo "Step 3/5: Waiting for MySQL to be ready..."
@@ -74,13 +82,14 @@ kill "$BOOT_PID" 2>/dev/null || true
 wait "$BOOT_PID" 2>/dev/null || true
 sleep 3
 
-./runtime_output_directory/mysqld --datadir="$DATA_DIR" --socket="$SOCKET" --port="$MYSQLD_PORT" \
+nohup ./runtime_output_directory/mysqld --datadir="$DATA_DIR" --socket="$SOCKET" --port="$MYSQLD_PORT" \
   --pid-file="$PID_FILE" --default-storage-engine=lineairdb \
   --max-connections=16384 \
   --open-files-limit=65535 \
   --table-open-cache=8192 \
-  --disable-log-bin &
+  --disable-log-bin >> "$MYSQL_LOG_FILE" 2>&1 &
 MYSQL_PID=$!
+disown "$MYSQL_PID" 2>/dev/null || true
 
 until ./runtime_output_directory/mysqladmin ping -u root --socket="$SOCKET" --port="$MYSQLD_PORT" >/dev/null 2>&1; do
   sleep 1
@@ -95,3 +104,4 @@ echo "Port      : $MYSQLD_PORT"
 echo "Data dir  : $DATA_DIR"
 echo "Socket    : $SOCKET"
 echo "Server    : ${SERVER_HOST}:${SERVER_PORT}"
+echo "Log       : $MYSQL_LOG_FILE"


### PR DESCRIPTION
- LineairDB: eliminate sched_yield
  - condition_variable for epoch synchronization (Sync, Fence, WaitForIndexIsLinearizable)
  - _mm_pause for OCC lock-bit spin-wait loops
  - sleep_for / cv for thread pool and callback manager drain paths
- proxy: zero-copy row parsing via string_view
- ansible: perf profiling support (measure_usage.yml + bench_aws.py --perf + plot_perf.py)
- bench: managed server lifecycle in benchrun.py, MySQL pidstat fix
- misc: 32xlarge vCPU mapping, mysqld stdout redirect, perf stop ordering fix
