### PR TITLE
Feat/proxy local view

### DIFF
--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -470,10 +470,23 @@ LineairDBTransaction::lookup_local_read_set(
   return std::nullopt;
 }
 
+void LineairDBTransaction::drop_local_read(const std::string& table_name,
+                                           const std::string& key) {
+  for (auto it = local_read_set_.begin(); it != local_read_set_.end(); ++it) {
+    if (it->table_name == table_name && it->key == key) {
+      local_read_set_.erase(it);
+      return;
+    }
+  }
+}
+
 void LineairDBTransaction::record_local_write(const std::string& table_name,
                                               const std::string& key,
                                               bool found,
                                               const std::string& value) {
+  // A later write/delete replaces any cached read for the same key
+  drop_local_read(table_name, key);
+
   for (auto& entry : local_write_set_) {
     if (entry.table_name == table_name && entry.key == key) {
       entry.found = found;

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -38,10 +38,28 @@ const std::pair<const std::byte *const, const size_t>
 LineairDBTransaction::read(std::string key) {
   if (table_is_not_chosen()) return std::pair<const std::byte *const, const size_t>{nullptr, 0};
 
-  flush_write_buffer_for_table(db_table_key);
+  // Silo-style local view: own writes are visible before remote reads
+  if (auto entry = lookup_local_write_set(db_table_key, key)) {
+    if (!entry->found) return {nullptr, 0};
+    last_read_value_ = entry->value;
+    return {reinterpret_cast<const std::byte*>(last_read_value_.data()), last_read_value_.size()};
+  }
 
+  // Repeat exact-key reads can use the local read set
+  if (auto entry = lookup_local_read_set(db_table_key, key)) {
+    if (!entry->found) return {nullptr, 0};
+    last_read_value_ = entry->value;
+    return {reinterpret_cast<const std::byte*>(last_read_value_.data()), last_read_value_.size()};
+  }
+
+  // First exact-key read goes to the server and enters the local read set
   last_read_value_ = lineairdb_proxy->tx_read(this, key);
-  if (last_read_value_.empty()) return std::pair<const std::byte *const, const size_t>{nullptr, 0};
+  if (last_read_value_.empty()) {
+    record_local_read(db_table_key, key, false, ""); // value unused when not found
+    return std::pair<const std::byte *const, const size_t>{nullptr, 0};
+  }
+
+  record_local_read(db_table_key, key, true, last_read_value_);
 
   return {reinterpret_cast<const std::byte*>(last_read_value_.data()), last_read_value_.size()};
 }
@@ -49,13 +67,40 @@ LineairDBTransaction::read(std::string key) {
 std::vector<std::pair<bool, std::string>>
 LineairDBTransaction::batch_read(const std::vector<std::string>& keys) {
   if (table_is_not_chosen()) return {};
-  flush_write_buffer_for_table(db_table_key);
 
-  auto results = lineairdb_proxy->tx_batch_read(this, keys);
   std::vector<std::pair<bool, std::string>> pairs;
-  pairs.reserve(results.size());
-  for (auto& r : results) {
-    pairs.emplace_back(r.found, std::move(r.value));
+  pairs.resize(keys.size());
+
+  std::vector<std::string> rpc_keys;
+  std::vector<size_t> rpc_positions;
+  rpc_keys.reserve(keys.size());
+  rpc_positions.reserve(keys.size());
+
+  // Resolve keys covered by the local read/write sets first
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (auto entry = lookup_local_write_set(db_table_key, keys[i])) {
+      pairs[i] = {entry->found, entry->value};
+      continue;
+    }
+    if (auto entry = lookup_local_read_set(db_table_key, keys[i])) {
+      pairs[i] = {entry->found, entry->value};
+      continue;
+    }
+    rpc_positions.push_back(i);
+    rpc_keys.push_back(keys[i]);
+  }
+
+  // Fetch only cache misses; tx_batch_read() returns rows in rpc_keys order
+  //   Example: keys=[A,B,C], B is local -> rpc_keys=[A,C],
+  //            rpc_positions=[0,2], so RPC results fill pairs[0] and pairs[2].
+  if (!rpc_keys.empty()) {
+    auto results = lineairdb_proxy->tx_batch_read(this, rpc_keys);
+    for (size_t i = 0; i < results.size(); ++i) {
+      // Map each RPC result back to the original keys[] position
+      const size_t pos = rpc_positions[i];
+      pairs[pos] = {results[i].found, std::move(results[i].value)};
+      record_local_read(db_table_key, keys[pos], pairs[pos].first, pairs[pos].second);
+    }
   }
   return pairs;
 }
@@ -99,13 +144,17 @@ LineairDBTransaction::get_matching_keys(std::string first_key_part) {
 bool LineairDBTransaction::write(std::string key, const std::string value) {
   if (table_is_not_chosen()) return false;
 
-  return lineairdb_proxy->tx_write(this, key, value);
+  const bool ok = lineairdb_proxy->tx_write(this, key, value);
+  if (ok) record_local_write(db_table_key, key, true, value);
+  return ok;
 }
 
 bool LineairDBTransaction::delete_value(std::string key) {
   if (table_is_not_chosen()) return false;
 
-  return lineairdb_proxy->tx_delete(this, key);
+  const bool ok = lineairdb_proxy->tx_delete(this, key);
+  if (ok) record_local_write(db_table_key, key, false, ""); // value unused when not found
+  return ok;
 }
 
 // Secondary index operations
@@ -293,6 +342,7 @@ void LineairDBTransaction::buffer_write(const std::string& table_name,
   op.value = value;
   op.table_name = table_name;
   write_buffer_ops_.push_back(std::move(op));
+  record_local_write(table_name, key, true, value);
 
   if (write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
     flush_write_buffer();
@@ -323,6 +373,7 @@ void LineairDBTransaction::buffer_delete(const std::string& table_name,
   op.key = key;
   op.table_name = table_name;
   write_buffer_ops_.push_back(std::move(op));
+  record_local_write(table_name, key, false, ""); // value unused when not found
 
   if (write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
     flush_write_buffer();
@@ -397,6 +448,54 @@ bool LineairDBTransaction::flush_write_buffer_for_table(
 
   write_buffer_ops_ = std::move(keep_ops);
   return true;
+}
+
+std::optional<LineairDBTransaction::LocalRowEntry>
+LineairDBTransaction::lookup_local_write_set(
+    const std::string& table_name, const std::string& key) const {
+  for (auto it = local_write_set_.rbegin(); it != local_write_set_.rend(); ++it) {
+    if (it->table_name == table_name && it->key == key) {
+      return *it;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<LineairDBTransaction::LocalRowEntry>
+LineairDBTransaction::lookup_local_read_set(
+    const std::string& table_name, const std::string& key) const {
+  for (auto it = local_read_set_.rbegin(); it != local_read_set_.rend(); ++it) {
+    if (it->table_name == table_name && it->key == key) return *it;
+  }
+  return std::nullopt;
+}
+
+void LineairDBTransaction::record_local_write(const std::string& table_name,
+                                              const std::string& key,
+                                              bool found,
+                                              const std::string& value) {
+  for (auto& entry : local_write_set_) {
+    if (entry.table_name == table_name && entry.key == key) {
+      entry.found = found;
+      entry.value = value;
+      return;
+    }
+  }
+  local_write_set_.push_back({table_name, key, found, value});
+}
+
+void LineairDBTransaction::record_local_read(const std::string& table_name,
+                                             const std::string& key,
+                                             bool found,
+                                             const std::string& value) {
+  for (auto& entry : local_read_set_) {
+    if (entry.table_name == table_name && entry.key == key) {
+      entry.found = found;
+      entry.value = value;
+      return;
+    }
+  }
+  local_read_set_.push_back({table_name, key, found, value});
 }
 
 void LineairDBTransaction::begin_transaction() {

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -210,7 +210,11 @@ LineairDBTransaction::get_matching_keys_and_values_in_range(std::string start_ke
                                                             uint64_t row_limit,
                                                             bool reverse_scan) {
   if (table_is_not_chosen()) return {};
-  flush_write_buffer_for_table(db_table_key);
+  const bool can_merge_local_rows = (row_limit == 0 && pushed_filter_.empty());
+  // LIMIT / pushed filter scans must see only server-filtered rows
+  if (!can_merge_local_rows) {
+    flush_write_buffer_for_table(db_table_key);
+  }
 
   auto results = lineairdb_proxy->tx_get_matching_keys_and_values_in_range(
       this, start_key, end_key, row_limit, reverse_scan);
@@ -219,19 +223,31 @@ LineairDBTransaction::get_matching_keys_and_values_in_range(std::string start_ke
   for (const auto& kv : results) {
     pairs.emplace_back(kv.key, kv.value);
   }
+  // Merge unflushed own writes after the server has validated the range
+  if (can_merge_local_rows) {
+    merge_pending_rows_into_range_scan(pairs, start_key, end_key, reverse_scan);
+  }
   return pairs;
 }
 
 std::vector<std::pair<std::string, std::string>>
 LineairDBTransaction::get_matching_keys_and_values_from_prefix(std::string prefix) {
   if (table_is_not_chosen()) return {};
-  flush_write_buffer_for_table(db_table_key);
+  const bool can_merge_local_rows = pushed_filter_.empty();
+  // Pushed filter scans must see only server-filtered rows
+  if (!can_merge_local_rows) {
+    flush_write_buffer_for_table(db_table_key);
+  }
 
   auto results = lineairdb_proxy->tx_get_matching_keys_and_values_from_prefix(this, prefix);
 
   std::vector<std::pair<std::string, std::string>> pairs;
   for (const auto& kv : results) {
     pairs.emplace_back(kv.key, kv.value);
+  }
+  // Merge unflushed own writes after the server has validated the prefix
+  if (can_merge_local_rows) {
+    merge_pending_rows_into_prefix_scan(pairs, prefix);
   }
   return pairs;
 }
@@ -476,6 +492,87 @@ void LineairDBTransaction::drop_local_read(const std::string& table_name,
     if (it->table_name == table_name && it->key == key) {
       local_read_set_.erase(it);
       return;
+    }
+  }
+}
+
+bool LineairDBTransaction::key_is_in_range(const std::string& key,
+                                           const std::string& start_key,
+                                           const std::string& end_key) const {
+  // LineairDB ranges are [start_key, end_key)
+  if (key < start_key) return false;
+  if (!end_key.empty() && key >= end_key) return false;
+  return true;
+}
+
+bool LineairDBTransaction::key_starts_with(const std::string& key,
+                                           const std::string& prefix) const {
+  // Prefix scans use the encoded primary-key prefix
+  if (key.size() < prefix.size()) return false;
+  return key.compare(0, prefix.size(), prefix) == 0;
+}
+
+void LineairDBTransaction::remove_scan_row(
+    std::vector<std::pair<std::string, std::string>>& rows,
+    const std::string& key) const {
+  // Local write/delete replaces any server row with the same key
+  for (auto it = rows.begin(); it != rows.end(); ++it) {
+    if (it->first == key) {
+      rows.erase(it);
+      return;
+    }
+  }
+}
+
+void LineairDBTransaction::insert_scan_row_in_order(
+    std::vector<std::pair<std::string, std::string>>& rows,
+    const std::string& key, const std::string& value,
+    bool reverse_scan) const {
+  // Keep the materialized scan result in key order
+  for (auto it = rows.begin(); it != rows.end(); ++it) {
+    if ((!reverse_scan && key < it->first) || (reverse_scan && key > it->first)) {
+      rows.insert(it, {key, value});
+      return;
+    }
+  }
+  rows.emplace_back(key, value);
+}
+
+void LineairDBTransaction::merge_pending_rows_into_range_scan(
+    std::vector<std::pair<std::string, std::string>>& rows,
+    const std::string& start_key, const std::string& end_key,
+    bool reverse_scan) const {
+  // Server scan validates the range; proxy only adds its unflushed row ops
+  for (const auto& op : write_buffer_ops_) {
+    if (op.table_name != db_table_key) continue;
+    if (op.type != LineairDBProxy::BatchOp::Type::Write &&
+        op.type != LineairDBProxy::BatchOp::Type::Delete) {
+      continue;
+    }
+    if (!key_is_in_range(op.key, start_key, end_key)) continue;
+
+    remove_scan_row(rows, op.key);
+    if (op.type == LineairDBProxy::BatchOp::Type::Write) {
+      insert_scan_row_in_order(rows, op.key, op.value, reverse_scan);
+    }
+  }
+}
+
+void LineairDBTransaction::merge_pending_rows_into_prefix_scan(
+    std::vector<std::pair<std::string, std::string>>& rows,
+    const std::string& prefix) const {
+  // Prefix scans are ASC, so inserted local rows keep ASC key order
+  for (const auto& op : write_buffer_ops_) {
+    if (op.table_name != db_table_key) continue;
+    if (op.type != LineairDBProxy::BatchOp::Type::Write &&
+        op.type != LineairDBProxy::BatchOp::Type::Delete) {
+      continue;
+    }
+    if (!key_starts_with(op.key, prefix)) continue;
+
+    remove_scan_row(rows, op.key);
+    if (op.type == LineairDBProxy::BatchOp::Type::Write) {
+      insert_scan_row_in_order(rows, op.key, op.value, false);
     }
   }
 }

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -40,6 +40,7 @@ LineairDBTransaction::read(std::string key) {
 
   // Silo-style local view: own writes are visible before remote reads
   if (auto entry = lookup_local_write_set(db_table_key, key)) {
+    rpc_trace_.record_local_view("read_write_hit");
     if (!entry->found) return {nullptr, 0};
     last_read_value_ = entry->value;
     return {reinterpret_cast<const std::byte*>(last_read_value_.data()), last_read_value_.size()};
@@ -47,12 +48,14 @@ LineairDBTransaction::read(std::string key) {
 
   // Repeat exact-key reads can use the local read set
   if (auto entry = lookup_local_read_set(db_table_key, key)) {
+    rpc_trace_.record_local_view("read_cache_hit");
     if (!entry->found) return {nullptr, 0};
     last_read_value_ = entry->value;
     return {reinterpret_cast<const std::byte*>(last_read_value_.data()), last_read_value_.size()};
   }
 
   // First exact-key read goes to the server and enters the local read set
+  rpc_trace_.record_local_view("read_miss");
   last_read_value_ = lineairdb_proxy->tx_read(this, key);
   if (last_read_value_.empty()) {
     record_local_read(db_table_key, key, false, ""); // value unused when not found
@@ -79,13 +82,16 @@ LineairDBTransaction::batch_read(const std::vector<std::string>& keys) {
   // Resolve keys covered by the local read/write sets first
   for (size_t i = 0; i < keys.size(); ++i) {
     if (auto entry = lookup_local_write_set(db_table_key, keys[i])) {
+      rpc_trace_.record_local_view("batch_write_hit");
       pairs[i] = {entry->found, entry->value};
       continue;
     }
     if (auto entry = lookup_local_read_set(db_table_key, keys[i])) {
+      rpc_trace_.record_local_view("batch_cache_hit");
       pairs[i] = {entry->found, entry->value};
       continue;
     }
+    rpc_trace_.record_local_view("batch_miss");
     rpc_positions.push_back(i);
     rpc_keys.push_back(keys[i]);
   }

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -178,6 +178,24 @@ private:
       const std::string& table_name, const std::string& key) const;
   void drop_local_read(const std::string& table_name,
                        const std::string& key);
+  bool key_is_in_range(const std::string& key,
+                       const std::string& start_key,
+                       const std::string& end_key) const;
+  bool key_starts_with(const std::string& key,
+                       const std::string& prefix) const;
+  void remove_scan_row(std::vector<std::pair<std::string, std::string>>& rows,
+                       const std::string& key) const;
+  void insert_scan_row_in_order(
+      std::vector<std::pair<std::string, std::string>>& rows,
+      const std::string& key, const std::string& value,
+      bool reverse_scan) const;
+  void merge_pending_rows_into_range_scan(
+      std::vector<std::pair<std::string, std::string>>& rows,
+      const std::string& start_key, const std::string& end_key,
+      bool reverse_scan) const;
+  void merge_pending_rows_into_prefix_scan(
+      std::vector<std::pair<std::string, std::string>>& rows,
+      const std::string& prefix) const;
   void record_local_write(const std::string& table_name,
                           const std::string& key, bool found,
                           const std::string& value);

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -176,6 +176,8 @@ private:
       const std::string& table_name, const std::string& key) const;
   std::optional<LocalRowEntry> lookup_local_read_set(
       const std::string& table_name, const std::string& key) const;
+  void drop_local_read(const std::string& table_name,
+                       const std::string& key);
   void record_local_write(const std::string& table_name,
                           const std::string& key, bool found,
                           const std::string& value);

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -151,16 +151,37 @@ private:
   };
   std::vector<RowCountDelta> rowcount_deltas_;
 
+  struct LocalRowEntry {
+    std::string table_name;
+    std::string key;
+    bool found;
+    std::string value;
+  };
+  // Proxy-side read set for exact primary-key reads
+  std::vector<LocalRowEntry> local_read_set_;
+  // Proxy-side write set for exact primary-key writes/deletes
+  std::vector<LocalRowEntry> local_write_set_;
+
   // Predicate pushdown: serialized PushedPredicate for scan filtering
   std::string pushed_filter_;
 
   // Max number of buffered write/delete ops before an automatic flush
   static constexpr size_t WRITE_BATCH_SIZE = 100;
-  // Stores row and secondary-index write/delete ops in MySQL issue order
+  // Pending RPC flush queue for row and secondary-index ops in MySQL order
   std::vector<LineairDBProxy::BatchOp> write_buffer_ops_;
 
   TxRpcTrace rpc_trace_;
 
+  std::optional<LocalRowEntry> lookup_local_write_set(
+      const std::string& table_name, const std::string& key) const;
+  std::optional<LocalRowEntry> lookup_local_read_set(
+      const std::string& table_name, const std::string& key) const;
+  void record_local_write(const std::string& table_name,
+                          const std::string& key, bool found,
+                          const std::string& value);
+  void record_local_read(const std::string& table_name,
+                         const std::string& key, bool found,
+                         const std::string& value);
   bool thd_is_transaction() const;
   void register_transaction_to_mysql();
   void register_single_statement_to_mysql();

--- a/proxy/rpc_trace.cc
+++ b/proxy/rpc_trace.cc
@@ -135,7 +135,9 @@ void TxRpcTrace::start(int64_t tx_id, std::thread::id tid) {
   started_wall_ = std::chrono::system_clock::now();
   rpcs_.clear();
   statements_.clear();
+  local_view_entries_.clear();
   by_type_.clear();
+  local_view_by_kind_.clear();
 }
 
 void TxRpcTrace::on_stmt(const std::string& sql) {
@@ -180,6 +182,22 @@ void TxRpcTrace::record(MessageType type, uint64_t us, uint32_t req_b,
   a.us += us;
   a.req_b += req_b;
   a.resp_b += resp_b;
+}
+
+void TxRpcTrace::record_local_view(const std::string& kind) {
+  if (!active_) return;
+  const uint64_t off = std::chrono::duration_cast<std::chrono::microseconds>(
+                           std::chrono::steady_clock::now() - started_)
+                           .count();
+
+  LocalViewEntry e;
+  e.kind = kind;
+  e.off_us = off;
+  e.stmt_idx = statements_.empty()
+                   ? UINT32_MAX
+                   : static_cast<uint32_t>(statements_.size() - 1);
+  local_view_entries_.push_back(std::move(e));
+  local_view_by_kind_[kind]++;
 }
 
 std::string TxRpcTrace::finalize_jsonl(bool committed) {
@@ -239,6 +257,24 @@ std::string TxRpcTrace::finalize_jsonl(bool committed) {
   }
   os << ']';
 
+  os << ",\"local_view_events\":[";
+  for (size_t i = 0; i < local_view_entries_.size(); ++i) {
+    const auto& e = local_view_entries_[i];
+    if (i > 0) os << ',';
+    os << '{'
+       << "\"i\":" << i
+       << ",\"kind\":\"" << json_escape(e.kind, 128) << '"'
+       << ",\"off_us\":" << e.off_us
+       << ",\"stmt\":";
+    if (e.stmt_idx == UINT32_MAX) {
+      os << "null";
+    } else {
+      os << e.stmt_idx;
+    }
+    os << '}';
+  }
+  os << ']';
+
   os << ",\"summary_by_type\":{";
   bool first = true;
   for (const auto& kv : by_type_) {
@@ -250,6 +286,15 @@ std::string TxRpcTrace::finalize_jsonl(bool committed) {
        << ",\"req_b\":" << kv.second.req_b
        << ",\"resp_b\":" << kv.second.resp_b
        << '}';
+  }
+  os << '}';
+
+  os << ",\"summary_local_view\":{";
+  bool first_local = true;
+  for (const auto& kv : local_view_by_kind_) {
+    if (!first_local) os << ',';
+    first_local = false;
+    os << '"' << json_escape(kv.first, 128) << "\":" << kv.second;
   }
   os << '}';
 

--- a/proxy/rpc_trace.hh
+++ b/proxy/rpc_trace.hh
@@ -31,6 +31,13 @@ struct StatementEntry {
   uint32_t last_rpc_idx;
 };
 
+// Per-local-view decision captured before a point read falls back to RPC.
+struct LocalViewEntry {
+  std::string kind;
+  uint64_t off_us;
+  uint32_t stmt_idx;
+};
+
 // Per-LineairDBTransaction trace state.
 class TxRpcTrace {
  public:
@@ -39,6 +46,7 @@ class TxRpcTrace {
   void on_stmt(const std::string& sql);
   void record(MessageType type, uint64_t us, uint32_t req_b,
               uint32_t resp_b, const std::string& meta);
+  void record_local_view(const std::string& kind);
   std::string finalize_jsonl(bool committed);
 
   bool active() const { return active_; }
@@ -51,6 +59,7 @@ class TxRpcTrace {
   std::chrono::system_clock::time_point started_wall_;
   std::vector<RpcEntry> rpcs_;
   std::vector<StatementEntry> statements_;
+  std::vector<LocalViewEntry> local_view_entries_;
 
   struct Agg {
     uint32_t n = 0;
@@ -60,6 +69,7 @@ class TxRpcTrace {
   };
 
   std::map<MessageType, Agg> by_type_;
+  std::map<std::string, uint32_t> local_view_by_kind_;
 };
 
 // Singleton JSONL logger enabled by ENABLE_RPC_TRACE.


### PR DESCRIPTION
## Summary
- Add a proxy-side local read/write view for exact primary-key reads.
- Resolve `read()` and `batch_read()` from local writes and cached reads before issuing RPCs.
- Merge unflushed local row writes/deletes into primary-key scan results when no LIMIT or pushed filter is involved.
- Add RPC trace counters for local view hit/miss events.