### PR TITLE
Feat/masstree integration

### DIFF
--- a/ansible/lineairdb.yml
+++ b/ansible/lineairdb.yml
@@ -6,8 +6,9 @@
   tasks:
     - name: Sync ordo repo + submodules
       shell: |
+        set -euo pipefail
         cd ~/ordo
-        ./scripts/stop_server.sh
+        ./scripts/stop_server.sh || true
         git fetch origin
         git checkout {{ ordo_branch | default('main') }}
         git pull --ff-only
@@ -27,6 +28,7 @@
 
     - name: Build server + proxy
       shell: |
+        set -euo pipefail
         cd ~/ordo
         ./scripts/build_partial.sh 2>&1 | tail -40
       args:
@@ -39,6 +41,7 @@
 
     - name: Start LineairDB-Server
       shell: |
+        set -euo pipefail
         cd ~/ordo
         ulimit -n {{ lineairdb_nofile_limit }}
         ./scripts/start_server.sh

--- a/ansible/lineairdb.yml
+++ b/ansible/lineairdb.yml
@@ -4,19 +4,42 @@
   vars:
     lineairdb_nofile_limit: 1048576
   tasks:
-    - name: Start LineairDB-Server
+    - name: Sync ordo repo + submodules
       shell: |
         cd ~/ordo
         ./scripts/stop_server.sh
         git fetch origin
         git checkout {{ ordo_branch | default('main') }}
-        git pull --ff-only || true
-        git submodule update --init --recursive || true
-        echo "Ordo($(git rev-parse --abbrev-ref HEAD)@$(git rev-parse --short HEAD)),"\
-             "LineairDB($(cd third_party/LineairDB && git rev-parse --abbrev-ref HEAD)@$(cd third_party/LineairDB && git rev-parse --short HEAD)),"\
-             "mysql-server($(cd third_party/mysql-server && git rev-parse --abbrev-ref HEAD)@$(cd third_party/mysql-server && git rev-parse --short HEAD)),"\
-             "benchbase($(cd third_party/benchbase && git rev-parse --abbrev-ref HEAD)@$(cd third_party/benchbase && git rev-parse --short HEAD))"
-        ./scripts/build_partial.sh
+        git pull --ff-only
+        git submodule update --init --recursive
+        echo "=== SHAs ==="
+        echo "Ordo($(git rev-parse --abbrev-ref HEAD)@$(git rev-parse --short HEAD))"
+        echo "LineairDB($(cd third_party/LineairDB && git rev-parse --abbrev-ref HEAD)@$(cd third_party/LineairDB && git rev-parse --short HEAD))"
+        echo "mysql-server($(cd third_party/mysql-server && git rev-parse --abbrev-ref HEAD)@$(cd third_party/mysql-server && git rev-parse --short HEAD))"
+        echo "benchbase($(cd third_party/benchbase && git rev-parse --abbrev-ref HEAD)@$(cd third_party/benchbase && git rev-parse --short HEAD))"
+      args:
+        executable: /bin/bash
+      register: sync_result
+
+    - name: Show repo / submodule SHAs
+      debug:
+        var: sync_result.stdout_lines
+
+    - name: Build server + proxy
+      shell: |
+        cd ~/ordo
+        ./scripts/build_partial.sh 2>&1 | tail -40
+      args:
+        executable: /bin/bash
+      register: build_result
+
+    - name: Show build tail
+      debug:
+        var: build_result.stdout_lines
+
+    - name: Start LineairDB-Server
+      shell: |
+        cd ~/ordo
         ulimit -n {{ lineairdb_nofile_limit }}
         ./scripts/start_server.sh
       args:

--- a/ansible/measure_usage.yml
+++ b/ansible/measure_usage.yml
@@ -339,6 +339,7 @@
   vars:
     run_id: "run"
     sample_dir: /tmp/metrics
+    enable_perf: false
     haproxy_host: "{{ (groups.get('haproxy', []) | length > 0) | ternary(groups['haproxy'][0], '') }}"
   tasks:
     # Stop perf FIRST (before any other cleanup) to ensure the target

--- a/ansible/mysql.yml
+++ b/ansible/mysql.yml
@@ -4,8 +4,9 @@
   tasks:
     - name: Sync ordo repo + submodules
       shell: |
+        set -euo pipefail
         cd ~/ordo
-        ./scripts/stop_mysql.sh
+        ./scripts/stop_mysql.sh || true
         git fetch origin
         git checkout {{ ordo_branch | default('main') }}
         git pull --ff-only
@@ -25,6 +26,7 @@
 
     - name: Build server + proxy
       shell: |
+        set -euo pipefail
         cd ~/ordo
         ./scripts/build_partial.sh 2>&1 | tail -40
       args:
@@ -37,6 +39,7 @@
 
     - name: Start MySQL with LineairDB-Proxy
       shell: |
+        set -euo pipefail
         cd ~/ordo
         ./scripts/start_mysql.sh \
           --mysqld-port 3307 \
@@ -47,6 +50,7 @@
 
     - name: apply bench/setup.sql
       shell: |
+        set -euo pipefail
         ~/ordo/build/runtime_output_directory/mysql \
           -u root --protocol=TCP -h 127.0.0.1 -P 3307 \
           < ~/ordo/bench/setup.sql
@@ -56,6 +60,7 @@
     # Note: BenchBase connects directly to each MySQL for setup to avoid DDL sync issues via HAProxy.
     - name: Create HAProxy and BenchBase access users
       shell: |
+        set -euo pipefail
         ~/ordo/build/runtime_output_directory/mysql \
           -u root --protocol=TCP -h 127.0.0.1 -P 3307 \
           -e "CREATE USER IF NOT EXISTS 'haproxy_check'@'%' IDENTIFIED WITH mysql_native_password BY '';

--- a/ansible/mysql.yml
+++ b/ansible/mysql.yml
@@ -2,19 +2,42 @@
 - hosts: mysql
   gather_facts: false
   tasks:
-    - name: Start MySQL with LineairDB-Proxy
+    - name: Sync ordo repo + submodules
       shell: |
         cd ~/ordo
         ./scripts/stop_mysql.sh
         git fetch origin
         git checkout {{ ordo_branch | default('main') }}
-        git pull --ff-only || true
-        git submodule update --init --recursive || true
-        echo "Ordo($(git rev-parse --abbrev-ref HEAD)@$(git rev-parse --short HEAD)),"\
-             "LineairDB($(cd third_party/LineairDB && git rev-parse --abbrev-ref HEAD)@$(cd third_party/LineairDB && git rev-parse --short HEAD)),"\
-             "mysql-server($(cd third_party/mysql-server && git rev-parse --abbrev-ref HEAD)@$(cd third_party/mysql-server && git rev-parse --short HEAD)),"\
-             "benchbase($(cd third_party/benchbase && git rev-parse --abbrev-ref HEAD)@$(cd third_party/benchbase && git rev-parse --short HEAD))"
-        ./scripts/build_partial.sh
+        git pull --ff-only
+        git submodule update --init --recursive
+        echo "=== SHAs ==="
+        echo "Ordo($(git rev-parse --abbrev-ref HEAD)@$(git rev-parse --short HEAD))"
+        echo "LineairDB($(cd third_party/LineairDB && git rev-parse --abbrev-ref HEAD)@$(cd third_party/LineairDB && git rev-parse --short HEAD))"
+        echo "mysql-server($(cd third_party/mysql-server && git rev-parse --abbrev-ref HEAD)@$(cd third_party/mysql-server && git rev-parse --short HEAD))"
+        echo "benchbase($(cd third_party/benchbase && git rev-parse --abbrev-ref HEAD)@$(cd third_party/benchbase && git rev-parse --short HEAD))"
+      args:
+        executable: /bin/bash
+      register: sync_result
+
+    - name: Show repo / submodule SHAs
+      debug:
+        var: sync_result.stdout_lines
+
+    - name: Build server + proxy
+      shell: |
+        cd ~/ordo
+        ./scripts/build_partial.sh 2>&1 | tail -40
+      args:
+        executable: /bin/bash
+      register: build_result
+
+    - name: Show build tail
+      debug:
+        var: build_result.stdout_lines
+
+    - name: Start MySQL with LineairDB-Proxy
+      shell: |
+        cd ~/ordo
         ./scripts/start_mysql.sh \
           --mysqld-port 3307 \
           --server-host {{ hostvars['lineairdb-1'].private_ip }} \

--- a/ansible/py/bench_aws.py
+++ b/ansible/py/bench_aws.py
@@ -359,9 +359,35 @@ def run_benchmarks(args, run_id):
         run(f"python3 {SCRIPT_DIR / 'plot_tpcc.py'} --root {result_root}", check=False)
     if args.bench_type == "tpch":
         run(f"python3 {SCRIPT_DIR / 'plot_tpch.py'} --root {result_root}", check=False)
+    if args.perf:
+        _plot_perf_reports(result_root)
 
     log(f"Benchmark complete. run_id={run_id}")
     return run_id
+
+
+def _plot_perf_reports(result_root):
+    """Render plot_perf.py for every collected perf-report-*.txt under result_root."""
+    config_root = result_root / build_machine_spec()
+    plot_dir = config_root / "_plot"
+    plot_dir.mkdir(parents=True, exist_ok=True)
+
+    role_modes = {"lineairdb": "server", "mysql": "proxy"}
+    for role, mode in role_modes.items():
+        cfg = CLUSTER.get(role)
+        if not cfg:
+            continue
+        size = cfg["instance_type"].split(".")[-1]
+        vcpu = _VCPU_BY_SIZE.get(size, 0)
+        if vcpu == 0:
+            continue
+        for report in sorted((config_root / role).glob(f"*/perf-report-{mode}-*.txt")):
+            output = plot_dir / f"perf_{report.parent.name}.png"
+            run(
+                f"python3 {SCRIPT_DIR / 'plot_perf.py'} {report} "
+                f"--vcpu {vcpu} --mode {mode} --output {output}",
+                check=False,
+            )
 
 
 # ──────────────────────────────────────────────

--- a/ansible/py/bench_aws.py
+++ b/ansible/py/bench_aws.py
@@ -48,12 +48,12 @@ CLUSTER = {
     },
     "haproxy": {
         "tag": "ordo-haproxy",
-        "instance_type": "c6i.4xlarge",
+        "instance_type": "c6i.8xlarge",
         "count": 1,
     },
     "benchbase": {
         "tag": "ordo-bench",
-        "instance_type": "c6i.4xlarge",
+        "instance_type": "c6i.16xlarge",
         "count": 1,
     },
 }
@@ -65,7 +65,7 @@ AWS_DEFAULTS = {
     "ssh_key": "~/.ssh/ordo-aws.pem",
     "ssh_user": "ubuntu",
     # On-demand fallback params (extracted from launch template)
-    "ami_id": "ami-03ce71439341a2e5f",
+    "ami_id": "ami-0dcfb21660acb41dd",
     "security_group": "sg-02d9a0d5948d02dbb",
     "subnet": "subnet-0a15ff55a4cae198b",  # ap-southeast-2c (same-AZ pinning)
 }

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -299,14 +299,13 @@ message DbCreateSecondaryIndex {
     }
 }
 
-// Scan keys in [start_key, end_key] range, excluding exclusive_end_key.
+// Scan keys in [start_key, end_key) range.
 // @see LineairDBTransaction::get_matching_keys_in_range()
 message TxGetMatchingKeysInRange {
     message Request {
         int64 transaction_id = 1;
         bytes start_key = 2;
         bytes end_key = 3;
-        bytes exclusive_end_key = 4;
         string table_name = 5;
     }
     message Response {
@@ -315,7 +314,7 @@ message TxGetMatchingKeysInRange {
     }
 }
 
-// Scan key-value pairs in [start_key, end_key] range, excluding exclusive_end_key.
+// Scan key-value pairs in [start_key, end_key) range.
 // Skips tombstones (null/zero-length values).
 // @see LineairDBTransaction::get_matching_keys_and_values_in_range()
 message TxGetMatchingKeysAndValuesInRange {
@@ -323,7 +322,6 @@ message TxGetMatchingKeysAndValuesInRange {
         int64 transaction_id = 1;
         bytes start_key = 2;
         bytes end_key = 3;
-        bytes exclusive_end_key = 4;
         PushedPredicate filter = 5;
         string table_name = 6;
     }
@@ -349,15 +347,13 @@ message TxGetMatchingKeysAndValuesFromPrefix {
     }
 }
 
-// Reverse scan to find the last key in [start_key, end_key] range,
-// excluding exclusive_end_key.
+// Reverse scan to find the last key in [start_key, end_key) range.
 // @see LineairDBTransaction::fetch_last_key_in_range()
 message TxFetchLastKeyInRange {
     message Request {
         int64 transaction_id = 1;
         bytes start_key = 2;
         bytes end_key = 3;
-        bytes exclusive_end_key = 4;
         string table_name = 5;
     }
     message Response {
@@ -399,8 +395,7 @@ message TxFetchNextKeyWithPrefix {
     }
 }
 
-// Scan primary keys from a secondary index in [start_key, end_key] range,
-// excluding exclusive_end_key.
+// Scan primary keys from a secondary index in [start_key, end_key) range.
 // @see LineairDBTransaction::get_matching_primary_keys_in_range()
 message TxGetMatchingPrimaryKeysInRange {
     message Request {
@@ -408,7 +403,6 @@ message TxGetMatchingPrimaryKeysInRange {
         string index_name = 2;
         bytes start_key = 3;
         bytes end_key = 4;
-        bytes exclusive_end_key = 5;
         string table_name = 6;
     }
     message Response {
@@ -433,7 +427,7 @@ message TxGetMatchingPrimaryKeysFromPrefix {
 }
 
 // Reverse scan to find the last primary key in a secondary index range
-// [start_key, end_key], excluding exclusive_end_key.
+// [start_key, end_key).
 // @see LineairDBTransaction::fetch_last_primary_key_in_secondary_range()
 message TxFetchLastPrimaryKeyInSecondaryRange {
     message Request {
@@ -441,7 +435,6 @@ message TxFetchLastPrimaryKeyInSecondaryRange {
         string index_name = 2;
         bytes start_key = 3;
         bytes end_key = 4;
-        bytes exclusive_end_key = 5;
         string table_name = 6;
     }
     message Response {
@@ -452,7 +445,7 @@ message TxFetchLastPrimaryKeyInSecondaryRange {
 }
 
 // Reverse scan to find the last secondary index entry (secondary key + primary keys)
-// in [start_key, end_key] range, excluding exclusive_end_key.
+// in [start_key, end_key) range.
 // @see LineairDBTransaction::fetch_last_secondary_entry_in_range()
 message TxFetchLastSecondaryEntryInRange {
     message Request {
@@ -460,7 +453,6 @@ message TxFetchLastSecondaryEntryInRange {
         string index_name = 2;
         bytes start_key = 3;
         bytes end_key = 4;
-        bytes exclusive_end_key = 5;
         string table_name = 6;
     }
     message Response {

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -784,14 +784,14 @@ int ha_lineairdb::index_last(uchar *buf) {
   tx->choose_table(db_table_name);
 
   if (active_index == table->s->primary_key) {
-    auto key_values = tx->get_matching_keys_and_values_in_range("", "", "");
+    auto key_values = tx->get_matching_keys_and_values_in_range("", "");
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
       secondary_index_payloads_.push_back(std::move(kv.second));
     }
   } else {
     secondary_index_results_ =
-        tx->get_matching_primary_keys_in_range(current_index_name, "", "", "");
+        tx->get_matching_primary_keys_in_range(current_index_name, "", "");
     batch_fetch_secondary_payloads(tx);
   }
 
@@ -2303,23 +2303,12 @@ void ha_lineairdb::build_search_plan(const uchar *key, key_part_map keypart_map,
     current_plan_.end_key_serialized =
         convert_key_to_ldbformat(end_range->key, end_range->keypart_map);
 
-    if (end_range->flag == HA_READ_BEFORE_KEY) {
-      // exclusive end (Note: Scan is inclusive)
-      current_plan_.exclusive_end_key_serialized =
-          current_plan_.end_key_serialized;
-    } else {
-      // inclusive end: check if prefix extension is needed
-      uint end_used_parts =
-          count_used_key_parts(key_info, end_range->keypart_map);
-      if (end_used_parts < key_info->user_defined_key_parts) {
-        current_plan_.end_key_serialized =
-            build_prefix_range_end(current_plan_.end_key_serialized);
-        if (!current_plan_.end_key_serialized.empty()) {
-          // treat prefix range as exclusive upper bound
-          current_plan_.exclusive_end_key_serialized =
-              current_plan_.end_key_serialized;
-        }
-      }
+    if (end_range->flag != HA_READ_BEFORE_KEY) {
+      // SQL inclusive upper bound must become LineairDB's exclusive upper
+      // bound. This is required for both full keys (k <= 30) and partial-key
+      // prefix ranges.
+      current_plan_.end_key_serialized =
+          build_prefix_range_end(current_plan_.end_key_serialized);
     }
   }
 }
@@ -2360,15 +2349,14 @@ int ha_lineairdb::execute_index_first(uchar *buf, LineairDBTransaction *tx) {
 
   if (current_plan_.is_primary) {
     auto key_values = tx->get_matching_keys_and_values_in_range(
-        start_key, end_key, current_plan_.exclusive_end_key_serialized);
+        start_key, end_key);
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
       secondary_index_payloads_.push_back(std::move(kv.second));
     }
   } else {
     secondary_index_results_ = tx->get_matching_primary_keys_in_range(
-        current_index_name, start_key, end_key,
-        current_plan_.exclusive_end_key_serialized);
+        current_index_name, start_key, end_key);
     batch_fetch_secondary_payloads(tx);
   }
 
@@ -2447,7 +2435,7 @@ int ha_lineairdb::execute_same_key_materialize(uchar *buf,
 
   if (current_plan_.is_primary) {
     auto key_values = tx->get_matching_keys_and_values_in_range(
-        prefix, prefix_end, prefix_end);
+        prefix, prefix_end);
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
       secondary_index_payloads_.push_back(std::move(kv.second));
@@ -2466,7 +2454,7 @@ int ha_lineairdb::execute_same_key_materialize(uchar *buf,
   }
 
   secondary_index_results_ = tx->get_matching_primary_keys_in_range(
-      current_index_name, prefix, prefix_end, prefix_end);
+      current_index_name, prefix, prefix_end);
   batch_fetch_secondary_payloads(tx);
 
   if (tx->is_aborted()) {
@@ -2493,7 +2481,7 @@ int ha_lineairdb::execute_prefix_first(uchar *buf, LineairDBTransaction *tx) {
     // Restrict to [prefix, prefix_end) so index_next never leaks non-prefix
     // rows.
     auto key_values = tx->get_matching_keys_and_values_in_range(
-        prefix, prefix_end, prefix_end);
+        prefix, prefix_end);
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
       secondary_index_payloads_.push_back(std::move(kv.second));
@@ -2514,7 +2502,7 @@ int ha_lineairdb::execute_prefix_first(uchar *buf, LineairDBTransaction *tx) {
   // Restrict to [prefix, prefix_end) so index_next never leaks non-prefix
   // rows.
   secondary_index_results_ = tx->get_matching_primary_keys_in_range(
-      current_index_name, prefix, prefix_end, prefix_end);
+      current_index_name, prefix, prefix_end);
   batch_fetch_secondary_payloads(tx);
 
   if (tx->is_aborted()) {
@@ -2545,16 +2533,14 @@ int ha_lineairdb::execute_range_materialize(uchar *buf,
   // execute scan
   if (current_plan_.is_primary) {
     auto key_values = tx->get_matching_keys_and_values_in_range(
-        effective_start, effective_end,
-        current_plan_.exclusive_end_key_serialized);
+        effective_start, effective_end);
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
       secondary_index_payloads_.push_back(std::move(kv.second));
     }
   } else {
     secondary_index_results_ = tx->get_matching_primary_keys_in_range(
-        current_index_name, effective_start, effective_end,
-        current_plan_.exclusive_end_key_serialized);
+        current_index_name, effective_start, effective_end);
     batch_fetch_secondary_payloads(tx);
   }
 
@@ -2577,19 +2563,23 @@ int ha_lineairdb::execute_range_materialize(uchar *buf,
  */
 int ha_lineairdb::execute_prev_key(uchar *buf, LineairDBTransaction *tx) {
   const std::string &target_key = current_plan_.start_key_serialized;
+  // HA_READ_BEFORE_KEY : SQL < target → already exclusive end.
+  // HA_READ_KEY_OR_PREV: SQL <= target → convert via build_prefix_range_end so
+  //                      [begin, end) scan keeps target itself.
   const bool exclude_target = (current_plan_.find_flag == HA_READ_BEFORE_KEY);
-  const std::string exclusive_end = exclude_target ? target_key : std::string();
+  const std::string effective_end =
+      exclude_target ? target_key : build_prefix_range_end(target_key);
 
   if (current_plan_.is_primary) {
-    auto key_values = tx->get_matching_keys_and_values_in_range("", target_key,
-                                                                exclusive_end);
+    auto key_values =
+        tx->get_matching_keys_and_values_in_range("", effective_end);
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
       secondary_index_payloads_.push_back(std::move(kv.second));
     }
   } else {
     secondary_index_results_ = tx->get_matching_primary_keys_in_range(
-        current_index_name, "", target_key, exclusive_end);
+        current_index_name, "", effective_end);
     batch_fetch_secondary_payloads(tx);
   }
 
@@ -2616,11 +2606,10 @@ int ha_lineairdb::execute_prefix_last(uchar *buf, LineairDBTransaction *tx) {
     const std::string &prefix_end = current_plan_.same_group_end_serialized;
 
     if (current_plan_.is_primary) {
-      auto key_values = tx->get_matching_keys_and_values_in_range(
-          prefix, prefix_end, prefix_end);
+      auto key_values =
+          tx->get_matching_keys_and_values_in_range(prefix, prefix_end);
       if (key_values.empty()) {
-        key_values =
-            tx->get_matching_keys_and_values_in_range("", prefix, prefix);
+        key_values = tx->get_matching_keys_and_values_in_range("", prefix);
       }
       for (auto &kv : key_values) {
         secondary_index_results_.push_back(kv.first);
@@ -2628,10 +2617,10 @@ int ha_lineairdb::execute_prefix_last(uchar *buf, LineairDBTransaction *tx) {
       }
     } else {
       secondary_index_results_ = tx->get_matching_primary_keys_in_range(
-          current_index_name, prefix, prefix_end, prefix_end);
+          current_index_name, prefix, prefix_end);
       if (secondary_index_results_.empty()) {
         secondary_index_results_ = tx->get_matching_primary_keys_in_range(
-            current_index_name, "", prefix, prefix);
+            current_index_name, "", prefix);
       }
       batch_fetch_secondary_payloads(tx);
     }
@@ -2653,7 +2642,6 @@ int ha_lineairdb::execute_prefix_last(uchar *buf, LineairDBTransaction *tx) {
   if (current_plan_.is_primary) {
     auto key_values = tx->get_matching_keys_and_values_in_range(
         current_plan_.same_group_prefix_serialized,
-        current_plan_.same_group_end_serialized,
         current_plan_.same_group_end_serialized);
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
@@ -2662,7 +2650,6 @@ int ha_lineairdb::execute_prefix_last(uchar *buf, LineairDBTransaction *tx) {
   } else {
     secondary_index_results_ = tx->get_matching_primary_keys_in_range(
         current_index_name, current_plan_.same_group_prefix_serialized,
-        current_plan_.same_group_end_serialized,
         current_plan_.same_group_end_serialized);
     batch_fetch_secondary_payloads(tx);
   }

--- a/proxy/index_search_plan.hh
+++ b/proxy/index_search_plan.hh
@@ -40,7 +40,6 @@ struct IndexSearchPlan
     // boundary information (serialized)
     std::string start_key_serialized;
     std::string end_key_serialized;
-    std::string exclusive_end_key_serialized; // for HA_READ_BEFORE_KEY
 
     // same group boundary (for index_next_same)
     std::string same_group_prefix_serialized;
@@ -57,7 +56,6 @@ struct IndexSearchPlan
         find_flag = HA_READ_KEY_EXACT;
         start_key_serialized.clear();
         end_key_serialized.clear();
-        exclusive_end_key_serialized.clear();
         same_group_prefix_serialized.clear();
         same_group_end_serialized.clear();
     }

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -421,8 +421,7 @@ bool LineairDBProxy::tx_update_secondary_index(LineairDBTransaction* tx,
 
 std::vector<std::string> LineairDBProxy::tx_get_matching_keys_in_range(LineairDBTransaction* tx,
                                                                         const std::string& start_key,
-                                                                        const std::string& end_key,
-                                                                        const std::string& exclusive_end_key) {
+                                                                        const std::string& end_key) {
     int64_t tx_id = tx->get_tx_id();
     LOG_DEBUG("CLIENT: tx_get_matching_keys_in_range called with tx_id=%ld", tx_id);
     if (!connected_) {
@@ -437,7 +436,6 @@ std::vector<std::string> LineairDBProxy::tx_get_matching_keys_in_range(LineairDB
     request.set_table_name(tx->get_selected_table_name());
     request.set_start_key(start_key);
     request.set_end_key(end_key);
-    request.set_exclusive_end_key(exclusive_end_key);
 
     if (!send_protobuf_message(request, response, MessageType::TX_GET_MATCHING_KEYS_IN_RANGE)) {
         LOG_ERROR("RPC failed: Failed to send message to server");
@@ -457,8 +455,7 @@ std::vector<std::string> LineairDBProxy::tx_get_matching_keys_in_range(LineairDB
 
 std::vector<KeyValue> LineairDBProxy::tx_get_matching_keys_and_values_in_range(LineairDBTransaction* tx,
                                                                                 const std::string& start_key,
-                                                                                const std::string& end_key,
-                                                                                const std::string& exclusive_end_key) {
+                                                                                const std::string& end_key) {
     int64_t tx_id = tx->get_tx_id();
     LOG_DEBUG("CLIENT: tx_get_matching_keys_and_values_in_range called with tx_id=%ld", tx_id);
     if (!connected_) {
@@ -471,7 +468,6 @@ std::vector<KeyValue> LineairDBProxy::tx_get_matching_keys_and_values_in_range(L
     request.set_table_name(tx->get_selected_table_name());
     request.set_start_key(start_key);
     request.set_end_key(end_key);
-    request.set_exclusive_end_key(exclusive_end_key);
 
     // Attach pushed predicate filter if available
     const auto& filter = tx->get_pushed_filter();
@@ -618,8 +614,7 @@ int LineairDBProxy::tx_scan_into_buffers(LineairDBTransaction* tx,
 
 std::optional<std::string> LineairDBProxy::tx_fetch_last_key_in_range(LineairDBTransaction* tx,
                                                                        const std::string& start_key,
-                                                                       const std::string& end_key,
-                                                                       const std::string& exclusive_end_key) {
+                                                                       const std::string& end_key) {
     int64_t tx_id = tx->get_tx_id();
     LOG_DEBUG("CLIENT: tx_fetch_last_key_in_range called with tx_id=%ld", tx_id);
     if (!connected_) {
@@ -634,7 +629,6 @@ std::optional<std::string> LineairDBProxy::tx_fetch_last_key_in_range(LineairDBT
     request.set_table_name(tx->get_selected_table_name());
     request.set_start_key(start_key);
     request.set_end_key(end_key);
-    request.set_exclusive_end_key(exclusive_end_key);
 
     if (!send_protobuf_message(request, response, MessageType::TX_FETCH_LAST_KEY_IN_RANGE)) {
         LOG_ERROR("RPC failed: Failed to send message to server");
@@ -716,8 +710,7 @@ std::optional<std::string> LineairDBProxy::tx_fetch_next_key_with_prefix(Lineair
 std::vector<std::string> LineairDBProxy::tx_get_matching_primary_keys_in_range(LineairDBTransaction* tx,
                                                                                 const std::string& index_name,
                                                                                 const std::string& start_key,
-                                                                                const std::string& end_key,
-                                                                                const std::string& exclusive_end_key) {
+                                                                                const std::string& end_key) {
     int64_t tx_id = tx->get_tx_id();
     LOG_DEBUG("CLIENT: tx_get_matching_primary_keys_in_range called with tx_id=%ld, index=%s", tx_id, index_name.c_str());
     if (!connected_) {
@@ -733,7 +726,6 @@ std::vector<std::string> LineairDBProxy::tx_get_matching_primary_keys_in_range(L
     request.set_index_name(index_name);
     request.set_start_key(start_key);
     request.set_end_key(end_key);
-    request.set_exclusive_end_key(exclusive_end_key);
 
     if (!send_protobuf_message(request, response, MessageType::TX_GET_MATCHING_PRIMARY_KEYS_IN_RANGE)) {
         LOG_ERROR("RPC failed: Failed to send message to server");
@@ -789,8 +781,7 @@ std::vector<std::string> LineairDBProxy::tx_get_matching_primary_keys_from_prefi
 std::optional<std::string> LineairDBProxy::tx_fetch_last_primary_key_in_secondary_range(LineairDBTransaction* tx,
                                                                                           const std::string& index_name,
                                                                                           const std::string& start_key,
-                                                                                          const std::string& end_key,
-                                                                                          const std::string& exclusive_end_key) {
+                                                                                          const std::string& end_key) {
     int64_t tx_id = tx->get_tx_id();
     LOG_DEBUG("CLIENT: tx_fetch_last_primary_key_in_secondary_range called with tx_id=%ld, index=%s", tx_id, index_name.c_str());
     if (!connected_) {
@@ -806,7 +797,6 @@ std::optional<std::string> LineairDBProxy::tx_fetch_last_primary_key_in_secondar
     request.set_index_name(index_name);
     request.set_start_key(start_key);
     request.set_end_key(end_key);
-    request.set_exclusive_end_key(exclusive_end_key);
 
     if (!send_protobuf_message(request, response, MessageType::TX_FETCH_LAST_PRIMARY_KEY_IN_SECONDARY_RANGE)) {
         LOG_ERROR("RPC failed: Failed to send message to server");
@@ -824,8 +814,7 @@ std::optional<std::string> LineairDBProxy::tx_fetch_last_primary_key_in_secondar
 std::optional<SecondaryIndexEntry> LineairDBProxy::tx_fetch_last_secondary_entry_in_range(LineairDBTransaction* tx,
                                                                                             const std::string& index_name,
                                                                                             const std::string& start_key,
-                                                                                            const std::string& end_key,
-                                                                                            const std::string& exclusive_end_key) {
+                                                                                            const std::string& end_key) {
     int64_t tx_id = tx->get_tx_id();
     LOG_DEBUG("CLIENT: tx_fetch_last_secondary_entry_in_range called with tx_id=%ld, index=%s", tx_id, index_name.c_str());
     if (!connected_) {
@@ -841,7 +830,6 @@ std::optional<SecondaryIndexEntry> LineairDBProxy::tx_fetch_last_secondary_entry
     request.set_index_name(index_name);
     request.set_start_key(start_key);
     request.set_end_key(end_key);
-    request.set_exclusive_end_key(exclusive_end_key);
 
     if (!send_protobuf_message(request, response, MessageType::TX_FETCH_LAST_SECONDARY_ENTRY_IN_RANGE)) {
         LOG_ERROR("RPC failed: Failed to send message to server");

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -144,12 +144,10 @@ public:
     // primary key scan operations
     std::vector<std::string> tx_get_matching_keys_in_range(LineairDBTransaction* tx,
                                                            const std::string& start_key,
-                                                           const std::string& end_key,
-                                                           const std::string& exclusive_end_key);
+                                                           const std::string& end_key);
     std::vector<KeyValue> tx_get_matching_keys_and_values_in_range(LineairDBTransaction* tx,
                                                                     const std::string& start_key,
-                                                                    const std::string& end_key,
-                                                                    const std::string& exclusive_end_key);
+                                                                    const std::string& end_key);
     std::vector<KeyValue> tx_get_matching_keys_and_values_from_prefix(LineairDBTransaction* tx,
                                                                        const std::string& prefix);
     // Zero-copy variant: parse binary response directly into caller-provided buffers.
@@ -161,8 +159,7 @@ public:
                              std::unordered_map<std::string, size_t>& out_cache);
     std::optional<std::string> tx_fetch_last_key_in_range(LineairDBTransaction* tx,
                                                            const std::string& start_key,
-                                                           const std::string& end_key,
-                                                           const std::string& exclusive_end_key);
+                                                           const std::string& end_key);
     std::optional<std::string> tx_fetch_first_key_with_prefix(LineairDBTransaction* tx,
                                                                const std::string& prefix,
                                                                const std::string& prefix_end);
@@ -174,21 +171,18 @@ public:
     std::vector<std::string> tx_get_matching_primary_keys_in_range(LineairDBTransaction* tx,
                                                                     const std::string& index_name,
                                                                     const std::string& start_key,
-                                                                    const std::string& end_key,
-                                                                    const std::string& exclusive_end_key);
+                                                                    const std::string& end_key);
     std::vector<std::string> tx_get_matching_primary_keys_from_prefix(LineairDBTransaction* tx,
                                                                        const std::string& index_name,
                                                                        const std::string& prefix);
     std::optional<std::string> tx_fetch_last_primary_key_in_secondary_range(LineairDBTransaction* tx,
                                                                              const std::string& index_name,
                                                                              const std::string& start_key,
-                                                                             const std::string& end_key,
-                                                                             const std::string& exclusive_end_key);
+                                                                             const std::string& end_key);
     std::optional<SecondaryIndexEntry> tx_fetch_last_secondary_entry_in_range(LineairDBTransaction* tx,
                                                                                const std::string& index_name,
                                                                                const std::string& start_key,
-                                                                               const std::string& end_key,
-                                                                               const std::string& exclusive_end_key);
+                                                                               const std::string& end_key);
 
     // table/index management (non-transactional)
     bool db_create_table(const std::string& table_name);

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -144,22 +144,20 @@ bool LineairDBTransaction::update_secondary_index(std::string index_name,
 
 std::vector<std::string>
 LineairDBTransaction::get_matching_keys_in_range(std::string start_key,
-                                                 std::string end_key,
-                                                 const std::string &exclusive_end_key) {
+                                                 std::string end_key) {
   if (table_is_not_chosen()) return {};
   flush_write_buffer();
 
-  return lineairdb_proxy->tx_get_matching_keys_in_range(this, start_key, end_key, exclusive_end_key);
+  return lineairdb_proxy->tx_get_matching_keys_in_range(this, start_key, end_key);
 }
 
 std::vector<std::pair<std::string, std::string>>
 LineairDBTransaction::get_matching_keys_and_values_in_range(std::string start_key,
-                                                            std::string end_key,
-                                                            const std::string &exclusive_end_key) {
+                                                            std::string end_key) {
   if (table_is_not_chosen()) return {};
   flush_write_buffer();
 
-  auto results = lineairdb_proxy->tx_get_matching_keys_and_values_in_range(this, start_key, end_key, exclusive_end_key);
+  auto results = lineairdb_proxy->tx_get_matching_keys_and_values_in_range(this, start_key, end_key);
 
   std::vector<std::pair<std::string, std::string>> pairs;
   for (const auto& kv : results) {
@@ -184,12 +182,11 @@ LineairDBTransaction::get_matching_keys_and_values_from_prefix(std::string prefi
 
 std::optional<std::string>
 LineairDBTransaction::fetch_last_key_in_range(const std::string &start_key,
-                                              const std::string &end_key,
-                                              const std::string &exclusive_end_key) {
+                                              const std::string &end_key) {
   if (table_is_not_chosen()) return std::nullopt;
   flush_write_buffer();
 
-  return lineairdb_proxy->tx_fetch_last_key_in_range(this, start_key, end_key, exclusive_end_key);
+  return lineairdb_proxy->tx_fetch_last_key_in_range(this, start_key, end_key);
 }
 
 std::optional<std::string>
@@ -215,12 +212,11 @@ LineairDBTransaction::fetch_next_key_with_prefix(const std::string &last_key,
 std::vector<std::string>
 LineairDBTransaction::get_matching_primary_keys_in_range(std::string index_name,
                                                          std::string start_key,
-                                                         std::string end_key,
-                                                         const std::string &exclusive_end_key) {
+                                                         std::string end_key) {
   if (table_is_not_chosen()) return {};
   flush_write_buffer();
 
-  return lineairdb_proxy->tx_get_matching_primary_keys_in_range(this, index_name, start_key, end_key, exclusive_end_key);
+  return lineairdb_proxy->tx_get_matching_primary_keys_in_range(this, index_name, start_key, end_key);
 }
 
 std::vector<std::string>
@@ -235,23 +231,21 @@ LineairDBTransaction::get_matching_primary_keys_from_prefix(std::string index_na
 std::optional<std::string>
 LineairDBTransaction::fetch_last_primary_key_in_secondary_range(const std::string &index_name,
                                                                 const std::string &start_key,
-                                                                const std::string &end_key,
-                                                                const std::string &exclusive_end_key) {
+                                                                const std::string &end_key) {
   if (table_is_not_chosen()) return std::nullopt;
   flush_write_buffer();
 
-  return lineairdb_proxy->tx_fetch_last_primary_key_in_secondary_range(this, index_name, start_key, end_key, exclusive_end_key);
+  return lineairdb_proxy->tx_fetch_last_primary_key_in_secondary_range(this, index_name, start_key, end_key);
 }
 
 std::optional<SecondaryIndexEntry>
 LineairDBTransaction::fetch_last_secondary_entry_in_range(const std::string &index_name,
                                                           const std::string &start_key,
-                                                          const std::string &end_key,
-                                                          const std::string &exclusive_end_key) {
+                                                          const std::string &end_key) {
   if (table_is_not_chosen()) return std::nullopt;
   flush_write_buffer();
 
-  return lineairdb_proxy->tx_fetch_last_secondary_entry_in_range(this, index_name, start_key, end_key, exclusive_end_key);
+  return lineairdb_proxy->tx_fetch_last_secondary_entry_in_range(this, index_name, start_key, end_key);
 }
 
 // Row count delta tracking

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -34,32 +34,26 @@ public:
                    const std::vector<LineairDBProxy::BatchSecondaryIndexOp>& si_writes);
   std::vector<std::string> get_all_keys();
   std::vector<std::string> get_matching_keys(std::string key);
-  std::vector<std::string> get_matching_keys_in_range(std::string start_key, std::string end_key,
-                                                      const std::string &exclusive_end_key = "");
+  std::vector<std::string> get_matching_keys_in_range(std::string start_key, std::string end_key);
   std::vector<std::pair<std::string, std::string>> get_matching_keys_and_values_in_range(
-      std::string start_key, std::string end_key,
-      const std::string &exclusive_end_key = "");
+      std::string start_key, std::string end_key);
   std::vector<std::pair<std::string, std::string>> get_matching_keys_and_values_from_prefix(
       std::string prefix);
   bool write(std::string key, const std::string value);
   bool write_secondary_index(std::string index_name, std::string secondary_key, const std::string primary_key);
   std::vector<std::string> read_secondary_index(std::string index_name, std::string secondary_key);
   std::vector<std::string> get_matching_primary_keys_in_range(
-      std::string index_name, std::string start_key, std::string end_key,
-      const std::string &exclusive_end_key = "");
+      std::string index_name, std::string start_key, std::string end_key);
   std::vector<std::string> get_matching_primary_keys_from_prefix(
       std::string index_name, std::string prefix);
   std::optional<std::string> fetch_last_key_in_range(
-      const std::string &start_key, const std::string &end_key,
-      const std::string &exclusive_end_key = "");
+      const std::string &start_key, const std::string &end_key);
   std::optional<std::string> fetch_last_primary_key_in_secondary_range(
       const std::string &index_name, const std::string &start_key,
-      const std::string &end_key,
-      const std::string &exclusive_end_key = "");
+      const std::string &end_key);
   std::optional<SecondaryIndexEntry> fetch_last_secondary_entry_in_range(
       const std::string &index_name, const std::string &start_key,
-      const std::string &end_key,
-      const std::string &exclusive_end_key = "");
+      const std::string &end_key);
   std::optional<std::string> fetch_first_key_with_prefix(
       const std::string &prefix, const std::string &prefix_end);
   std::optional<std::string> fetch_next_key_with_prefix(

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -465,15 +465,12 @@ void LineairDBRpc::handleTxGetMatchingKeysInRange(const std::string& message, st
         }
         std::string start_key = request.start_key();
         std::string end_key = request.end_key();
-        std::string exclusive_end_key = request.exclusive_end_key();
 
         std::optional<std::string_view> end_opt;
         if (!end_key.empty()) { end_opt = end_key; }
 
         auto scan_result = tx->Scan(
-            start_key, end_opt, [&response, &exclusive_end_key](auto key, auto) {
-                // Skip if key matches exclusive end key (HA_READ_BEFORE_KEY)
-                if (!exclusive_end_key.empty() && key == exclusive_end_key) { return false; }
+            start_key, end_opt, [&response](auto key, auto) {
                 response.add_keys(std::string(key));
                 return false;
             });
@@ -515,7 +512,6 @@ void LineairDBRpc::handleTxGetMatchingKeysAndValuesInRange(const std::string& me
         }
         std::string start_key = request.start_key();
         std::string end_key = request.end_key();
-        std::string exclusive_end_key = request.exclusive_end_key();
 
         std::optional<std::string_view> end_opt;
         if (!end_key.empty()) { end_opt = end_key; }
@@ -528,10 +524,8 @@ void LineairDBRpc::handleTxGetMatchingKeysAndValuesInRange(const std::string& me
 
         // Scan callback: value is pair<const void*, size_t> from LineairDB
         auto scan_result = tx->Scan(
-            start_key, end_opt, [&result, &exclusive_end_key,
+            start_key, end_opt, [&result,
                                   filter_expr, filter_num_cols, &evaluator](auto key, auto value) {
-                // Skip if key matches exclusive end key (HA_READ_BEFORE_KEY)
-                if (!exclusive_end_key.empty() && key == exclusive_end_key) { return false; }
                 // Skip tombstones (deleted rows)
                 if (value.first == nullptr || value.second == 0) { return false; }
                 // Predicate pushdown: evaluate filter if present
@@ -667,15 +661,13 @@ void LineairDBRpc::handleTxFetchLastKeyInRange(const std::string& message, std::
         }
         std::string start_key = request.start_key();
         std::string end_key = request.end_key();
-        std::string exclusive_end_key = request.exclusive_end_key();
 
         std::optional<std::string_view> end_opt;
         if (!end_key.empty()) { end_opt = end_key; }
 
         std::optional<std::string> result;
         auto scan_result = tx->ScanReverse(
-            start_key, end_opt, [&result, &exclusive_end_key](auto key, auto) {
-                if (!exclusive_end_key.empty() && key == exclusive_end_key) { return false; }
+            start_key, end_opt, [&result](auto key, auto) {
                 result = std::string(key);
                 return true;
             });
@@ -846,17 +838,14 @@ void LineairDBRpc::handleTxGetMatchingPrimaryKeysInRange(const std::string& mess
         std::string index_name = request.index_name();
         std::string start_key = request.start_key();
         std::string end_key = request.end_key();
-        std::string exclusive_end_key = request.exclusive_end_key();
 
         std::optional<std::string_view> end_opt;
         if (!end_key.empty()) { end_opt = end_key; }
 
         auto scan_result = tx->ScanSecondaryIndex(
             index_name, start_key, end_opt,
-            [&response, &exclusive_end_key](std::string_view secondary_key,
-                                            const std::vector<std::string>& primary_keys) {
-                // Skip if secondary_key matches exclusive end key (HA_READ_BEFORE_KEY)
-                if (!exclusive_end_key.empty() && secondary_key == exclusive_end_key) { return false; }
+            [&response]([[maybe_unused]] std::string_view secondary_key,
+                        const std::vector<std::string>& primary_keys) {
                 for (const auto& pk : primary_keys) { response.add_primary_keys(pk); }
                 return false;
             });
@@ -945,7 +934,6 @@ void LineairDBRpc::handleTxFetchLastPrimaryKeyInSecondaryRange(const std::string
         std::string index_name = request.index_name();
         std::string start_key = request.start_key();
         std::string end_key = request.end_key();
-        std::string exclusive_end_key = request.exclusive_end_key();
 
         std::optional<std::string_view> end_opt;
         if (!end_key.empty()) { end_opt = end_key; }
@@ -953,9 +941,8 @@ void LineairDBRpc::handleTxFetchLastPrimaryKeyInSecondaryRange(const std::string
         std::optional<std::string> result;
         auto scan_result = tx->ScanSecondaryIndexReverse(
             index_name, start_key, end_opt,
-            [&result, &exclusive_end_key](std::string_view secondary_key,
-                                            const std::vector<std::string>& primary_keys) {
-                if (!exclusive_end_key.empty() && secondary_key == exclusive_end_key) { return false; }
+            [&result]([[maybe_unused]] std::string_view secondary_key,
+                      const std::vector<std::string>& primary_keys) {
                 if (primary_keys.empty()) { return false; }
                 result = primary_keys.back();
                 return true;
@@ -1003,7 +990,6 @@ void LineairDBRpc::handleTxFetchLastSecondaryEntryInRange(const std::string& mes
         std::string index_name = request.index_name();
         std::string start_key = request.start_key();
         std::string end_key = request.end_key();
-        std::string exclusive_end_key = request.exclusive_end_key();
 
         std::optional<std::string_view> end_opt;
         if (!end_key.empty()) { end_opt = end_key; }
@@ -1011,9 +997,8 @@ void LineairDBRpc::handleTxFetchLastSecondaryEntryInRange(const std::string& mes
         bool found = false;
         auto scan_result = tx->ScanSecondaryIndexReverse(
             index_name, start_key, end_opt,
-            [&response, &found, &exclusive_end_key](std::string_view secondary_key,
-                                                     const std::vector<std::string>& primary_keys) {
-                if (!exclusive_end_key.empty() && secondary_key == exclusive_end_key) { return false; }
+            [&response, &found](std::string_view secondary_key,
+                                const std::vector<std::string>& primary_keys) {
                 if (primary_keys.empty()) { return false; }
                 found = true;
                 auto* entry = response.mutable_entry();

--- a/server/storage/database_manager.cc
+++ b/server/storage/database_manager.cc
@@ -12,6 +12,7 @@ DatabaseManager::DatabaseManager() {
     conf.enable_logging       = false;  // avoid per-thread LineairDB logs
     conf.max_thread           = 1;
     conf.concurrency_control_protocol = LineairDB::Config::ConcurrencyControl::Silo;
+    conf.index_structure = LineairDB::Config::IndexStructure::Masstree;
     database_ = std::make_shared<LineairDB::Database>(conf);
     LOG_INFO("Database manager initialized");
 }


### PR DESCRIPTION
## Summary
Switch the storage layer default index to Masstree, adapt the proxy/handler to LineairDB's exclusive-end Scan contract, and harden the AWS deploy/bench tooling so future runs cannot silently fall back to a stale binary.

## Why
This branch consumes the Masstree backend introduced in `Noxy3301/LineairDB feat/masstree`, which switches the storage layer's default range-index implementation. The handler had to follow LineairDB's new `[begin, end)` Scan contract end-to-end; without the conversion in `build_search_plan` and `execute_prev_key`, SQL queries with inclusive upper bounds silently lose the boundary row.

## Changes

### Backend switch
- `feat(server): default index to Masstree` — set `Config::index_structure` in `DatabaseManager`.

### Scan contract migration
- `fix(scan): adapt handler to LineairDB [begin, end) Scan contract`
  - convert SQL inclusive upper bounds via `build_prefix_range_end` in both `build_search_plan` and `execute_prev_key`
  - remove the now-redundant `exclusive_end_key` plumbing from proto (6 messages), server callbacks, proxy, and `IndexSearchPlan`

### AWS infrastructure
- `chore(aws): bake Masstree-ready AMI and surface deploy verification`
  - new base AMI with Masstree pre-built, autoconf/automake/libtool installed
  - ansible no longer swallows git pull / submodule update / build failures with `|| true`
  - SHA echo and build tail are surfaced in the ansible log via `register` + `debug`
  - split the playbook into sync / build / start tasks
- `chore(aws): auto-generate per-node perf breakdown plots when --perf is set`
  - `bench_aws.py` walks the result tree and runs `plot_perf.py` for lineairdb-server and every mysqld
- `fix(ansible): make playbook stop on real failures, not just trailing echo`
  - `set -euo pipefail` on every shell block
  - `stop_*.sh` wrapped with `|| true` for fresh-AMI idempotency

### Submodule bumps
- Three `chore: bump LineairDB submodule` commits track Masstree integration progress in the LineairDB PR.

## Related
- LineairDB PR: `Noxy3301/LineairDB feat/masstree → research/ordo`