### PR TITLE
Fix/rpc correctness

### DIFF
--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -124,8 +124,8 @@
 #define BLOB_MEMROOT_ALLOC_SIZE (8192)
 #define FENCE false
 
-// DICT_UNIQUE from InnoDB dict0mem.h — defined locally to avoid InnoDB dependency
-static constexpr uint DICT_UNIQUE = 2;
+// LineairDB SecondaryIndexOption::Constraint wire bit for UNIQUE.
+static constexpr uint LDB_INDEX_UNIQUE = 1u;
 
 namespace {
 constexpr unsigned char kKeyMarkerNotNull = 0x00;
@@ -1903,7 +1903,7 @@ int ha_lineairdb::create(const char *table_name, TABLE *table, HA_CREATE_INFO *,
   // Create secondary indexes (also ignore "already exists")
   for (uint i = 0; i < table->s->keys; i++) {
     auto key_info = table->key_info[i];
-    uint index_type = (key_info.flags & HA_NOSAME) ? DICT_UNIQUE : 0;
+    uint index_type = (key_info.flags & HA_NOSAME) ? LDB_INDEX_UNIQUE : 0;
     if (i != table->s->primary_key) {
       proxy->db_create_secondary_index(
           db_table_name, std::string(key_info.name), index_type);
@@ -1952,7 +1952,7 @@ bool ha_lineairdb::inplace_alter_table(TABLE *altered_table [[maybe_unused]],
     uint key_idx = ha_alter_info->index_add_buffer[i];
     KEY *key_info = &ha_alter_info->key_info_buffer[key_idx];
 
-    uint index_type = (key_info->flags & HA_NOSAME) ? DICT_UNIQUE : 0;
+    uint index_type = (key_info->flags & HA_NOSAME) ? LDB_INDEX_UNIQUE : 0;
 
     // In a disaggregated setup, another MySQL node may have already created
     // this secondary index on the shared LineairDB server. Treat "already

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -1479,6 +1479,14 @@ int ha_lineairdb::external_lock(THD *thd, int lock_type) {
 
   const bool tx_is_ready_to_commit = lock_type == F_UNLCK;
   if (tx_is_ready_to_commit) {
+    // Drop the predicate pushed by cond_push() so the next statement starts clean.
+    pushed_filter_serialized_.clear();
+    LineairDBThdCtx **ctx_slot = reinterpret_cast<LineairDBThdCtx **>(
+        thd_ha_data(thd, lineairdb_hton));
+    if (ctx_slot != nullptr && *ctx_slot != nullptr &&
+        (*ctx_slot)->tx != nullptr) {
+      (*ctx_slot)->tx->clear_pushed_filter();
+    }
     return 0;
   }
 

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -18,6 +18,9 @@ LineairDBTransaction::LineairDBTransaction(THD* thd,
 std::string LineairDBTransaction::get_selected_table_name() { return db_table_key; }
 
 void LineairDBTransaction::choose_table(std::string db_table_name) {
+  if (db_table_key != db_table_name) {
+    pushed_filter_.clear();
+  }
   db_table_key = db_table_name;
 }
 


### PR DESCRIPTION
## Summary

- Align proxy UNIQUE secondary-index option with LineairDB's wire format.
- Clear stale pushed predicates at statement unlock and table switch.
- Serialize AND/OR predicate children through Item_cond::argument_list().

## Details

- LineairDB now uses bit 0 for UNIQUE and bit 1 for NOT_NULL, so the proxy must send 1 for UNIQUE instead of the old InnoDB-derived value 2.
- Pushed predicates are statement-local, but the transaction object can live across statements, so stale filters must be cleared explicitly.
- Item_cond does not expose AND/OR children through Item_func::arguments(), so predicate serialization must walk argument_list().