### PR TITLE
Pref/rpc reduction

### DIFF
--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -47,6 +47,14 @@ enum OpCode {
     TX_BATCH_WRITE = 26;
 }
 
+enum BatchOpType {
+    BATCH_OP_UNKNOWN = 0;
+    BATCH_OP_WRITE = 1;
+    BATCH_OP_DELETE = 2;
+    BATCH_OP_SECONDARY_INDEX_WRITE = 3;
+    BATCH_OP_SECONDARY_INDEX_DELETE = 4;
+}
+
 // Shared key-value pair used across scan responses.
 message KeyValue {
     bytes key = 1;
@@ -96,24 +104,21 @@ message TxBatchRead {
     }
 }
 
-// Write multiple rows in a single round-trip.
-// Each row includes a PK write and optional secondary index writes.
-// Used by bulk load to reduce RPC round-trips.
+// Flush writes and deletes in the same order MySQL issued them.
 message TxBatchWrite {
-    message WriteOp {
-        bytes key = 1;
-        bytes value = 2;
-    }
-    message SecondaryIndexOp {
-        string index_name = 1;
-        bytes secondary_key = 2;
-        bytes primary_key = 3;
+    message BatchOp {
+        BatchOpType type = 1;
+        bytes key = 2;
+        bytes value = 3;
+        string index_name = 4;
+        bytes secondary_key = 5;
+        bytes primary_key = 6;
     }
     message Request {
         int64 transaction_id = 1;
         string table_name = 2;
-        repeated WriteOp writes = 3;
-        repeated SecondaryIndexOp secondary_index_writes = 4;
+        // Operations are applied in the same order as MySQL produced them.
+        repeated BatchOp ops = 3;
     }
     message Response {
         bool success = 1;

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -113,11 +113,12 @@ message TxBatchWrite {
         string index_name = 4;
         bytes secondary_key = 5;
         bytes primary_key = 6;
+        string table_name = 7;
     }
     message Request {
         int64 transaction_id = 1;
         string table_name = 2;
-        // Operations are applied in the same order as MySQL produced them.
+        // Operations are applied in the same order as MySQL issued them.
         repeated BatchOp ops = 3;
     }
     message Response {

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -324,6 +324,7 @@ message TxGetMatchingKeysAndValuesInRange {
         bytes end_key = 3;
         PushedPredicate filter = 5;
         string table_name = 6;
+        uint64 row_limit = 7; // 0 means no limit.
     }
     message Response {
         repeated KeyValue results = 1;

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -331,6 +331,7 @@ message TxGetMatchingKeysAndValuesInRange {
         PushedPredicate filter = 5;
         string table_name = 6;
         uint64 row_limit = 7; // 0 means no limit.
+        bool reverse_scan = 8; // true means scan in descending key order.
     }
     message Response {
         repeated KeyValue results = 1;

--- a/proxy/CMakeLists.txt
+++ b/proxy/CMakeLists.txt
@@ -38,10 +38,11 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 set(LINEAIRDB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/LineairDB")
 add_subdirectory(${LINEAIRDB_DIR} ${CMAKE_CURRENT_BINARY_DIR}/LineairDB)
 set(LINEAIRDB_PLUGIN_DYNAMIC "ha_lineairdb")
-set(LINEAIRDB_SOURCES ha_lineairdb.cc ha_lineairdb.hh 
+set(LINEAIRDB_SOURCES ha_lineairdb.cc ha_lineairdb.hh
                       lineairdb_field.cc lineairdb_field.hh
                       lineairdb_transaction.cc lineairdb_transaction.hh
-                      lineairdb_proxy.cc lineairdb_proxy.hh)
+                      lineairdb_proxy.cc lineairdb_proxy.hh
+                      rpc_trace.cc rpc_trace.hh)
 add_definitions(-DMYSQL_SERVER)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error -Wextra -mcx16 -fPIC")
 

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -1106,6 +1106,57 @@ static bool serialize_item(const Item *item,
   }
 }
 
+// True when one predicate operand is an integer field or integer constant
+static bool item_is_limit_safe_scalar(const Item *item) {
+  // Accept only expression shapes the server can compare exactly for LIMIT.
+  if (item == nullptr) return false;                 // Missing expression
+  if (item->type() == Item::INT_ITEM) return true;   // Integer constant
+
+  // Field operands must be integer columns to avoid string/collation mismatch.
+  if (item->type() != Item::FIELD_ITEM) return false; // Not a field
+  const Item_field *field_item = down_cast<const Item_field *>(item);
+  if (field_item->field == nullptr) return false;    // Missing field metadata
+  return field_item->field->result_type() == INT_RESULT;
+}
+
+// True when WHERE is an AND tree of simple integer comparisons
+static bool item_is_limit_safe_filter(const Item *item) {
+  if (item == nullptr) return true;                  // No WHERE to check
+
+  // AND is safe to recurse; OR is kept local until we add stricter tests.
+  if (item->type() == Item::COND_ITEM) {
+    // Keep LIMIT filters to AND trees; OR can be added after stricter tests.
+    auto *cond_item =
+        const_cast<Item_cond *>(down_cast<const Item_cond *>(item));
+    if (cond_item->functype() != Item_func::COND_AND_FUNC) return false;
+    for (Item &child : *cond_item->argument_list()) {
+      if (!item_is_limit_safe_filter(&child)) return false;
+    }
+    return true;
+  }
+
+  // Leaf predicates must be binary comparisons.
+  if (item->type() != Item::FUNC_ITEM) return false; // Not a comparison
+  const Item_func *func = down_cast<const Item_func *>(item);
+  switch (func->functype()) {
+    case Item_func::EQ_FUNC:
+    case Item_func::NE_FUNC:
+    case Item_func::LT_FUNC:
+    case Item_func::LE_FUNC:
+    case Item_func::GT_FUNC:
+    case Item_func::GE_FUNC:
+      break;
+    default:
+      return false;                                  // Complex predicate
+  }
+
+  // Both sides must be safe scalar operands.
+  if (func->argument_count() != 2) return false;     // Binary compare only
+  Item **args = func->arguments();
+  return item_is_limit_safe_scalar(args[0]) &&
+         item_is_limit_safe_scalar(args[1]);
+}
+
 // Push the SELECT WHERE into this transaction if LIMIT will depend on it
 static bool prepare_select_filter_for_tx(THD *thd, TABLE *table,
                                          LineairDBTransaction *tx,
@@ -1145,7 +1196,7 @@ static bool prepare_select_filter_for_tx(THD *thd, TABLE *table,
     *serialized_filter = encoded;
   }
   tx->set_pushed_filter(encoded);
-  return true;
+  return item_is_limit_safe_filter(where);
 }
 
 const Item *ha_lineairdb::cond_push(const Item *cond) {
@@ -2821,9 +2872,9 @@ int ha_lineairdb::execute_prefix_last(uchar *buf, LineairDBTransaction *tx) {
           ha_thd(), key, current_plan_.used_key_parts,
           has_unpushed_filter_ || !filter_ready);
       const bool push_desc_limit =
-          (scan_limit.row_limit > 0 && scan_limit.reverse_scan);
+          (scan_limit.row_limit == 1 && scan_limit.reverse_scan);
 
-      // Prefix-last can use reverse scan for ORDER BY ... DESC LIMIT N.
+      // Prefix-last can use reverse scan for ORDER BY ... DESC LIMIT 1.
       auto key_values = tx->get_matching_keys_and_values_in_range(
           prefix, prefix_end,
           push_desc_limit ? static_cast<uint64_t>(scan_limit.row_limit) : 0,
@@ -2872,9 +2923,9 @@ int ha_lineairdb::execute_prefix_last(uchar *buf, LineairDBTransaction *tx) {
         ha_thd(), key, current_plan_.used_key_parts,
         has_unpushed_filter_ || !filter_ready);
     const bool push_desc_limit =
-        (scan_limit.row_limit > 0 && scan_limit.reverse_scan);
+        (scan_limit.row_limit == 1 && scan_limit.reverse_scan);
 
-    // Prefix-last materialization only uses DESC LIMIT; ASC would change last.
+    // Prefix-last materialization only uses DESC LIMIT 1.
     auto key_values = tx->get_matching_keys_and_values_in_range(
         current_plan_.same_group_prefix_serialized,
         current_plan_.same_group_end_serialized,

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -701,10 +701,8 @@ int ha_lineairdb::delete_row(const uchar *buf) {
     return HA_ERR_LOCK_DEADLOCK;
   }
 
-  tx->choose_table(db_table_name);
-  bool is_successful = tx->delete_value(key);
-  if (!is_successful)
-    return HA_ERR_LOCK_DEADLOCK;
+  // Buffer the base-row delete; read/scan paths and commit flush it later.
+  tx->buffer_delete(db_table_name, key);
 
   if (tx->is_aborted()) {
     thd_mark_transaction_to_rollback(ha_thd(), 1);
@@ -716,16 +714,14 @@ int ha_lineairdb::delete_row(const uchar *buf) {
     if (i != table->s->primary_key) {
       std::string secondary_key = build_secondary_key_from_row(buf, key_info);
 
-      bool is_successful =
-          tx->delete_secondary_index(key_info.name, secondary_key, key);
-      if (!is_successful)
-        return HA_ERR_LOCK_DEADLOCK;
-
-      if (tx->is_aborted()) {
-        thd_mark_transaction_to_rollback(ha_thd(), 1);
-        return HA_ERR_LOCK_DEADLOCK;
-      }
+      tx->buffer_delete_secondary_index(db_table_name, key_info.name,
+                                        secondary_key, key);
     }
+  }
+
+  if (tx->is_aborted()) {
+    thd_mark_transaction_to_rollback(ha_thd(), 1);
+    return HA_ERR_LOCK_DEADLOCK;
   }
 
   tx->add_rowcount_delta(share, db_table_name, -1);

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -139,13 +139,20 @@ constexpr unsigned char kKeyTypeOther = 0xF0;
 
 } // namespace
 
-// True when one ORDER BY item is exactly the requested keypart in ASC order
+// LIMIT and direction to pass to a range scan
+struct RangeScanLimit {
+  ha_rows row_limit{0};
+  bool reverse_scan{false};
+};
+
+// True when one ORDER BY item is exactly the requested keypart and direction
 static bool order_item_matches_key_part(ORDER *order, const KEY *key,
-                                        uint key_part_idx) {
+                                        uint key_part_idx,
+                                        enum_order direction) {
   // Validate the ORDER BY node shape before comparing fields
   if (order == nullptr) return false;                // Missing ORDER node
   if (key == nullptr) return false;                  // Missing key metadata
-  if (order->direction != ORDER_ASC) return false;   // DESC needs filesort
+  if (order->direction != direction) return false;   // Wrong direction
 
   const bool key_part_exists = (key_part_idx < key->user_defined_key_parts);
   if (!key_part_exists) return false;                // ORDER exceeds key
@@ -169,10 +176,11 @@ static bool order_item_matches_key_part(ORDER *order, const KEY *key,
   return order_field->field_index() == key_field->field_index();
 }
 
-// True when ORDER BY is a prefix of the remaining key suffix in ASC order
-static bool order_by_matches_key_suffix_asc(Query_block *qb, const KEY *key,
-                                            uint matched_prefix) {
-  // LIMIT pushdown needs an explicit ORDER BY that matches scan order
+// True when ORDER BY is a prefix of the remaining key suffix in one direction
+static bool order_by_matches_key_suffix(Query_block *qb, const KEY *key,
+                                        uint matched_prefix,
+                                        enum_order direction) {
+  // LIMIT needs an explicit ORDER BY that matches scan order
   if (qb == nullptr) return false;                   // Missing query block
   if (key == nullptr) return false;                  // Missing key metadata
   if (qb->order_list.elements == 0) return false;    // Unordered LIMIT
@@ -181,12 +189,12 @@ static bool order_by_matches_key_suffix_asc(Query_block *qb, const KEY *key,
   const uint key_parts = key->user_defined_key_parts;
   if (matched_prefix >= key_parts) return true;      // Full key fixed
 
-  // ORDER BY must follow the unfixed key suffix in ASC order
+  // ORDER BY must follow the unfixed key suffix in one direction
   uint order_pos = 0;
   for (ORDER *order = qb->order_list.first; order != nullptr;
        order = order->next, ++order_pos) {
     const uint key_part_idx = matched_prefix + order_pos;
-    if (!order_item_matches_key_part(order, key, key_part_idx)) {
+    if (!order_item_matches_key_part(order, key, key_part_idx, direction)) {
       return false;
     }
   }
@@ -194,36 +202,54 @@ static bool order_by_matches_key_suffix_asc(Query_block *qb, const KEY *key,
   return true;
 }
 
-// Returns SQL LIMIT N to push into an ordered range scan, or 0 to keep it local
-static ha_rows ordered_range_scan_limit(THD *thd, const KEY *key,
-                                        uint matched_prefix,
-                                        bool has_extra_filter) {
-  // Keep filtered scans unlimited until filter and limit fallback are unified
-  if (has_extra_filter) return 0;                    // WHERE may drop rows
+// Returns LIMIT and scan direction to push, or row_limit=0 to keep it local
+static RangeScanLimit range_scan_limit_for_order(
+    THD *thd, const KEY *key, uint matched_prefix, bool has_mysql_only_filter) {
+  RangeScanLimit scan_limit;
+
+  // Keep scans unlimited when MySQL must evaluate a filter the server lacks
+  if (has_mysql_only_filter) return scan_limit;        // Server may miss rows
 
   // Validate this is a simple SELECT with a query expression to inspect
-  if (thd == nullptr) return 0;                      // Missing session
-  if (thd->lex == nullptr) return 0;                 // Missing SQL state
-  if (thd->lex->unit == nullptr) return 0;           // Missing query unit
+  if (thd == nullptr) return scan_limit;               // Missing session
+  if (thd->lex == nullptr) return scan_limit;          // Missing SQL state
+  if (thd->lex->unit == nullptr) return scan_limit;    // Missing query unit
   const bool is_select = (thd->lex->sql_command == SQLCOM_SELECT);
-  if (!is_select) return 0;                          // Not SELECT
+  if (!is_select) return scan_limit;                   // Not SELECT
 
-  // LIMIT pushdown is only safe for one-table, non-aggregate reads
+  // LIMIT is only safe for one-table, non-aggregate reads
   Query_expression *unit = thd->lex->unit;
   Query_block *qb = unit->global_parameters();
-  if (qb == nullptr) return 0;                       // Missing query block
-  if (qb->leaf_table_count != 1) return 0;           // Join needs root LIMIT
-  if (qb->is_explicitly_grouped()) return 0;         // GROUP BY changes rows
-  if (qb->is_implicitly_grouped()) return 0;         // Aggregate changes rows
+  if (qb == nullptr) return scan_limit;                // Missing query block
+  if (qb->leaf_table_count != 1) return scan_limit;    // Join needs root LIMIT
+  if (qb->is_explicitly_grouped()) return scan_limit;  // GROUP BY changes rows
+  if (qb->is_implicitly_grouped()) return scan_limit;  // Aggregate changes rows
 
   // Extract LIMIT N and reject shapes the storage scan cannot represent
-  if (unit->offset_limit_cnt != 0) return 0;         // OFFSET not supported
-  if (unit->select_limit_cnt == 0) return 0;         // Empty LIMIT
+  if (unit->offset_limit_cnt != 0) return scan_limit;  // OFFSET not supported
+  if (unit->select_limit_cnt == 0) return scan_limit;  // Empty LIMIT
   const bool has_limit = (unit->select_limit_cnt != HA_POS_ERROR);
-  if (!has_limit) return 0;                          // No LIMIT clause
-  if (!order_by_matches_key_suffix_asc(qb, key, matched_prefix)) return 0;
+  if (!has_limit) return scan_limit;                   // No LIMIT clause
 
-  return unit->select_limit_cnt;
+  // A full-key point lookup returns at most one row, so direction is irrelevant
+  const uint key_parts = key->user_defined_key_parts;
+  if (matched_prefix >= key_parts) {
+    scan_limit.row_limit = unit->select_limit_cnt;
+    return scan_limit;
+  }
+
+  // ASC uses the natural key order; DESC uses LineairDB ScanReverse
+  if (order_by_matches_key_suffix(qb, key, matched_prefix, ORDER_ASC)) {
+    scan_limit.row_limit = unit->select_limit_cnt;
+    return scan_limit;
+  }
+  if (order_by_matches_key_suffix(qb, key, matched_prefix, ORDER_DESC)) {
+    scan_limit.row_limit = unit->select_limit_cnt;
+    scan_limit.reverse_scan = true;
+    return scan_limit;
+  }
+
+  return scan_limit;
 }
 
 // LineairDB server connection target (GLOBAL sysvars backing storage)
@@ -743,6 +769,11 @@ int ha_lineairdb::index_read_map(uchar *buf, const uchar *key,
   }
 
   tx->choose_table(db_table_name);
+  if (!pushed_filter_serialized_.empty()) {
+    tx->set_pushed_filter(pushed_filter_serialized_);
+  } else {
+    tx->clear_pushed_filter();
+  }
 
   KEY *key_info = &table->key_info[active_index];
 
@@ -1073,6 +1104,48 @@ static bool serialize_item(const Item *item,
     default:
       return false;  // unsupported item type → skip PP
   }
+}
+
+// Push the SELECT WHERE into this transaction if LIMIT will depend on it
+static bool prepare_select_filter_for_tx(THD *thd, TABLE *table,
+                                         LineairDBTransaction *tx,
+                                         std::string *serialized_filter) {
+  // Check the handler state needed to inspect the current SELECT.
+  if (tx == nullptr) return false;                   // Missing transaction
+  if (thd == nullptr) return false;                  // Missing session
+  const bool has_table = (table != nullptr && table->s != nullptr);
+  if (!has_table) return false;                      // Missing table
+  if (thd->lex == nullptr) return false;             // Missing SQL state
+  if (thd->lex->unit == nullptr) return false;       // Missing query unit
+
+  // Read the current SELECT WHERE from MySQL's query block.
+  Query_block *qb = thd->lex->unit->global_parameters();
+  if (qb == nullptr) return false;                   // Missing query block
+
+  const Item *where = qb->where_cond();
+  if (where == nullptr) {
+    if (serialized_filter != nullptr) serialized_filter->clear();
+    tx->clear_pushed_filter();
+    return true;                                     // No WHERE to push
+  }
+
+  // Convert WHERE into the existing predicate protobuf format.
+  LineairDB::Protocol::PushedPredicate predicate;
+  predicate.set_num_columns(table->s->fields);
+  if (!serialize_item(where, predicate.mutable_expr())) {
+    if (serialized_filter != nullptr) serialized_filter->clear();
+    tx->clear_pushed_filter();
+    return false;                                    // MySQL must filter
+  }
+
+  // Attach the encoded filter to the transaction for the next scan RPC.
+  std::string encoded;
+  predicate.SerializeToString(&encoded);
+  if (serialized_filter != nullptr) {
+    *serialized_filter = encoded;
+  }
+  tx->set_pushed_filter(encoded);
+  return true;
 }
 
 const Item *ha_lineairdb::cond_push(const Item *cond) {
@@ -2548,13 +2621,18 @@ int ha_lineairdb::execute_same_key_materialize(uchar *buf,
   const std::string &prefix_end = current_plan_.same_group_end_serialized;
 
   if (current_plan_.is_primary) {
+    // Push LIMIT only when the server can also apply the SELECT WHERE.
     const KEY *key = &table->key_info[active_index];
-    const bool has_extra_filter =
-        has_unpushed_filter_ || !pushed_filter_serialized_.empty();
-    const ha_rows row_limit = ordered_range_scan_limit(
-        ha_thd(), key, current_plan_.used_key_parts, has_extra_filter);
+    const bool filter_ready = prepare_select_filter_for_tx(
+        ha_thd(), table, tx, &pushed_filter_serialized_);
+    const RangeScanLimit scan_limit = range_scan_limit_for_order(
+        ha_thd(), key, current_plan_.used_key_parts,
+        has_unpushed_filter_ || !filter_ready);
+
+    // Same-key scans can use ASC or DESC LIMIT when ORDER BY matches the key.
     auto key_values = tx->get_matching_keys_and_values_in_range(
-        prefix, prefix_end, static_cast<uint64_t>(row_limit));
+        prefix, prefix_end, static_cast<uint64_t>(scan_limit.row_limit),
+        scan_limit.reverse_scan);
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
       secondary_index_payloads_.push_back(std::move(kv.second));
@@ -2651,8 +2729,18 @@ int ha_lineairdb::execute_range_materialize(uchar *buf,
 
   // execute scan
   if (current_plan_.is_primary) {
+    // Push LIMIT only when the server can also apply the SELECT WHERE.
+    const KEY *key = &table->key_info[active_index];
+    const bool filter_ready = prepare_select_filter_for_tx(
+        ha_thd(), table, tx, &pushed_filter_serialized_);
+    const RangeScanLimit scan_limit = range_scan_limit_for_order(
+        ha_thd(), key, current_plan_.used_key_parts,
+        has_unpushed_filter_ || !filter_ready);
+
+    // Range scans can use ASC or DESC LIMIT when ORDER BY matches the key.
     auto key_values = tx->get_matching_keys_and_values_in_range(
-        effective_start, effective_end);
+        effective_start, effective_end,
+        static_cast<uint64_t>(scan_limit.row_limit), scan_limit.reverse_scan);
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
       secondary_index_payloads_.push_back(std::move(kv.second));
@@ -2717,7 +2805,7 @@ int ha_lineairdb::execute_prev_key(uchar *buf, LineairDBTransaction *tx) {
 
 /**
  * @brief kPrefixLast: last row in prefix range
- * @note for now, return the last row in materialize mode (slow but correct)
+ * @note Materialize mode returns the last row directly (slow but correct)
  */
 int ha_lineairdb::execute_prefix_last(uchar *buf, LineairDBTransaction *tx) {
   if (current_plan_.find_flag == HA_READ_PREFIX_LAST_OR_PREV) {
@@ -2725,10 +2813,27 @@ int ha_lineairdb::execute_prefix_last(uchar *buf, LineairDBTransaction *tx) {
     const std::string &prefix_end = current_plan_.same_group_end_serialized;
 
     if (current_plan_.is_primary) {
-      auto key_values =
-          tx->get_matching_keys_and_values_in_range(prefix, prefix_end);
+      // Push LIMIT only when the server can also apply the SELECT WHERE.
+      const KEY *key = &table->key_info[active_index];
+      const bool filter_ready = prepare_select_filter_for_tx(
+          ha_thd(), table, tx, &pushed_filter_serialized_);
+      const RangeScanLimit scan_limit = range_scan_limit_for_order(
+          ha_thd(), key, current_plan_.used_key_parts,
+          has_unpushed_filter_ || !filter_ready);
+      const bool push_desc_limit =
+          (scan_limit.row_limit > 0 && scan_limit.reverse_scan);
+
+      // Prefix-last can use reverse scan for ORDER BY ... DESC LIMIT N.
+      auto key_values = tx->get_matching_keys_and_values_in_range(
+          prefix, prefix_end,
+          push_desc_limit ? static_cast<uint64_t>(scan_limit.row_limit) : 0,
+          push_desc_limit);
       if (key_values.empty()) {
-        key_values = tx->get_matching_keys_and_values_in_range("", prefix);
+        // HA_READ_PREFIX_LAST_OR_PREV may fall back to the previous prefix.
+        key_values = tx->get_matching_keys_and_values_in_range(
+            "", prefix,
+            push_desc_limit ? static_cast<uint64_t>(scan_limit.row_limit) : 0,
+            push_desc_limit);
       }
       for (auto &kv : key_values) {
         secondary_index_results_.push_back(kv.first);
@@ -2759,9 +2864,22 @@ int ha_lineairdb::execute_prefix_last(uchar *buf, LineairDBTransaction *tx) {
 
   // materialize mode
   if (current_plan_.is_primary) {
+    // Push LIMIT only when the server can also apply the SELECT WHERE.
+    const KEY *key = &table->key_info[active_index];
+    const bool filter_ready = prepare_select_filter_for_tx(
+        ha_thd(), table, tx, &pushed_filter_serialized_);
+    const RangeScanLimit scan_limit = range_scan_limit_for_order(
+        ha_thd(), key, current_plan_.used_key_parts,
+        has_unpushed_filter_ || !filter_ready);
+    const bool push_desc_limit =
+        (scan_limit.row_limit > 0 && scan_limit.reverse_scan);
+
+    // Prefix-last materialization only uses DESC LIMIT; ASC would change last.
     auto key_values = tx->get_matching_keys_and_values_in_range(
         current_plan_.same_group_prefix_serialized,
-        current_plan_.same_group_end_serialized);
+        current_plan_.same_group_end_serialized,
+        push_desc_limit ? static_cast<uint64_t>(scan_limit.row_limit) : 0,
+        push_desc_limit);
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
       secondary_index_payloads_.push_back(std::move(kv.second));

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -1506,7 +1506,13 @@ int ha_lineairdb::external_lock(THD *thd, int lock_type) {
   }
 
   // get_transaction() will automatically start the transaction if needed
-  (void)get_transaction(thd);
+  LineairDBTransaction *tx = get_transaction(thd);
+  if (tx != nullptr) {
+    const LEX_CSTRING &q = thd->query();
+    if (q.str != nullptr && q.length > 0) {
+      tx->on_stmt_boundary(std::string(q.str, q.length));
+    }
+  }
 
   // Stats sync: apply cached table row counts from the server (received
   // in BEGIN/END responses) so the optimizer sees correct cardinalities.

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -555,10 +555,8 @@ int ha_lineairdb::update_row(const uchar *old_data, uchar *new_data) {
     return HA_ERR_LOCK_DEADLOCK;
   }
 
-  tx->choose_table(db_table_name);
-  bool is_successful = tx->write(key, write_buffer_);
-  if (!is_successful)
-    return HA_ERR_LOCK_DEADLOCK;
+  // Buffer the base-row update; read/scan paths and commit flush it later.
+  tx->buffer_write(db_table_name, key, write_buffer_);
 
   if (tx->is_aborted()) {
     thd_mark_transaction_to_rollback(ha_thd(), 1);

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -117,6 +117,7 @@
 #include "sql/item_cmpfunc.h"
 #include "sql/item_func.h"
 #include "sql/sql_class.h"
+#include "sql/sql_lex.h"
 #include "sql/sql_plugin.h"
 #include "sql/table.h"
 #include "typelib.h"
@@ -137,6 +138,93 @@ constexpr unsigned char kKeyTypeDatetime = 0x30;
 constexpr unsigned char kKeyTypeOther = 0xF0;
 
 } // namespace
+
+// True when one ORDER BY item is exactly the requested keypart in ASC order
+static bool order_item_matches_key_part(ORDER *order, const KEY *key,
+                                        uint key_part_idx) {
+  // Validate the ORDER BY node shape before comparing fields
+  if (order == nullptr) return false;                // Missing ORDER node
+  if (key == nullptr) return false;                  // Missing key metadata
+  if (order->direction != ORDER_ASC) return false;   // DESC needs filesort
+
+  const bool key_part_exists = (key_part_idx < key->user_defined_key_parts);
+  if (!key_part_exists) return false;                // ORDER exceeds key
+
+  const bool has_order_item =
+      (order->item != nullptr && *(order->item) != nullptr);
+  if (!has_order_item) return false;                 // Missing ORDER item
+
+  // Resolve ORDER BY expression to a table field
+  Item *item = (*order->item)->real_item();
+  const bool is_field_item = (item->type() == Item::FIELD_ITEM);
+  if (!is_field_item) return false;                  // Not a bare field
+
+  // Compare the ORDER BY field with the expected keypart
+  Item_field *field_item = down_cast<Item_field *>(item);
+  const Field *order_field = field_item->field;
+  const Field *key_field = key->key_part[key_part_idx].field;
+  if (order_field == nullptr) return false;          // Missing ORDER field
+  if (key_field == nullptr) return false;            // Missing key field
+
+  return order_field->field_index() == key_field->field_index();
+}
+
+// True when ORDER BY is a prefix of the remaining key suffix in ASC order
+static bool order_by_matches_key_suffix_asc(Query_block *qb, const KEY *key,
+                                            uint matched_prefix) {
+  // LIMIT pushdown needs an explicit ORDER BY that matches scan order
+  if (qb == nullptr) return false;                   // Missing query block
+  if (key == nullptr) return false;                  // Missing key metadata
+  if (qb->order_list.elements == 0) return false;    // Unordered LIMIT
+
+  // If all keyparts are fixed, the scan can return at most one key
+  const uint key_parts = key->user_defined_key_parts;
+  if (matched_prefix >= key_parts) return true;      // Full key fixed
+
+  // ORDER BY must follow the unfixed key suffix in ASC order
+  uint order_pos = 0;
+  for (ORDER *order = qb->order_list.first; order != nullptr;
+       order = order->next, ++order_pos) {
+    const uint key_part_idx = matched_prefix + order_pos;
+    if (!order_item_matches_key_part(order, key, key_part_idx)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// Returns SQL LIMIT N to push into an ordered range scan, or 0 to keep it local
+static ha_rows ordered_range_scan_limit(THD *thd, const KEY *key,
+                                        uint matched_prefix,
+                                        bool has_extra_filter) {
+  // Keep filtered scans unlimited until filter and limit fallback are unified
+  if (has_extra_filter) return 0;                    // WHERE may drop rows
+
+  // Validate this is a simple SELECT with a query expression to inspect
+  if (thd == nullptr) return 0;                      // Missing session
+  if (thd->lex == nullptr) return 0;                 // Missing SQL state
+  if (thd->lex->unit == nullptr) return 0;           // Missing query unit
+  const bool is_select = (thd->lex->sql_command == SQLCOM_SELECT);
+  if (!is_select) return 0;                          // Not SELECT
+
+  // LIMIT pushdown is only safe for one-table, non-aggregate reads
+  Query_expression *unit = thd->lex->unit;
+  Query_block *qb = unit->global_parameters();
+  if (qb == nullptr) return 0;                       // Missing query block
+  if (qb->leaf_table_count != 1) return 0;           // Join needs root LIMIT
+  if (qb->is_explicitly_grouped()) return 0;         // GROUP BY changes rows
+  if (qb->is_implicitly_grouped()) return 0;         // Aggregate changes rows
+
+  // Extract LIMIT N and reject shapes the storage scan cannot represent
+  if (unit->offset_limit_cnt != 0) return 0;         // OFFSET not supported
+  if (unit->select_limit_cnt == 0) return 0;         // Empty LIMIT
+  const bool has_limit = (unit->select_limit_cnt != HA_POS_ERROR);
+  if (!has_limit) return 0;                          // No LIMIT clause
+  if (!order_by_matches_key_suffix_asc(qb, key, matched_prefix)) return 0;
+
+  return unit->select_limit_cnt;
+}
 
 // LineairDB server connection target (GLOBAL sysvars backing storage)
 static char *srv_server_host = nullptr;
@@ -994,12 +1082,14 @@ static bool serialize_item(const Item *item,
 const Item *ha_lineairdb::cond_push(const Item *cond) {
   DBUG_TRACE;
   pushed_filter_serialized_.clear();
+  has_unpushed_filter_ = false;
   if (!cond || !table) return cond;
 
   LineairDB::Protocol::PushedPredicate predicate;
   predicate.set_num_columns(table->s->fields);
   if (!serialize_item(cond, predicate.mutable_expr())) {
     // Serialization failed → no PP, MySQL evaluates everything
+    has_unpushed_filter_ = true;
     return cond;
   }
   predicate.SerializeToString(&pushed_filter_serialized_);
@@ -1494,6 +1584,7 @@ int ha_lineairdb::external_lock(THD *thd, int lock_type) {
   if (tx_is_ready_to_commit) {
     // Drop the predicate pushed by cond_push() so the next statement starts clean.
     pushed_filter_serialized_.clear();
+    has_unpushed_filter_ = false;
     LineairDBThdCtx **ctx_slot = reinterpret_cast<LineairDBThdCtx **>(
         thd_ha_data(thd, lineairdb_hton));
     if (ctx_slot != nullptr && *ctx_slot != nullptr &&
@@ -2461,8 +2552,13 @@ int ha_lineairdb::execute_same_key_materialize(uchar *buf,
   const std::string &prefix_end = current_plan_.same_group_end_serialized;
 
   if (current_plan_.is_primary) {
+    const KEY *key = &table->key_info[active_index];
+    const bool has_extra_filter =
+        has_unpushed_filter_ || !pushed_filter_serialized_.empty();
+    const ha_rows row_limit = ordered_range_scan_limit(
+        ha_thd(), key, current_plan_.used_key_parts, has_extra_filter);
     auto key_values = tx->get_matching_keys_and_values_in_range(
-        prefix, prefix_end);
+        prefix, prefix_end, static_cast<uint64_t>(row_limit));
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
       secondary_index_payloads_.push_back(std::move(kv.second));

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -398,6 +398,8 @@ public:
 private:
   // Serialized PushedPredicate protobuf from cond_push()
   std::string pushed_filter_serialized_;
+  // True when cond_push() cannot build a server-side filter
+  bool has_unpushed_filter_{false};
   /** The multi range read session object */
   DsMrr_impl m_ds_mrr;
 

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -457,7 +457,8 @@ std::vector<std::string> LineairDBProxy::tx_get_matching_keys_in_range(LineairDB
 
 std::vector<KeyValue> LineairDBProxy::tx_get_matching_keys_and_values_in_range(LineairDBTransaction* tx,
                                                                                 const std::string& start_key,
-                                                                                const std::string& end_key) {
+                                                                                const std::string& end_key,
+                                                                                uint64_t row_limit) {
     int64_t tx_id = tx->get_tx_id();
     LOG_DEBUG("CLIENT: tx_get_matching_keys_and_values_in_range called with tx_id=%ld", tx_id);
     if (!connected_) {
@@ -470,6 +471,7 @@ std::vector<KeyValue> LineairDBProxy::tx_get_matching_keys_and_values_in_range(L
     request.set_table_name(tx->get_selected_table_name());
     request.set_start_key(start_key);
     request.set_end_key(end_key);
+    request.set_row_limit(row_limit);
 
     // Attach pushed predicate filter if available
     const auto& filter = tx->get_pushed_filter();

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -4,12 +4,14 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <errno.h>
+#include <chrono>
 #include <cstring>
 #include <iostream>
 #include <vector>
 
 #include "lineairdb_proxy.hh"
 #include "lineairdb_transaction.hh"
+#include "rpc_trace.hh"
 #include "../common/log.h"
 
 
@@ -1025,13 +1027,17 @@ bool LineairDBProxy::send_message(const std::string& serialized_request, std::st
 }
 
 template<typename RequestType, typename ResponseType>
-bool LineairDBProxy::send_protobuf_message(const RequestType& request, ResponseType& response, MessageType message_type) {
+bool LineairDBProxy::send_protobuf_message(const RequestType& request,
+                                           ResponseType& response,
+                                           MessageType message_type,
+                                           const std::string& meta) {
     // serialize request
     std::string serialized_request = request.SerializeAsString();
 
     // send message with header
     std::string serialized_response;
-    if (!send_message_with_header(serialized_request, serialized_response, message_type)) {
+    if (!send_message_with_header(serialized_request, serialized_response,
+                                  message_type, meta)) {
         LOG_ERROR("PROTOBUF_MESSAGE: Failed to send message with header");
         return false;
     }
@@ -1050,9 +1056,11 @@ bool LineairDBProxy::send_protobuf_message(const RequestType& request, ResponseT
 template<typename RequestType>
 bool LineairDBProxy::send_protobuf_recv_binary(const RequestType& request,
                                                 std::string& raw_response,
-                                                MessageType message_type) {
+                                                MessageType message_type,
+                                                const std::string& meta) {
     std::string serialized_request = request.SerializeAsString();
-    return send_message_with_header(serialized_request, raw_response, message_type);
+    return send_message_with_header(serialized_request, raw_response,
+                                    message_type, meta);
 }
 
 // Parse flat binary scan response into vector<KeyValue>.
@@ -1107,7 +1115,11 @@ std::vector<KeyValue> LineairDBProxy::parse_binary_kv_response(const std::string
 
 bool LineairDBProxy::send_message_with_header(const std::string& serialized_request,
                                               std::string& serialized_response,
-                                              MessageType message_type) {
+                                              MessageType message_type,
+                                              const std::string& meta) {
+    auto rpc_start_ts = std::chrono::steady_clock::now();
+    const uint32_t req_bytes = static_cast<uint32_t>(serialized_request.size());
+
     if (!connected_) {
         LOG_ERROR("SEND_MESSAGE: Not connected!");
         return false;
@@ -1177,5 +1189,13 @@ bool LineairDBProxy::send_message_with_header(const std::string& serialized_requ
     }
 
     LOG_DEBUG("SEND_MESSAGE: Message exchange completed successfully");
+    if (current_trace_ != nullptr && current_trace_->active()) {
+        auto rpc_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                          std::chrono::steady_clock::now() - rpc_start_ts)
+                          .count();
+        current_trace_->record(
+            message_type, static_cast<uint64_t>(rpc_us), req_bytes,
+            static_cast<uint32_t>(serialized_response.size()), meta);
+    }
     return true;
 }

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -250,8 +250,7 @@ std::vector<LineairDBProxy::BatchReadResult> LineairDBProxy::tx_batch_read(
 
 bool LineairDBProxy::tx_batch_write(LineairDBTransaction* tx,
                                     const std::string& table_name,
-                                    const std::vector<BatchWriteOp>& writes,
-                                    const std::vector<BatchSecondaryIndexOp>& si_writes) {
+                                    const std::vector<BatchOp>& ops) {
     int64_t tx_id = tx->get_tx_id();
     if (!connected_) {
         LOG_ERROR("RPC failed: Not connected to server");
@@ -264,17 +263,31 @@ bool LineairDBProxy::tx_batch_write(LineairDBTransaction* tx,
     request.set_transaction_id(tx_id);
     request.set_table_name(table_name);
 
-    for (const auto& w : writes) {
-        auto* op = request.add_writes();
-        op->set_key(w.key);
-        op->set_value(w.value);
-    }
-
-    for (const auto& si : si_writes) {
-        auto* op = request.add_secondary_index_writes();
-        op->set_index_name(si.index_name);
-        op->set_secondary_key(si.secondary_key);
-        op->set_primary_key(si.primary_key);
+    for (const auto& batch_op : ops) {
+        auto* op = request.add_ops();
+        switch (batch_op.type) {
+            case BatchOp::Type::Write:
+                op->set_type(LineairDB::Protocol::BATCH_OP_WRITE);
+                op->set_key(batch_op.key);
+                op->set_value(batch_op.value);
+                break;
+            case BatchOp::Type::Delete:
+                op->set_type(LineairDB::Protocol::BATCH_OP_DELETE);
+                op->set_key(batch_op.key);
+                break;
+            case BatchOp::Type::SecondaryIndexWrite:
+                op->set_type(LineairDB::Protocol::BATCH_OP_SECONDARY_INDEX_WRITE);
+                op->set_index_name(batch_op.index_name);
+                op->set_secondary_key(batch_op.secondary_key);
+                op->set_primary_key(batch_op.primary_key);
+                break;
+            case BatchOp::Type::SecondaryIndexDelete:
+                op->set_type(LineairDB::Protocol::BATCH_OP_SECONDARY_INDEX_DELETE);
+                op->set_index_name(batch_op.index_name);
+                op->set_secondary_key(batch_op.secondary_key);
+                op->set_primary_key(batch_op.primary_key);
+                break;
+        }
     }
 
     if (!send_protobuf_message(request, response, MessageType::TX_BATCH_WRITE)) {

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -475,7 +475,8 @@ std::vector<std::string> LineairDBProxy::tx_get_matching_keys_in_range(LineairDB
 std::vector<KeyValue> LineairDBProxy::tx_get_matching_keys_and_values_in_range(LineairDBTransaction* tx,
                                                                                 const std::string& start_key,
                                                                                 const std::string& end_key,
-                                                                                uint64_t row_limit) {
+                                                                                uint64_t row_limit,
+                                                                                bool reverse_scan) {
     int64_t tx_id = tx->get_tx_id();
     LOG_DEBUG("CLIENT: tx_get_matching_keys_and_values_in_range called with tx_id=%ld", tx_id);
     if (!connected_) {
@@ -489,6 +490,7 @@ std::vector<KeyValue> LineairDBProxy::tx_get_matching_keys_and_values_in_range(L
     request.set_start_key(start_key);
     request.set_end_key(end_key);
     request.set_row_limit(row_limit);
+    request.set_reverse_scan(reverse_scan);
 
     // Attach pushed predicate filter if available
     const auto& filter = tx->get_pushed_filter();

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -270,22 +270,26 @@ bool LineairDBProxy::tx_batch_write(LineairDBTransaction* tx,
                 op->set_type(LineairDB::Protocol::BATCH_OP_WRITE);
                 op->set_key(batch_op.key);
                 op->set_value(batch_op.value);
+                op->set_table_name(batch_op.table_name);
                 break;
             case BatchOp::Type::Delete:
                 op->set_type(LineairDB::Protocol::BATCH_OP_DELETE);
                 op->set_key(batch_op.key);
+                op->set_table_name(batch_op.table_name);
                 break;
             case BatchOp::Type::SecondaryIndexWrite:
                 op->set_type(LineairDB::Protocol::BATCH_OP_SECONDARY_INDEX_WRITE);
                 op->set_index_name(batch_op.index_name);
                 op->set_secondary_key(batch_op.secondary_key);
                 op->set_primary_key(batch_op.primary_key);
+                op->set_table_name(batch_op.table_name);
                 break;
             case BatchOp::Type::SecondaryIndexDelete:
                 op->set_type(LineairDB::Protocol::BATCH_OP_SECONDARY_INDEX_DELETE);
                 op->set_index_name(batch_op.index_name);
                 op->set_secondary_key(batch_op.secondary_key);
                 op->set_primary_key(batch_op.primary_key);
+                op->set_table_name(batch_op.table_name);
                 break;
         }
     }

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -154,7 +154,8 @@ public:
     std::vector<KeyValue> tx_get_matching_keys_and_values_in_range(LineairDBTransaction* tx,
                                                                     const std::string& start_key,
                                                                     const std::string& end_key,
-                                                                    uint64_t row_limit = 0);
+                                                                    uint64_t row_limit = 0,
+                                                                    bool reverse_scan = false);
     std::vector<KeyValue> tx_get_matching_keys_and_values_from_prefix(LineairDBTransaction* tx,
                                                                        const std::string& prefix);
     // Zero-copy variant: parse binary response directly into caller-provided buffers.

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -110,19 +110,23 @@ public:
     };
     std::vector<BatchReadResult> tx_batch_read(LineairDBTransaction* tx,
                                                 const std::vector<std::string>& keys);
-    struct BatchWriteOp {
+    struct BatchOp {
+        enum class Type {
+            Write,
+            Delete,
+            SecondaryIndexWrite,
+            SecondaryIndexDelete
+        };
+        Type type;
         std::string key;
         std::string value;
-    };
-    struct BatchSecondaryIndexOp {
         std::string index_name;
         std::string secondary_key;
         std::string primary_key;
     };
     bool tx_batch_write(LineairDBTransaction* tx,
                         const std::string& table_name,
-                        const std::vector<BatchWriteOp>& writes,
-                        const std::vector<BatchSecondaryIndexOp>& si_writes);
+                        const std::vector<BatchOp>& ops);
 
     // secondary index operations
     std::vector<std::string> tx_read_secondary_index(LineairDBTransaction* tx,

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -12,6 +12,7 @@
 #include "lineairdb.pb.h"
 
 class LineairDBTransaction;
+class TxRpcTrace;
 
 struct KeyValue {
     std::string key;
@@ -201,22 +202,31 @@ public:
         return table_stats_cache_;
     }
 
+    // Route per-RPC measurements to the active transaction trace.
+    void set_current_trace(TxRpcTrace* trace) { current_trace_ = trace; }
+
 private:
     std::unordered_map<std::string, int64_t> table_stats_cache_;
     template<typename RequestType, typename ResponseType>
-    bool send_protobuf_message(const RequestType& request, ResponseType& response, MessageType message_type);
+    bool send_protobuf_message(const RequestType& request, ResponseType& response,
+                               MessageType message_type, const std::string& meta = "");
     // Send protobuf request, receive raw binary response
     template<typename RequestType>
-    bool send_protobuf_recv_binary(const RequestType& request, std::string& raw_response, MessageType message_type);
+    bool send_protobuf_recv_binary(const RequestType& request, std::string& raw_response,
+                                   MessageType message_type, const std::string& meta = "");
     // Parse flat binary scan response: [is_aborted:1B] [entries...] [sentinel: key_len=0]
     static std::vector<KeyValue> parse_binary_kv_response(const std::string& raw, bool& is_aborted);
     bool send_message(const std::string& serialized_request, std::string& serialized_response);
-    bool send_message_with_header(const std::string& serialized_request, std::string& serialized_response, MessageType message_type);
+    bool send_message_with_header(const std::string& serialized_request,
+                                  std::string& serialized_response,
+                                  MessageType message_type,
+                                  const std::string& meta = "");
 
     int socket_fd_;
     bool connected_;
     std::string host_;
     int port_;
+    TxRpcTrace* current_trace_ = nullptr;
 };
 
 #endif // LINEAIRDB_PROXY_H

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -123,6 +123,7 @@ public:
         std::string index_name;
         std::string secondary_key;
         std::string primary_key;
+        std::string table_name;
     };
     bool tx_batch_write(LineairDBTransaction* tx,
                         const std::string& table_name,

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -148,7 +148,8 @@ public:
                                                            const std::string& end_key);
     std::vector<KeyValue> tx_get_matching_keys_and_values_in_range(LineairDBTransaction* tx,
                                                                     const std::string& start_key,
-                                                                    const std::string& end_key);
+                                                                    const std::string& end_key,
+                                                                    uint64_t row_limit = 0);
     std::vector<KeyValue> tx_get_matching_keys_and_values_from_prefix(LineairDBTransaction* tx,
                                                                        const std::string& prefix);
     // Zero-copy variant: parse binary response directly into caller-provided buffers.

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -158,12 +158,13 @@ LineairDBTransaction::get_matching_keys_in_range(std::string start_key,
 std::vector<std::pair<std::string, std::string>>
 LineairDBTransaction::get_matching_keys_and_values_in_range(std::string start_key,
                                                             std::string end_key,
-                                                            uint64_t row_limit) {
+                                                            uint64_t row_limit,
+                                                            bool reverse_scan) {
   if (table_is_not_chosen()) return {};
   flush_write_buffer_for_table(db_table_key);
 
   auto results = lineairdb_proxy->tx_get_matching_keys_and_values_in_range(
-      this, start_key, end_key, row_limit);
+      this, start_key, end_key, row_limit, reverse_scan);
 
   std::vector<std::pair<std::string, std::string>> pairs;
   for (const auto& kv : results) {

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -158,11 +158,13 @@ LineairDBTransaction::get_matching_keys_in_range(std::string start_key,
 
 std::vector<std::pair<std::string, std::string>>
 LineairDBTransaction::get_matching_keys_and_values_in_range(std::string start_key,
-                                                            std::string end_key) {
+                                                            std::string end_key,
+                                                            uint64_t row_limit) {
   if (table_is_not_chosen()) return {};
   flush_write_buffer();
 
-  auto results = lineairdb_proxy->tx_get_matching_keys_and_values_in_range(this, start_key, end_key);
+  auto results = lineairdb_proxy->tx_get_matching_keys_and_values_in_range(
+      this, start_key, end_key, row_limit);
 
   std::vector<std::pair<std::string, std::string>> pairs;
   for (const auto& kv : results) {

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -62,9 +62,8 @@ LineairDBTransaction::batch_read(const std::vector<std::string>& keys) {
 
 bool LineairDBTransaction::batch_write(
     const std::string& table_name,
-    const std::vector<LineairDBProxy::BatchWriteOp>& writes,
-    const std::vector<LineairDBProxy::BatchSecondaryIndexOp>& si_writes) {
-  return lineairdb_proxy->tx_batch_write(this, table_name, writes, si_writes);
+    const std::vector<LineairDBProxy::BatchOp>& ops) {
+  return lineairdb_proxy->tx_batch_write(this, table_name, ops);
 }
 
 std::vector<std::string>
@@ -292,7 +291,11 @@ void LineairDBTransaction::buffer_write(const std::string& table_name,
     flush_write_buffer();
   }
   write_buffer_table_ = table_name;
-  write_buffer_ops_.push_back({key, value});
+  LineairDBProxy::BatchOp op;
+  op.type = LineairDBProxy::BatchOp::Type::Write;
+  op.key = key;
+  op.value = value;
+  write_buffer_ops_.push_back(std::move(op));
 
   if (write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
     flush_write_buffer();
@@ -303,21 +306,72 @@ void LineairDBTransaction::buffer_write_secondary_index(const std::string& table
                                                         const std::string& index_name,
                                                         const std::string& secondary_key,
                                                         const std::string& primary_key) {
-  write_buffer_si_ops_.push_back({index_name, secondary_key, primary_key});
+  if (!write_buffer_ops_.empty() && write_buffer_table_ != table_name) {
+    flush_write_buffer();
+  }
+  write_buffer_table_ = table_name;
+
+  LineairDBProxy::BatchOp op;
+  op.type = LineairDBProxy::BatchOp::Type::SecondaryIndexWrite;
+  op.index_name = index_name;
+  op.secondary_key = secondary_key;
+  op.primary_key = primary_key;
+  write_buffer_ops_.push_back(std::move(op));
+
+  if (write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
+    flush_write_buffer();
+  }
+}
+
+void LineairDBTransaction::buffer_delete(const std::string& table_name,
+                                         const std::string& key) {
+  if (!write_buffer_ops_.empty() && write_buffer_table_ != table_name) {
+    flush_write_buffer();
+  }
+  write_buffer_table_ = table_name;
+
+  LineairDBProxy::BatchOp op;
+  op.type = LineairDBProxy::BatchOp::Type::Delete;
+  op.key = key;
+  write_buffer_ops_.push_back(std::move(op));
+
+  if (write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
+    flush_write_buffer();
+  }
+}
+
+void LineairDBTransaction::buffer_delete_secondary_index(
+    const std::string& table_name,
+    const std::string& index_name,
+    const std::string& secondary_key,
+    const std::string& primary_key) {
+  if (!write_buffer_ops_.empty() && write_buffer_table_ != table_name) {
+    flush_write_buffer();
+  }
+  write_buffer_table_ = table_name;
+
+  LineairDBProxy::BatchOp op;
+  op.type = LineairDBProxy::BatchOp::Type::SecondaryIndexDelete;
+  op.index_name = index_name;
+  op.secondary_key = secondary_key;
+  op.primary_key = primary_key;
+  write_buffer_ops_.push_back(std::move(op));
+
+  if (write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
+    flush_write_buffer();
+  }
 }
 
 bool LineairDBTransaction::flush_write_buffer() {
-  if (write_buffer_ops_.empty() && write_buffer_si_ops_.empty()) return true;
+  if (write_buffer_ops_.empty()) return true;
   if (is_aborted_) {
     write_buffer_ops_.clear();
-    write_buffer_si_ops_.clear();
     return false;
   }
 
   bool ok = lineairdb_proxy->tx_batch_write(
-      this, write_buffer_table_, write_buffer_ops_, write_buffer_si_ops_);
+      this, write_buffer_table_, write_buffer_ops_);
   write_buffer_ops_.clear();
-  write_buffer_si_ops_.clear();
   return ok;
 }
 

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -2,6 +2,8 @@
 #include "storage/lineairdb/ha_lineairdb.hh"
 #include "../common/log.h"
 
+#include <thread>
+
 LineairDBTransaction::LineairDBTransaction(THD* thd, 
                                             LineairDBProxy* lineairdb_proxy,
                                             handlerton* lineairdb_hton,
@@ -319,9 +321,13 @@ bool LineairDBTransaction::flush_write_buffer() {
 
 void LineairDBTransaction::begin_transaction() {
   assert(is_not_started());
+  rpc_trace_.start(-1, std::this_thread::get_id());
+  lineairdb_proxy->set_current_trace(&rpc_trace_);
+
   tx_id = lineairdb_proxy->tx_begin_transaction();
   // TODO: maybe need error handling when tx_id == -1
   assert(tx_id != -1);
+  rpc_trace_.set_tx_id(tx_id);
   is_aborted_ = false;
 
   if (thd_is_transaction()) {
@@ -379,6 +385,13 @@ bool LineairDBTransaction::end_transaction() {
   if (isFence && !was_aborted && committed) {
     lineairdb_proxy->db_fence();
   }
+
+  if (rpc_trace_.active()) {
+    RpcTraceLogger::instance().log_line(
+        rpc_trace_.finalize_jsonl(committed && !was_aborted));
+  }
+  lineairdb_proxy->set_current_trace(nullptr);
+
   delete this;
   return committed;
 }

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -38,7 +38,7 @@ const std::pair<const std::byte *const, const size_t>
 LineairDBTransaction::read(std::string key) {
   if (table_is_not_chosen()) return std::pair<const std::byte *const, const size_t>{nullptr, 0};
 
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   last_read_value_ = lineairdb_proxy->tx_read(this, key);
   if (last_read_value_.empty()) return std::pair<const std::byte *const, const size_t>{nullptr, 0};
@@ -49,7 +49,7 @@ LineairDBTransaction::read(std::string key) {
 std::vector<std::pair<bool, std::string>>
 LineairDBTransaction::batch_read(const std::vector<std::string>& keys) {
   if (table_is_not_chosen()) return {};
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   auto results = lineairdb_proxy->tx_batch_read(this, keys);
   std::vector<std::pair<bool, std::string>> pairs;
@@ -69,7 +69,7 @@ bool LineairDBTransaction::batch_write(
 std::vector<std::string>
 LineairDBTransaction::get_all_keys() {
   if (table_is_not_chosen()) return {};
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   auto key_value_pairs = lineairdb_proxy->tx_get_matching_keys_and_values_from_prefix(this, "");
 
@@ -84,7 +84,7 @@ LineairDBTransaction::get_all_keys() {
 std::vector<std::string>
 LineairDBTransaction::get_matching_keys(std::string first_key_part) {
   if (table_is_not_chosen()) return {};
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   auto key_value_pairs = lineairdb_proxy->tx_get_matching_keys_and_values_from_prefix(this, first_key_part);
 
@@ -114,7 +114,7 @@ std::vector<std::string>
 LineairDBTransaction::read_secondary_index(std::string index_name,
                                            std::string secondary_key) {
   if (table_is_not_chosen()) return {};
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_read_secondary_index(this, index_name, secondary_key);
 }
@@ -150,7 +150,7 @@ std::vector<std::string>
 LineairDBTransaction::get_matching_keys_in_range(std::string start_key,
                                                  std::string end_key) {
   if (table_is_not_chosen()) return {};
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_get_matching_keys_in_range(this, start_key, end_key);
 }
@@ -160,7 +160,7 @@ LineairDBTransaction::get_matching_keys_and_values_in_range(std::string start_ke
                                                             std::string end_key,
                                                             uint64_t row_limit) {
   if (table_is_not_chosen()) return {};
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   auto results = lineairdb_proxy->tx_get_matching_keys_and_values_in_range(
       this, start_key, end_key, row_limit);
@@ -175,7 +175,7 @@ LineairDBTransaction::get_matching_keys_and_values_in_range(std::string start_ke
 std::vector<std::pair<std::string, std::string>>
 LineairDBTransaction::get_matching_keys_and_values_from_prefix(std::string prefix) {
   if (table_is_not_chosen()) return {};
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   auto results = lineairdb_proxy->tx_get_matching_keys_and_values_from_prefix(this, prefix);
 
@@ -190,7 +190,7 @@ std::optional<std::string>
 LineairDBTransaction::fetch_last_key_in_range(const std::string &start_key,
                                               const std::string &end_key) {
   if (table_is_not_chosen()) return std::nullopt;
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_fetch_last_key_in_range(this, start_key, end_key);
 }
@@ -199,7 +199,7 @@ std::optional<std::string>
 LineairDBTransaction::fetch_first_key_with_prefix(const std::string &prefix,
                                                   const std::string &prefix_end) {
   if (table_is_not_chosen()) return std::nullopt;
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_fetch_first_key_with_prefix(this, prefix, prefix_end);
 }
@@ -208,7 +208,7 @@ std::optional<std::string>
 LineairDBTransaction::fetch_next_key_with_prefix(const std::string &last_key,
                                                  const std::string &prefix_end) {
   if (table_is_not_chosen()) return std::nullopt;
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_fetch_next_key_with_prefix(this, last_key, prefix_end);
 }
@@ -220,7 +220,7 @@ LineairDBTransaction::get_matching_primary_keys_in_range(std::string index_name,
                                                          std::string start_key,
                                                          std::string end_key) {
   if (table_is_not_chosen()) return {};
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_get_matching_primary_keys_in_range(this, index_name, start_key, end_key);
 }
@@ -229,7 +229,7 @@ std::vector<std::string>
 LineairDBTransaction::get_matching_primary_keys_from_prefix(std::string index_name,
                                                             std::string prefix) {
   if (table_is_not_chosen()) return {};
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_get_matching_primary_keys_from_prefix(this, index_name, prefix);
 }
@@ -239,7 +239,7 @@ LineairDBTransaction::fetch_last_primary_key_in_secondary_range(const std::strin
                                                                 const std::string &start_key,
                                                                 const std::string &end_key) {
   if (table_is_not_chosen()) return std::nullopt;
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_fetch_last_primary_key_in_secondary_range(this, index_name, start_key, end_key);
 }
@@ -249,7 +249,7 @@ LineairDBTransaction::fetch_last_secondary_entry_in_range(const std::string &ind
                                                           const std::string &start_key,
                                                           const std::string &end_key) {
   if (table_is_not_chosen()) return std::nullopt;
-  flush_write_buffer();
+  flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_fetch_last_secondary_entry_in_range(this, index_name, start_key, end_key);
 }
@@ -286,15 +286,11 @@ LineairDBTransaction::peek_rowcount_delta(const LineairDB_share *share) const {
 void LineairDBTransaction::buffer_write(const std::string& table_name,
                                         const std::string& key,
                                         const std::string& value) {
-  // If table changed, flush the current buffer first
-  if (!write_buffer_ops_.empty() && write_buffer_table_ != table_name) {
-    flush_write_buffer();
-  }
-  write_buffer_table_ = table_name;
   LineairDBProxy::BatchOp op;
   op.type = LineairDBProxy::BatchOp::Type::Write;
   op.key = key;
   op.value = value;
+  op.table_name = table_name;
   write_buffer_ops_.push_back(std::move(op));
 
   if (write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
@@ -306,16 +302,12 @@ void LineairDBTransaction::buffer_write_secondary_index(const std::string& table
                                                         const std::string& index_name,
                                                         const std::string& secondary_key,
                                                         const std::string& primary_key) {
-  if (!write_buffer_ops_.empty() && write_buffer_table_ != table_name) {
-    flush_write_buffer();
-  }
-  write_buffer_table_ = table_name;
-
   LineairDBProxy::BatchOp op;
   op.type = LineairDBProxy::BatchOp::Type::SecondaryIndexWrite;
   op.index_name = index_name;
   op.secondary_key = secondary_key;
   op.primary_key = primary_key;
+  op.table_name = table_name;
   write_buffer_ops_.push_back(std::move(op));
 
   if (write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
@@ -325,14 +317,10 @@ void LineairDBTransaction::buffer_write_secondary_index(const std::string& table
 
 void LineairDBTransaction::buffer_delete(const std::string& table_name,
                                          const std::string& key) {
-  if (!write_buffer_ops_.empty() && write_buffer_table_ != table_name) {
-    flush_write_buffer();
-  }
-  write_buffer_table_ = table_name;
-
   LineairDBProxy::BatchOp op;
   op.type = LineairDBProxy::BatchOp::Type::Delete;
   op.key = key;
+  op.table_name = table_name;
   write_buffer_ops_.push_back(std::move(op));
 
   if (write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
@@ -345,16 +333,12 @@ void LineairDBTransaction::buffer_delete_secondary_index(
     const std::string& index_name,
     const std::string& secondary_key,
     const std::string& primary_key) {
-  if (!write_buffer_ops_.empty() && write_buffer_table_ != table_name) {
-    flush_write_buffer();
-  }
-  write_buffer_table_ = table_name;
-
   LineairDBProxy::BatchOp op;
   op.type = LineairDBProxy::BatchOp::Type::SecondaryIndexDelete;
   op.index_name = index_name;
   op.secondary_key = secondary_key;
   op.primary_key = primary_key;
+  op.table_name = table_name;
   write_buffer_ops_.push_back(std::move(op));
 
   if (write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
@@ -369,10 +353,49 @@ bool LineairDBTransaction::flush_write_buffer() {
     return false;
   }
 
-  bool ok = lineairdb_proxy->tx_batch_write(
-      this, write_buffer_table_, write_buffer_ops_);
+  bool ok = lineairdb_proxy->tx_batch_write(this, "", write_buffer_ops_);
   write_buffer_ops_.clear();
   return ok;
+}
+
+bool LineairDBTransaction::flush_write_buffer_for_table(
+    const std::string& table_name) {
+  if (write_buffer_ops_.empty()) return true;
+  if (is_aborted_) {
+    write_buffer_ops_.clear();
+    return false;
+  }
+
+  bool has_table_ops = false;
+  for (const auto& op : write_buffer_ops_) {
+    if (op.table_name == table_name) {
+      has_table_ops = true;
+      break;
+    }
+  }
+  if (!has_table_ops) return true;
+
+  std::vector<LineairDBProxy::BatchOp> flush_ops;
+  std::vector<LineairDBProxy::BatchOp> keep_ops;
+  flush_ops.reserve(write_buffer_ops_.size());
+  keep_ops.reserve(write_buffer_ops_.size());
+
+  for (auto& op : write_buffer_ops_) {
+    if (op.table_name == table_name) {
+      flush_ops.push_back(std::move(op));
+    } else {
+      keep_ops.push_back(std::move(op));
+    }
+  }
+
+  bool ok = lineairdb_proxy->tx_batch_write(this, table_name, flush_ops);
+  if (!ok) {
+    write_buffer_ops_.clear();
+    return false;
+  }
+
+  write_buffer_ops_ = std::move(keep_ops);
+  return true;
 }
 
 void LineairDBTransaction::begin_transaction() {

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -36,7 +36,8 @@ public:
   std::vector<std::string> get_matching_keys(std::string key);
   std::vector<std::string> get_matching_keys_in_range(std::string start_key, std::string end_key);
   std::vector<std::pair<std::string, std::string>> get_matching_keys_and_values_in_range(
-      std::string start_key, std::string end_key, uint64_t row_limit = 0);
+      std::string start_key, std::string end_key, uint64_t row_limit = 0,
+      bool reverse_scan = false);
   std::vector<std::pair<std::string, std::string>> get_matching_keys_and_values_from_prefix(
       std::string prefix);
   bool write(std::string key, const std::string value);

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -82,6 +82,7 @@ public:
   // Flush buffered row/index ops before reads can observe the same table.
   // Must be called before read/scan RPCs to ensure read-your-own-writes.
   bool flush_write_buffer();
+  bool flush_write_buffer_for_table(const std::string& table_name);
 
   void begin_transaction();
   void set_status_to_abort();
@@ -154,7 +155,6 @@ private:
 
   // Max number of buffered write/delete ops before an automatic flush
   static constexpr size_t WRITE_BATCH_SIZE = 100;
-  std::string write_buffer_table_;
   // Stores row and secondary-index write/delete ops in MySQL issue order
   std::vector<LineairDBProxy::BatchOp> write_buffer_ops_;
 

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -37,7 +37,7 @@ public:
   std::vector<std::string> get_matching_keys(std::string key);
   std::vector<std::string> get_matching_keys_in_range(std::string start_key, std::string end_key);
   std::vector<std::pair<std::string, std::string>> get_matching_keys_and_values_in_range(
-      std::string start_key, std::string end_key);
+      std::string start_key, std::string end_key, uint64_t row_limit = 0);
   std::vector<std::pair<std::string, std::string>> get_matching_keys_and_values_from_prefix(
       std::string prefix);
   bool write(std::string key, const std::string value);

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -7,6 +7,7 @@
 #include "mysql/plugin.h"
 #include "sql/sql_class.h"
 #include "lineairdb_proxy.hh"
+#include "rpc_trace.hh"
 
 class LineairDB_share;
 
@@ -112,6 +113,8 @@ public:
   void add_rowcount_delta(LineairDB_share *share, const std::string &table_name, int64_t delta);
   int64_t peek_rowcount_delta(const LineairDB_share *share) const;
 
+  // RPC trace statement boundary; TxRpcTrace dedupes repeated SQL strings.
+  void on_stmt_boundary(const std::string& sql) { rpc_trace_.on_stmt(sql); }
 
   LineairDBTransaction(THD* thd, 
                        LineairDBProxy* lineairdb_proxy, 
@@ -149,6 +152,8 @@ private:
   std::string write_buffer_table_;
   std::vector<LineairDBProxy::BatchWriteOp> write_buffer_ops_;
   std::vector<LineairDBProxy::BatchSecondaryIndexOp> write_buffer_si_ops_;
+
+  TxRpcTrace rpc_trace_;
 
   bool thd_is_transaction() const;
   void register_transaction_to_mysql();

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -31,8 +31,7 @@ public:
   const std::pair<const std::byte *const, const size_t> read(std::string key);
   std::vector<std::pair<bool, std::string>> batch_read(const std::vector<std::string>& keys);
   bool batch_write(const std::string& table_name,
-                   const std::vector<LineairDBProxy::BatchWriteOp>& writes,
-                   const std::vector<LineairDBProxy::BatchSecondaryIndexOp>& si_writes);
+                   const std::vector<LineairDBProxy::BatchOp>& ops);
   std::vector<std::string> get_all_keys();
   std::vector<std::string> get_matching_keys(std::string key);
   std::vector<std::string> get_matching_keys_in_range(std::string start_key, std::string end_key);
@@ -74,8 +73,14 @@ public:
                                      const std::string& index_name,
                                      const std::string& secondary_key,
                                      const std::string& primary_key);
-  // Flush buffered writes to LineairDB so that subsequent reads can see them.
-  // Must be called before any read/scan RPC to ensure read-your-own-writes.
+  void buffer_delete(const std::string& table_name,
+                     const std::string& key);
+  void buffer_delete_secondary_index(const std::string& table_name,
+                                     const std::string& index_name,
+                                     const std::string& secondary_key,
+                                     const std::string& primary_key);
+  // Flush buffered row/index ops before reads can observe the same table.
+  // Must be called before read/scan RPCs to ensure read-your-own-writes.
   bool flush_write_buffer();
 
   void begin_transaction();
@@ -147,11 +152,11 @@ private:
   // Predicate pushdown: serialized PushedPredicate for scan filtering
   std::string pushed_filter_;
 
-  // Write buffer for batch write operations
+  // Max number of buffered write/delete ops before an automatic flush
   static constexpr size_t WRITE_BATCH_SIZE = 100;
   std::string write_buffer_table_;
-  std::vector<LineairDBProxy::BatchWriteOp> write_buffer_ops_;
-  std::vector<LineairDBProxy::BatchSecondaryIndexOp> write_buffer_si_ops_;
+  // Stores row and secondary-index write/delete ops in MySQL issue order
+  std::vector<LineairDBProxy::BatchOp> write_buffer_ops_;
 
   TxRpcTrace rpc_trace_;
 

--- a/proxy/rpc_trace.cc
+++ b/proxy/rpc_trace.cc
@@ -1,0 +1,301 @@
+#include "rpc_trace.hh"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+#include <unistd.h>
+#include <utility>
+
+namespace {
+
+std::string format_iso(std::chrono::system_clock::time_point tp) {
+  using namespace std::chrono;
+  auto t = system_clock::to_time_t(tp);
+  auto us = duration_cast<microseconds>(tp.time_since_epoch()).count() % 1000000;
+  if (us < 0) us += 1000000;
+  std::tm tm{};
+  gmtime_r(&t, &tm);
+
+  std::ostringstream os;
+  os << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S")
+     << '.' << std::setw(6) << std::setfill('0') << us << 'Z';
+  return os.str();
+}
+
+}  // namespace
+
+const char* message_type_name(MessageType t) {
+  switch (t) {
+    case MessageType::UNKNOWN:
+      return "UNKNOWN";
+    case MessageType::TX_BEGIN_TRANSACTION:
+      return "TX_BEGIN_TRANSACTION";
+    case MessageType::TX_ABORT:
+      return "TX_ABORT";
+    case MessageType::TX_READ:
+      return "TX_READ";
+    case MessageType::TX_WRITE:
+      return "TX_WRITE";
+    case MessageType::TX_DELETE:
+      return "TX_DELETE";
+    case MessageType::TX_READ_SECONDARY_INDEX:
+      return "TX_READ_SECONDARY_INDEX";
+    case MessageType::TX_WRITE_SECONDARY_INDEX:
+      return "TX_WRITE_SECONDARY_INDEX";
+    case MessageType::TX_DELETE_SECONDARY_INDEX:
+      return "TX_DELETE_SECONDARY_INDEX";
+    case MessageType::TX_UPDATE_SECONDARY_INDEX:
+      return "TX_UPDATE_SECONDARY_INDEX";
+    case MessageType::TX_GET_MATCHING_KEYS_IN_RANGE:
+      return "TX_GET_MATCHING_KEYS_IN_RANGE";
+    case MessageType::TX_GET_MATCHING_KEYS_AND_VALUES_IN_RANGE:
+      return "TX_GET_MATCHING_KEYS_AND_VALUES_IN_RANGE";
+    case MessageType::TX_GET_MATCHING_KEYS_AND_VALUES_FROM_PREFIX:
+      return "TX_GET_MATCHING_KEYS_AND_VALUES_FROM_PREFIX";
+    case MessageType::TX_FETCH_LAST_KEY_IN_RANGE:
+      return "TX_FETCH_LAST_KEY_IN_RANGE";
+    case MessageType::TX_FETCH_FIRST_KEY_WITH_PREFIX:
+      return "TX_FETCH_FIRST_KEY_WITH_PREFIX";
+    case MessageType::TX_FETCH_NEXT_KEY_WITH_PREFIX:
+      return "TX_FETCH_NEXT_KEY_WITH_PREFIX";
+    case MessageType::TX_GET_MATCHING_PRIMARY_KEYS_IN_RANGE:
+      return "TX_GET_MATCHING_PRIMARY_KEYS_IN_RANGE";
+    case MessageType::TX_GET_MATCHING_PRIMARY_KEYS_FROM_PREFIX:
+      return "TX_GET_MATCHING_PRIMARY_KEYS_FROM_PREFIX";
+    case MessageType::TX_FETCH_LAST_PRIMARY_KEY_IN_SECONDARY_RANGE:
+      return "TX_FETCH_LAST_PRIMARY_KEY_IN_SECONDARY_RANGE";
+    case MessageType::TX_FETCH_LAST_SECONDARY_ENTRY_IN_RANGE:
+      return "TX_FETCH_LAST_SECONDARY_ENTRY_IN_RANGE";
+    case MessageType::DB_FENCE:
+      return "DB_FENCE";
+    case MessageType::DB_END_TRANSACTION:
+      return "DB_END_TRANSACTION";
+    case MessageType::DB_CREATE_TABLE:
+      return "DB_CREATE_TABLE";
+    case MessageType::DB_SET_TABLE:
+      return "DB_SET_TABLE";
+    case MessageType::DB_CREATE_SECONDARY_INDEX:
+      return "DB_CREATE_SECONDARY_INDEX";
+    case MessageType::TX_BATCH_READ:
+      return "TX_BATCH_READ";
+    case MessageType::TX_BATCH_WRITE:
+      return "TX_BATCH_WRITE";
+  }
+  return "UNDEFINED";
+}
+
+std::string json_escape(const std::string& s, size_t max_len) {
+  std::string out;
+  out.reserve(s.size() + 8);
+  const size_t n = std::min(s.size(), max_len);
+  for (size_t i = 0; i < n; ++i) {
+    unsigned char c = static_cast<unsigned char>(s[i]);
+    switch (c) {
+      case '"':
+        out += "\\\"";
+        break;
+      case '\\':
+        out += "\\\\";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
+      default:
+        if (c < 0x20 || c >= 0x7f) {
+          char buf[8];
+          std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+          out += buf;
+        } else {
+          out += static_cast<char>(c);
+        }
+    }
+  }
+  if (s.size() > max_len) out += "...";
+  return out;
+}
+
+void TxRpcTrace::start(int64_t tx_id, std::thread::id tid) {
+  if (!RpcTraceLogger::instance().enabled()) {
+    active_ = false;
+    return;
+  }
+  active_ = true;
+  tx_id_ = tx_id;
+  tid_ = tid;
+  started_ = std::chrono::steady_clock::now();
+  started_wall_ = std::chrono::system_clock::now();
+  rpcs_.clear();
+  statements_.clear();
+  by_type_.clear();
+}
+
+void TxRpcTrace::on_stmt(const std::string& sql) {
+  if (!active_) return;
+  if (!statements_.empty() && statements_.back().sql == sql) return;
+  const uint64_t off = std::chrono::duration_cast<std::chrono::microseconds>(
+                           std::chrono::steady_clock::now() - started_)
+                           .count();
+  StatementEntry s;
+  s.sql = sql;
+  s.started_off_us = off;
+  s.first_rpc_idx = static_cast<uint32_t>(rpcs_.size());
+  s.last_rpc_idx = s.first_rpc_idx;
+  statements_.push_back(std::move(s));
+}
+
+void TxRpcTrace::record(MessageType type, uint64_t us, uint32_t req_b,
+                        uint32_t resp_b, const std::string& meta) {
+  if (!active_) return;
+  const uint64_t off = std::chrono::duration_cast<std::chrono::microseconds>(
+                           std::chrono::steady_clock::now() - started_)
+                           .count();
+
+  RpcEntry e;
+  e.type = type;
+  e.us = us;
+  e.off_us = (off >= us) ? (off - us) : 0;
+  e.req_b = req_b;
+  e.resp_b = resp_b;
+  e.stmt_idx = statements_.empty()
+                   ? UINT32_MAX
+                   : static_cast<uint32_t>(statements_.size() - 1);
+  e.meta = meta;
+  rpcs_.push_back(std::move(e));
+
+  if (!statements_.empty()) {
+    statements_.back().last_rpc_idx = static_cast<uint32_t>(rpcs_.size() - 1);
+  }
+
+  auto& a = by_type_[type];
+  a.n++;
+  a.us += us;
+  a.req_b += req_b;
+  a.resp_b += resp_b;
+}
+
+std::string TxRpcTrace::finalize_jsonl(bool committed) {
+  std::ostringstream os;
+  const uint64_t total_us =
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now() - started_)
+          .count();
+
+  std::ostringstream tid_os;
+  tid_os << tid_;
+
+  os << '{'
+     << "\"tx_id\":" << tx_id_
+     << ",\"thread_id\":\"" << tid_os.str() << '"'
+     << ",\"started_at\":\"" << format_iso(started_wall_) << '"'
+     << ",\"duration_us\":" << total_us
+     << ",\"status\":\"" << (committed ? "committed" : "aborted") << '"'
+     << ",\"rpc_count\":" << rpcs_.size()
+     << ",\"stmt_count\":" << statements_.size();
+
+  os << ",\"statements\":[";
+  for (size_t i = 0; i < statements_.size(); ++i) {
+    const auto& s = statements_[i];
+    if (i > 0) os << ',';
+    os << '{'
+       << "\"idx\":" << i
+       << ",\"sql\":\"" << json_escape(s.sql, 1024) << '"'
+       << ",\"started_off_us\":" << s.started_off_us
+       << ",\"first_rpc\":" << s.first_rpc_idx
+       << ",\"last_rpc\":" << s.last_rpc_idx
+       << '}';
+  }
+  os << ']';
+
+  os << ",\"rpcs\":[";
+  for (size_t i = 0; i < rpcs_.size(); ++i) {
+    const auto& r = rpcs_[i];
+    if (i > 0) os << ',';
+    os << '{'
+       << "\"i\":" << i
+       << ",\"type\":\"" << message_type_name(r.type) << '"'
+       << ",\"off_us\":" << r.off_us
+       << ",\"us\":" << r.us
+       << ",\"req_b\":" << r.req_b
+       << ",\"resp_b\":" << r.resp_b
+       << ",\"stmt\":";
+    if (r.stmt_idx == UINT32_MAX) {
+      os << "null";
+    } else {
+      os << r.stmt_idx;
+    }
+    if (!r.meta.empty()) {
+      os << ",\"meta\":\"" << json_escape(r.meta, 256) << '"';
+    }
+    os << '}';
+  }
+  os << ']';
+
+  os << ",\"summary_by_type\":{";
+  bool first = true;
+  for (const auto& kv : by_type_) {
+    if (!first) os << ',';
+    first = false;
+    os << '"' << message_type_name(kv.first) << "\":{"
+       << "\"n\":" << kv.second.n
+       << ",\"us\":" << kv.second.us
+       << ",\"req_b\":" << kv.second.req_b
+       << ",\"resp_b\":" << kv.second.resp_b
+       << '}';
+  }
+  os << '}';
+
+  os << '}';
+  active_ = false;
+  return os.str();
+}
+
+RpcTraceLogger& RpcTraceLogger::instance() {
+  static RpcTraceLogger inst;
+  return inst;
+}
+
+RpcTraceLogger::RpcTraceLogger() {
+  const char* env = std::getenv("ENABLE_RPC_TRACE");
+  if (env == nullptr || env[0] == '\0' || std::string(env) == "0") {
+    enabled_ = false;
+    return;
+  }
+
+  const char* path_env = std::getenv("ENABLE_RPC_TRACE_PATH");
+  std::string path;
+  if (path_env != nullptr && path_env[0] != '\0') {
+    path = path_env;
+  } else {
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "/tmp/ordo_rpc_trace_%d.jsonl",
+                  static_cast<int>(getpid()));
+    path = buf;
+  }
+
+  file_.open(path, std::ios::out | std::ios::app);
+  if (!file_.is_open()) {
+    enabled_ = false;
+    return;
+  }
+  enabled_ = true;
+}
+
+RpcTraceLogger::~RpcTraceLogger() {
+  if (file_.is_open()) file_.close();
+}
+
+void RpcTraceLogger::log_line(const std::string& jsonl) {
+  if (!enabled_) return;
+  std::lock_guard<std::mutex> lk(mu_);
+  file_ << jsonl << '\n';
+  file_.flush();
+}

--- a/proxy/rpc_trace.hh
+++ b/proxy/rpc_trace.hh
@@ -1,0 +1,84 @@
+#ifndef LINEAIRDB_RPC_TRACE_HH
+#define LINEAIRDB_RPC_TRACE_HH
+
+#include <chrono>
+#include <cstdint>
+#include <fstream>
+#include <map>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "lineairdb_proxy.hh"  // MessageType
+
+// Per-RPC record captured by send_message_with_header.
+struct RpcEntry {
+  MessageType type;
+  uint64_t us;          // duration microseconds
+  uint64_t off_us;      // offset from tx_begin in microseconds
+  uint32_t req_b;       // serialized request bytes
+  uint32_t resp_b;      // serialized response bytes
+  uint32_t stmt_idx;    // index into statements_; UINT32_MAX if pre-stmt
+  std::string meta;     // optional key, index name, prefix, etc.
+};
+
+// Per-statement record captured at statement boundaries.
+struct StatementEntry {
+  std::string sql;
+  uint64_t started_off_us;
+  uint32_t first_rpc_idx;
+  uint32_t last_rpc_idx;
+};
+
+// Per-LineairDBTransaction trace state.
+class TxRpcTrace {
+ public:
+  void start(int64_t tx_id, std::thread::id tid);
+  void set_tx_id(int64_t tx_id) { tx_id_ = tx_id; }
+  void on_stmt(const std::string& sql);
+  void record(MessageType type, uint64_t us, uint32_t req_b,
+              uint32_t resp_b, const std::string& meta);
+  std::string finalize_jsonl(bool committed);
+
+  bool active() const { return active_; }
+
+ private:
+  bool active_ = false;
+  int64_t tx_id_ = -1;
+  std::thread::id tid_;
+  std::chrono::steady_clock::time_point started_;
+  std::chrono::system_clock::time_point started_wall_;
+  std::vector<RpcEntry> rpcs_;
+  std::vector<StatementEntry> statements_;
+
+  struct Agg {
+    uint32_t n = 0;
+    uint64_t us = 0;
+    uint64_t req_b = 0;
+    uint64_t resp_b = 0;
+  };
+
+  std::map<MessageType, Agg> by_type_;
+};
+
+// Singleton JSONL logger enabled by ENABLE_RPC_TRACE.
+class RpcTraceLogger {
+ public:
+  static RpcTraceLogger& instance();
+  bool enabled() const { return enabled_; }
+  void log_line(const std::string& jsonl);
+
+ private:
+  RpcTraceLogger();
+  ~RpcTraceLogger();
+
+  bool enabled_ = false;
+  std::mutex mu_;
+  std::ofstream file_;
+};
+
+const char* message_type_name(MessageType t);
+std::string json_escape(const std::string& s, size_t max_len = 1024);
+
+#endif  // LINEAIRDB_RPC_TRACE_HH

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -537,6 +537,7 @@ void LineairDBRpc::handleTxGetMatchingKeysAndValuesInRange(const std::string& me
         std::string start_key = request.start_key();
         std::string end_key = request.end_key();
         const uint64_t row_limit = request.row_limit();
+        const bool reverse_scan = request.reverse_scan();
         // Count rows actually returned after tombstone and predicate checks.
         uint64_t returned_rows = 0;
 
@@ -550,9 +551,9 @@ void LineairDBRpc::handleTxGetMatchingKeysAndValuesInRange(const std::string& me
         PredicateEvaluator evaluator;
 
         // Scan callback: value is pair<const void*, size_t> from LineairDB
-        auto scan_result = tx->Scan(
-            start_key, end_opt, [&result, row_limit, &returned_rows,
-                                  filter_expr, filter_num_cols, &evaluator](auto key, auto value) {
+        auto append_matching_row =
+            [&result, row_limit, &returned_rows, filter_expr, filter_num_cols,
+             &evaluator](auto key, auto value) {
                 // Skip tombstones (deleted rows)
                 if (value.first == nullptr || value.second == 0) { return false; }
                 // Predicate pushdown: evaluate filter if present
@@ -575,7 +576,14 @@ void LineairDBRpc::handleTxGetMatchingKeysAndValuesInRange(const std::string& me
                 returned_rows++;
                 // Stop the LineairDB scan once the pushed LIMIT is satisfied.
                 return row_limit > 0 && returned_rows >= row_limit;
-            });
+            };
+
+        std::optional<size_t> scan_result;
+        if (reverse_scan) {
+            scan_result = tx->ScanReverse(start_key, end_opt, append_matching_row);
+        } else {
+            scan_result = tx->Scan(start_key, end_opt, append_matching_row);
+        }
 
         // Phantom detection: if Scan returns nullopt, the transaction is in an abort state
         if (!scan_result.has_value()) {

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -245,19 +245,38 @@ void LineairDBRpc::handleTxBatchWrite(const std::string& message, std::string& r
             tx->SetTable(request.table_name());
         }
 
-        for (int i = 0; i < request.writes_size(); i++) {
-            const auto& op = request.writes(i);
-            const std::string& value_str = op.value();
-            tx->Write(op.key(), reinterpret_cast<const std::byte*>(value_str.c_str()), value_str.size());
-            if (tx->IsAborted()) break;
-        }
-
         if (!tx->IsAborted()) {
-            for (int i = 0; i < request.secondary_index_writes_size(); i++) {
-                const auto& si = request.secondary_index_writes(i);
-                const std::string& pk = si.primary_key();
-                tx->WriteSecondaryIndex(si.index_name(), si.secondary_key(),
-                                        reinterpret_cast<const std::byte*>(pk.c_str()), pk.size());
+            for (int i = 0; i < request.ops_size(); i++) {
+                const auto& op = request.ops(i);
+                switch (op.type()) {
+                    case LineairDB::Protocol::BATCH_OP_WRITE: {
+                        const std::string& value_str = op.value();
+                        tx->Write(op.key(),
+                                  reinterpret_cast<const std::byte*>(value_str.c_str()),
+                                  value_str.size());
+                        break;
+                    }
+                    case LineairDB::Protocol::BATCH_OP_DELETE:
+                        tx->Delete(op.key());
+                        break;
+                    case LineairDB::Protocol::BATCH_OP_SECONDARY_INDEX_WRITE: {
+                        const std::string& pk = op.primary_key();
+                        tx->WriteSecondaryIndex(
+                            op.index_name(), op.secondary_key(),
+                            reinterpret_cast<const std::byte*>(pk.c_str()), pk.size());
+                        break;
+                    }
+                    case LineairDB::Protocol::BATCH_OP_SECONDARY_INDEX_DELETE: {
+                        const std::string& pk = op.primary_key();
+                        tx->DeleteSecondaryIndex(
+                            op.index_name(), op.secondary_key(),
+                            reinterpret_cast<const std::byte*>(pk.c_str()), pk.size());
+                        break;
+                    }
+                    case LineairDB::Protocol::BATCH_OP_UNKNOWN:
+                    default:
+                        break;
+                }
                 if (tx->IsAborted()) break;
             }
         }

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -248,6 +248,11 @@ void LineairDBRpc::handleTxBatchWrite(const std::string& message, std::string& r
         if (!tx->IsAborted()) {
             for (int i = 0; i < request.ops_size(); i++) {
                 const auto& op = request.ops(i);
+                const std::string& op_table =
+                    op.table_name().empty() ? request.table_name() : op.table_name();
+                if (!op_table.empty()) {
+                    tx->SetTable(op_table);
+                }
                 switch (op.type()) {
                     case LineairDB::Protocol::BATCH_OP_WRITE: {
                         const std::string& value_str = op.value();

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -512,6 +512,9 @@ void LineairDBRpc::handleTxGetMatchingKeysAndValuesInRange(const std::string& me
         }
         std::string start_key = request.start_key();
         std::string end_key = request.end_key();
+        const uint64_t row_limit = request.row_limit();
+        // Count rows actually returned after tombstone and predicate checks.
+        uint64_t returned_rows = 0;
 
         std::optional<std::string_view> end_opt;
         if (!end_key.empty()) { end_opt = end_key; }
@@ -524,7 +527,7 @@ void LineairDBRpc::handleTxGetMatchingKeysAndValuesInRange(const std::string& me
 
         // Scan callback: value is pair<const void*, size_t> from LineairDB
         auto scan_result = tx->Scan(
-            start_key, end_opt, [&result,
+            start_key, end_opt, [&result, row_limit, &returned_rows,
                                   filter_expr, filter_num_cols, &evaluator](auto key, auto value) {
                 // Skip tombstones (deleted rows)
                 if (value.first == nullptr || value.second == 0) { return false; }
@@ -545,7 +548,9 @@ void LineairDBRpc::handleTxGetMatchingKeysAndValuesInRange(const std::string& me
                 result.append(key.data(), key.size());
                 result.append(reinterpret_cast<const char*>(&vlen), 4);
                 result.append(static_cast<const char*>(value.first), value.second);
-                return false;  // continue scanning
+                returned_rows++;
+                // Stop the LineairDB scan once the pushed LIMIT is satisfied.
+                return row_limit > 0 && returned_rows >= row_limit;
             });
 
         // Phantom detection: if Scan returns nullopt, the transaction is in an abort state


### PR DESCRIPTION
## Summary

- Add RPC trace logging for transaction-level RPC analysis.
- Batch base-row updates, deletes, and secondary-index deletes through TX_BATCH_WRITE.
- Flush only table-related pending writes before reads and scans to preserve RYOW with fewer early flushes.
- Push LIMIT into ordered primary-key range scans when the scan order matches ORDER BY.
- Add reverse range scan support for DESC LIMIT paths.
- Keep LIMIT local unless the pushed WHERE filter is simple enough for the server to apply safely.