### PR TITLE
Feat/oneshot option

### DIFF
--- a/bench/bin/benchrun.py
+++ b/bench/bin/benchrun.py
@@ -193,7 +193,7 @@ def update_xml(config_path, **kwargs):
     config_path.write_text(text)
 
 
-def run_benchbase(benchmark, config_path, create=False, load=False, execute=False):
+def run_benchbase(benchmark, config_path, create=False, load=False, execute=False, oneshot=False):
     """Run BenchBase with given phases."""
     jar = BENCHBASE_DIR / "benchbase.jar"
     if not jar.exists():
@@ -203,9 +203,10 @@ def run_benchbase(benchmark, config_path, create=False, load=False, execute=Fals
     flags = f"--create={'true' if create else 'false'} --load={'true' if load else 'false'} --execute={'true' if execute else 'false'}"
     cmd = f"java -jar {jar} -b {benchmark} -c {config_path} {flags}"
 
+    env = {**os.environ, "HELIOS_ONESHOT_PLAN": "1"} if oneshot else None
     result = subprocess.run(
         cmd, shell=True, cwd=BENCHBASE_DIR,
-        capture_output=True, text=True,
+        capture_output=True, text=True, env=env,
     )
     return result
 
@@ -346,7 +347,7 @@ def setup_benchmark(benchmark, config_path, mysql_host, mysql_port):
     return load_time
 
 
-def run_execute(benchmark, config_path, terminals, result_base):
+def run_execute(benchmark, config_path, terminals, result_base, oneshot=False):
     """Run execute phase with metrics collection. Returns result dict."""
     print(f"\n{'='*50}")
     print(f"  {benchmark.upper()} | Terminals: {terminals}")
@@ -371,7 +372,8 @@ def run_execute(benchmark, config_path, terminals, result_base):
     jar = BENCHBASE_DIR / "benchbase.jar"
     bb_cmd = ["java", "-jar", str(jar), "-b", benchmark, "-c", str(config_path),
               "--create=false", "--load=false", "--execute=true"]
-    bb_proc = subprocess.Popen(bb_cmd, cwd=BENCHBASE_DIR, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    env = {**os.environ, "HELIOS_ONESHOT_PLAN": "1"} if oneshot else None
+    bb_proc = subprocess.Popen(bb_cmd, cwd=BENCHBASE_DIR, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env)
     # bb_proc.pid IS the java process (no shell wrapper)
     f = open(metrics_dir / "pidstat-bench.log", "w")
     p = subprocess.Popen(["pidstat", "-u", "-w", "-p", str(bb_proc.pid), "1"], stdout=f, stderr=subprocess.DEVNULL)
@@ -666,6 +668,9 @@ def main():
                         help="Skip auto start/stop of lineairdb-server and mysqld (assume already running)")
     parser.add_argument("--keep-lineairdb-logs", action="store_true",
                         help="Keep lineairdb_logs after the benchmark")
+    parser.add_argument("--oneshot", action="store_true",
+                        help="Enable Oneshot path: SET GLOBAL lineairdb_oneshot_execution=ON and "
+                             "pass HELIOS_ONESHOT_PLAN=1 to BenchBase (TPC-C procedures inject @_ldb_plan)")
     args = parser.parse_args()
 
     # Validate
@@ -780,6 +785,12 @@ def main():
 
 def _run_bench(args, config_work, thread_list, result_base):
     """Setup + execute sweep + summary + plots. Extracted so main() can wrap it."""
+    # Toggle Oneshot sysvar explicitly to avoid stale state from prior runs.
+    oneshot_value = "ON" if args.oneshot else "OFF"
+    print(f"  Setting lineairdb_oneshot_execution={oneshot_value}")
+    mysql_cmd(args.mysql_port, args.mysql_host,
+              f"SET GLOBAL lineairdb_oneshot_execution={oneshot_value};")
+
     # Setup phase
     load_time = None
     if args.no_setup:
@@ -807,7 +818,7 @@ def _run_bench(args, config_work, thread_list, result_base):
     # Execute: sweep terminal counts (data is reused)
     all_results = []
     for terminals in thread_list:
-        result = run_execute(args.benchmark, config_work, terminals, result_base)
+        result = run_execute(args.benchmark, config_work, terminals, result_base, oneshot=args.oneshot)
         if result:
             result["load_time"] = load_time
             all_results.append(result)

--- a/bench/bin/benchrun.py
+++ b/bench/bin/benchrun.py
@@ -850,12 +850,14 @@ def _run_bench(args, config_work, thread_list, result_base):
             plot_dir = result_base / "_plot"
             plot_dir.mkdir(parents=True, exist_ok=True)
 
-            # Throughput plot (always)
+            # Throughput plot (always): solid = throughput, dashed = goodput
             terminals = [r["terminals"] for r in all_results]
             throughput = [r.get("throughput", 0) for r in all_results]
+            goodput = [r.get("goodput", 0) for r in all_results]
 
             fig, ax = plt.subplots(figsize=(10, 6))
             ax.plot(terminals, throughput, "b-o", label="Throughput", linewidth=2)
+            ax.plot(terminals, goodput, "b--s", label="Goodput", linewidth=1.5, markersize=5, alpha=0.8)
             ax.set_xlabel("Terminals")
             ax.set_ylabel("req/s")
             ax.set_title(f"{args.benchmark.upper()} SF={args.scalefactor}")

--- a/bench/bin/benchrun.py
+++ b/bench/bin/benchrun.py
@@ -651,7 +651,7 @@ def _plot_metrics(result_base, plot_dir):
 
 def main():
     parser = argparse.ArgumentParser(description="Ordo benchmark runner")
-    parser.add_argument("benchmark", choices=["tpcc", "tpch", "ycsb"], help="Benchmark type")
+    parser.add_argument("benchmark", choices=["tpcc", "tpcc-np", "tpch", "ycsb"], help="Benchmark type")
     parser.add_argument("--terminals", type=int, default=64, help="Number of terminals (default: 64)")
     parser.add_argument("--sweep", type=str, help="Comma-separated thread counts to sweep (e.g. 1,4,16,64)")
     parser.add_argument("--scalefactor", type=float, default=1, help="Scale factor (default: 1)")
@@ -868,8 +868,8 @@ def _run_bench(args, config_work, thread_list, result_base):
             plt.close()
             print(f"Plot saved: {plot_dir / 'throughput.png'}")
 
-            # TPC-C latency distribution plot
-            if args.benchmark == "tpcc":
+            # TPC-C latency distribution plot (also for NP variant)
+            if args.benchmark in ("tpcc", "tpcc-np"):
                 _plot_tpcc_latency(result_base, plot_dir, args.scalefactor)
 
             # Metrics plots (CPU, context switches, per-process)

--- a/bench/config/tpcc-np.xml
+++ b/bench/config/tpcc-np.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<parameters>
+
+    <!--
+        TPC-C-NP: TPC-C subset that exercises only NewOrder and Payment.
+
+        NewOrder and Payment together cover 88% of the default TPC-C mix
+        (45% + 43%) and carry essentially all of the write-write
+        contention in the workload. The three transactions removed in
+        the NP variant are either read-only or deferred and therefore
+        do not exercise the concurrency-control path that NP is meant
+        to isolate:
+            - OrderStatus (4%): read-only customer inquiry
+            - Delivery   (4%): deferred / batch processing, whose tail
+                               latency reflects queue handling rather
+                               than CC overhead
+            - StockLevel (4%): read-only periodic report
+
+        The variant originates from DBx1000 (Yu et al., "Staring into
+        the Abyss: An Evaluation of Concurrency Control with One
+        Thousand Cores", VLDB 2014), whose README states "Only Payment
+        and New Order transactions are modeled." Subsequent concurrency
+        control papers, including Cicada (Lim et al., SIGMOD 2017),
+        adopt the same subset under the TPC-C-NP name.
+
+        Weights preserve the 45:43 spec ratio between NewOrder and
+        Payment (51.1% / 48.9% after renormalization). OrderStatus,
+        Delivery, and StockLevel remain declared as transaction types
+        but are weighted zero so the workload mix stays comparable
+        with the standard tpcc.xml definition.
+    -->
+
+    <!-- Connection details -->
+    <type>MYSQL</type>
+    <driver>com.mysql.cj.jdbc.Driver</driver>
+    <url>jdbc:mysql://localhost:3307/benchbase?rewriteBatchedStatements=true&amp;sslMode=DISABLED</url>
+    <username>root</username>
+    <password></password>
+    <isolation>TRANSACTION_SERIALIZABLE</isolation>
+    <batchsize>128</batchsize>
+    <allowPublicKeyRetrieval>true</allowPublicKeyRetrieval>
+
+    <!-- Scale factor is the number of warehouses in TPCC -->
+    <scalefactor>1</scalefactor>
+
+    <!-- The workload -->
+    <terminals>1</terminals>
+    <works>
+        <work>
+            <time>60</time>
+            <rate>unlimited</rate>
+            <weights>45,43,0,0,0</weights>
+        </work>
+    </works>
+
+    <!-- TPCC specific -->
+    <transactiontypes>
+        <transactiontype>
+            <name>NewOrder</name>
+        </transactiontype>
+        <transactiontype>
+            <name>Payment</name>
+        </transactiontype>
+        <transactiontype>
+            <name>OrderStatus</name>
+        </transactiontype>
+        <transactiontype>
+            <name>Delivery</name>
+        </transactiontype>
+        <transactiontype>
+            <name>StockLevel</name>
+        </transactiontype>
+    </transactiontypes>
+</parameters>

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -45,6 +45,14 @@ enum OpCode {
     // Batch operations
     TX_BATCH_READ = 25;
     TX_BATCH_WRITE = 26;
+
+    // Experimental one-shot operations
+    TX_STATELESS_READ = 27;
+    TX_STATELESS_BATCH_READ = 28;
+    TX_VALIDATE_AND_COMMIT = 29;
+    TX_STATELESS_RANGE_SCAN = 30;
+    TX_STATELESS_SECONDARY_RANGE_SCAN = 31;
+    TX_EXECUTE_READ_PLAN = 32;
 }
 
 enum BatchOpType {
@@ -59,6 +67,31 @@ enum BatchOpType {
 message KeyValue {
     bytes key = 1;
     bytes value = 2;
+}
+
+// A Masstree leaf/node version observed while scanning.
+message RangeValidationEntry {
+    string table_name = 1;
+    string index_name = 2; // Empty means primary index.
+    uint64 owner_ptr = 3;
+    uint64 node_ptr = 4;
+    uint64 version = 5;
+    bytes start_key = 6;
+    bytes end_key = 7;
+    uint64 row_limit = 8; // 0 means compare the whole range.
+    bool reverse_scan = 9;
+    repeated bytes result_keys = 10; // PK scan: primary keys. SI scan: secondary keys.
+    repeated bytes result_primary_keys = 11; // SI scan only.
+}
+
+// Exact index entry version observed by a stateless scan.
+// Empty index_name means the primary index entry itself.
+message IndexValidationEntry {
+    string table_name = 1;
+    string index_name = 2;
+    bytes key = 3;
+    uint64 tid = 4;
+    bool found = 5;
 }
 
 // Secondary index entry: a secondary key and its associated primary keys.
@@ -124,6 +157,183 @@ message TxBatchWrite {
     message Response {
         bool success = 1;
         bool is_aborted = 2;
+    }
+}
+
+// Read a primary-key value without opening a server-side transaction.
+// The returned TID is validated later by TxValidateAndCommit.
+message TxStatelessRead {
+    message Request {
+        string table_name = 1;
+        bytes key = 2;
+    }
+    message Response {
+        bool found = 1;
+        bytes value = 2;
+        uint64 tid = 3;
+    }
+}
+
+// Read multiple primary-key values without opening a server-side transaction.
+message TxStatelessBatchRead {
+    message ReadOp {
+        string table_name = 1;
+        bytes key = 2;
+    }
+    message Request {
+        repeated ReadOp ops = 1;
+    }
+    message ReadResult {
+        bool found = 1;
+        bytes value = 2;
+        uint64 tid = 3;
+    }
+    message Response {
+        repeated ReadResult results = 1;
+    }
+}
+
+// Scan primary-key rows without opening a server-side transaction.
+// Returned row TIDs and range versions are validated by TxValidateAndCommit.
+message TxStatelessRangeScan {
+    message Request {
+        string table_name = 1;
+        bytes start_key = 2;
+        bytes end_key = 3;
+        uint64 row_limit = 4; // 0 means no limit.
+        bool reverse_scan = 5;
+    }
+    message Row {
+        bytes key = 1;
+        bytes value = 2;
+        uint64 tid = 3;
+        bool found = 4;
+    }
+    message Response {
+        repeated Row rows = 1;
+        repeated RangeValidationEntry range_versions = 2;
+        repeated IndexValidationEntry index_reads = 3;
+        bool ok = 4;
+    }
+}
+
+// Scan secondary-index entries without opening a server-side transaction.
+// The SI entry TIDs, base row TIDs, and range versions are all validated by
+// TxValidateAndCommit.
+message TxStatelessSecondaryRangeScan {
+    message Request {
+        string table_name = 1;
+        string index_name = 2;
+        bytes start_key = 3;
+        bytes end_key = 4;
+        uint64 row_limit = 5; // 0 means no limit.
+        bool reverse_scan = 6;
+    }
+    message Row {
+        bytes secondary_key = 1;
+        bytes primary_key = 2;
+        bytes value = 3;
+        uint64 tid = 4;
+        bool found = 5;
+    }
+    message Response {
+        repeated Row rows = 1;
+        repeated RangeValidationEntry range_versions = 2;
+        repeated IndexValidationEntry index_reads = 3;
+        bool ok = 4;
+    }
+}
+
+// Execute a dependent read plan in one RPC.
+// Steps may read values produced by earlier steps to build later keys.
+message TxExecuteReadPlan {
+    message KeyBinding {
+        uint32 source_step = 1;
+        uint32 source_row = 2;
+        uint32 source_offset = 3;
+        uint32 source_length = 4; // 0 means the rest of the source bytes.
+        bool use_midpoint = 5;
+        bool from_key = 6;
+        int32 source_column = 7; // 1-based row column; 0 means disabled.
+        bool column_as_int_key = 8;
+        int64 int_delta = 9;
+    }
+    message PlanStep {
+        string table_name = 1;
+        bytes key_prefix = 2;
+        bytes end_key_prefix = 3;
+        bool is_scan = 4;
+        uint64 scan_limit = 5; // 0 means no limit.
+        string index_name = 6; // Empty means primary index.
+        repeated KeyBinding bindings = 7;
+        repeated KeyBinding end_bindings = 8;
+        bool for_each = 9;
+        bool reverse_scan = 10;
+    }
+    message StepResult {
+        bool found = 1;
+        bytes value = 2;
+        uint64 tid = 3;
+        bytes actual_key = 4;
+        repeated bytes scan_keys = 5;
+        repeated bytes scan_values = 6;
+        repeated uint64 scan_tids = 7;
+        repeated bytes secondary_keys = 8;
+        bytes actual_start_key = 9;
+        bytes actual_end_key = 10;
+        repeated RangeValidationEntry range_versions = 11;
+        repeated IndexValidationEntry index_reads = 12;
+    }
+    message Request {
+        repeated PlanStep steps = 1;
+    }
+    message Response {
+        repeated StepResult results = 1;
+        repeated RangeValidationEntry range_versions = 2;
+        repeated IndexValidationEntry index_reads = 3;
+        bool ok = 4;
+    }
+}
+
+// Validate stateless reads and install buffered writes in one RPC.
+message TxValidateAndCommit {
+    message ReadEntry {
+        string table_name = 1;
+        bytes key = 2;
+        uint64 tid = 3;
+        bool found = 4;
+    }
+    message WriteEntry {
+        string table_name = 1;
+        bytes key = 2;
+        bytes value = 3;
+        bool is_delete = 4;
+    }
+    message DeleteEntry {
+        string table_name = 1;
+        bytes key = 2;
+    }
+    message SecondaryIndexEntry {
+        string table_name = 1;
+        string index_name = 2;
+        bytes secondary_key = 3;
+        bytes primary_key = 4;
+        bool is_delete = 5;
+    }
+    message Request {
+        repeated ReadEntry reads = 1;
+        repeated WriteEntry writes = 2;
+        repeated DeleteEntry deletes = 3;
+        repeated SecondaryIndexEntry secondary_index_ops = 4;
+        repeated TableRowDelta row_deltas = 5;
+        bool fence = 6;
+        repeated RangeValidationEntry range_reads = 7;
+        repeated IndexValidationEntry index_reads = 8;
+    }
+    message Response {
+        bool committed = 1;
+        repeated TableRowCount table_stats = 2;
+        string abort_reason = 3;
     }
 }
 

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -96,6 +96,7 @@
 #include "../common/log.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -105,6 +106,7 @@
 #include <optional>
 #include <sstream>
 #include <string_view>
+#include <vector>
 // for ::strcasecmp
 #include <strings.h>
 
@@ -255,6 +257,7 @@ static RangeScanLimit range_scan_limit_for_order(
 // LineairDB server connection target (GLOBAL sysvars backing storage)
 static char *srv_server_host = nullptr;
 static ulong srv_server_port = 9999;
+static bool srv_oneshot_execution = false;
 
 // THD-scoped context
 struct LineairDBThdCtx {
@@ -605,13 +608,8 @@ int ha_lineairdb::write_row(uchar *buf) {
   tx->buffer_write(db_table_name, key, write_buffer_);
 
   // Write secondary index entries.
-  // Non-UNIQUE indexes are buffered (batched) for performance, just like PK writes.
-  // UNIQUE indexes (HA_NOSAME) need special handling: the server must check for
-  // duplicates at INSERT time, not at COMMIT. For example:
-  //   INSERT (1, 'a@example.com')  -- buffered, not yet on server
-  //   INSERT (2, 'a@example.com')  -- UNIQUE violation, must detect NOW
-  // If we buffered the UNIQUE write too, the server wouldn't know about row 1
-  // when checking row 2, and the duplicate would slip through until COMMIT.
+  // Normal transactions check UNIQUE indexes immediately.
+  // Oneshot sends UNIQUE index writes to validate-and-commit with row writes.
   for (uint i = 0; i < table->s->keys; i++) {
     auto key_info = table->key_info[i];
     if (i == table->s->primary_key) continue;
@@ -619,15 +617,17 @@ int ha_lineairdb::write_row(uchar *buf) {
     std::string secondary_key = build_secondary_key_from_row(buf, key_info);
 
     if (key_info.flags & HA_NOSAME) {
-      // Step 1: flush all pending buffered writes so the server has up-to-date
-      // data (otherwise it can't reliably detect duplicates).
-      // Step 2: send this UNIQUE index write immediately via RPC.
-      tx->flush_write_buffer();
-      tx->choose_table(db_table_name);
-      bool ok = tx->write_secondary_index(key_info.name, secondary_key, key);
-      if (!ok || tx->is_aborted()) {
-        thd_mark_transaction_to_rollback(ha_thd(), 1);
-        return HA_ERR_LOCK_DEADLOCK;
+      if (tx->is_oneshot_mode()) {
+        tx->buffer_write_secondary_index(db_table_name, key_info.name,
+                                         secondary_key, key);
+      } else {
+        tx->flush_write_buffer();
+        tx->choose_table(db_table_name);
+        bool ok = tx->write_secondary_index(key_info.name, secondary_key, key);
+        if (!ok || tx->is_aborted()) {
+          thd_mark_transaction_to_rollback(ha_thd(), 1);
+          return HA_ERR_LOCK_DEADLOCK;
+        }
       }
     } else {
       tx->buffer_write_secondary_index(db_table_name, key_info.name,
@@ -1155,6 +1155,318 @@ static bool item_is_limit_safe_filter(const Item *item) {
   Item **args = func->arguments();
   return item_is_limit_safe_scalar(args[0]) &&
          item_is_limit_safe_scalar(args[1]);
+}
+
+// Enable Oneshot only for DML; DDL must keep the normal transaction path
+static bool thd_can_use_oneshot(THD *thd) {
+  if (thd == nullptr) return false;                  // Missing session
+  if (thd->lex == nullptr) return false;             // Missing SQL state
+
+  switch (thd->lex->sql_command) {
+    case SQLCOM_SELECT:
+    case SQLCOM_UPDATE:
+    case SQLCOM_UPDATE_MULTI:
+    case SQLCOM_DELETE:
+    case SQLCOM_DELETE_MULTI:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Encode one integer DSL key part into the same bytes as handler keys
+static std::string encode_plan_int_key_part(int64_t value, int size = 4) {
+  uint64_t raw = 0;
+  uint64_t sign_mask = 0;
+
+  switch (size) {
+    case 1:
+      raw = static_cast<uint8_t>(static_cast<int8_t>(value));
+      sign_mask = 0x80ULL;
+      break;
+    case 2:
+      raw = static_cast<uint16_t>(static_cast<int16_t>(value));
+      sign_mask = 0x8000ULL;
+      break;
+    case 4:
+      raw = static_cast<uint32_t>(static_cast<int32_t>(value));
+      sign_mask = 0x80000000ULL;
+      break;
+    case 8:
+      raw = static_cast<uint64_t>(value);
+      sign_mask = 0x8000000000000000ULL;
+      break;
+    default:
+      raw = static_cast<uint32_t>(static_cast<int32_t>(value));
+      sign_mask = 0x80000000ULL;
+      size = 4;
+      break;
+  }
+
+  const uint64_t encoded = raw ^ sign_mask;
+  std::string out;
+  out.push_back(static_cast<char>(kKeyMarkerNotNull));
+  out.push_back(static_cast<char>(kKeyTypeInt));
+  out.push_back(static_cast<char>((size >> 8) & 0xFF));
+  out.push_back(static_cast<char>(size & 0xFF));
+  for (int i = size - 1; i >= 0; --i) {
+    out.push_back(static_cast<char>((encoded >> (i * 8)) & 0xFF));
+  }
+  return out;
+}
+
+// Encode one string DSL key part into the same bytes as handler keys
+static std::string encode_plan_string_key_part(const std::string& value) {
+  std::string out;
+  out.push_back(static_cast<char>(kKeyMarkerNotNull));
+  out.push_back(static_cast<char>(kKeyTypeString));
+  out.append(value);
+  out.push_back('\0');
+  const uint16_t length = static_cast<uint16_t>(value.size());
+  out.push_back(static_cast<char>((length >> 8) & 0xFF));
+  out.push_back(static_cast<char>(length & 0xFF));
+  return out;
+}
+
+static bool try_parse_plan_int(const std::string& text, int64_t *value) {
+  if (text.empty() || value == nullptr) return false;
+  char *end = nullptr;
+  *value = std::strtoll(text.c_str(), &end, 10);
+  return end == text.c_str() + text.size();
+}
+
+static bool thd_has_ldb_plan(THD *thd) {
+  if (thd == nullptr) return false;
+  auto it = thd->user_vars.find("_ldb_plan");
+  if (it == thd->user_vars.end()) return false;
+
+  auto *entry = it->second.get();
+  return entry != nullptr && entry->ptr() != nullptr && entry->length() > 0;
+}
+
+// Encode one DSL segment: 42=INT, 42t=TINYINT, 42s=SMALLINT, 42l=BIGINT
+static std::string encode_plan_key_segment(const std::string& segment) {
+  if (segment.empty()) return {};
+
+  int int_size = 4;
+  std::string number = segment;
+  const char suffix = segment.back();
+  if (suffix == 't') {
+    int_size = 1;
+    number = segment.substr(0, segment.size() - 1);
+  } else if (suffix == 's') {
+    int_size = 2;
+    number = segment.substr(0, segment.size() - 1);
+  } else if (suffix == 'i') {
+    int_size = 4;
+    number = segment.substr(0, segment.size() - 1);
+  } else if (suffix == 'l') {
+    int_size = 8;
+    number = segment.substr(0, segment.size() - 1);
+  }
+
+  int64_t int_value = 0;
+  if (try_parse_plan_int(number, &int_value)) {
+    return encode_plan_int_key_part(int_value, int_size);
+  }
+  return encode_plan_string_key_part(segment);
+}
+
+static std::vector<std::string> split_plan_text(const std::string& text,
+                                                char delimiter) {
+  std::vector<std::string> parts;
+  std::istringstream stream(text);
+  std::string part;
+  while (std::getline(stream, part, delimiter)) {
+    parts.push_back(part);
+  }
+  return parts;
+}
+
+static std::string normalize_plan_table_name(THD *thd,
+                                             const std::string& table_name) {
+  if (table_name.empty()) return table_name;
+  if (table_name[0] == '.') return table_name;
+  if (table_name.find('/') != std::string::npos) return "./" + table_name;
+
+  std::string prefix = "./";
+  if (thd != nullptr && thd->db().str != nullptr && thd->db().length > 0) {
+    prefix += std::string(thd->db().str, thd->db().length) + "/";
+  }
+  return prefix + table_name;
+}
+
+static LineairDBProxy::ReadPlanKeyBinding parse_plan_binding(
+    const std::string& spec) {
+  LineairDBProxy::ReadPlanKeyBinding binding;
+  if (spec.size() < 2 || spec[0] != 'B') return binding;
+
+  size_t pos = 1;
+  size_t step_end = spec.find('.', pos);
+  if (step_end == std::string::npos) step_end = spec.size();
+  binding.source_step = static_cast<uint32_t>(
+      std::strtoul(spec.substr(pos, step_end - pos).c_str(), nullptr, 10));
+  if (step_end >= spec.size()) return binding;
+  pos = step_end + 1;
+
+  size_t type_end = spec.find('.', pos);
+  if (type_end == std::string::npos) type_end = spec.size();
+  const std::string type = spec.substr(pos, type_end - pos);
+  pos = type_end + 1;
+
+  if (type == "K") {
+    binding.from_key = true;
+  } else if (type == "V") {
+    binding.from_key = false;
+  } else if (type == "MK") {
+    binding.use_midpoint = true;
+    binding.from_key = true;
+  } else if (type == "M") {
+    binding.use_midpoint = true;
+  } else if (type.rfind("MCI", 0) == 0 || type.rfind("CI", 0) == 0) {
+    const bool midpoint = type.rfind("MCI", 0) == 0;
+    const size_t number_pos = midpoint ? 3 : 2;
+    const std::string number = type.substr(number_pos);
+    char *end = nullptr;
+    const long column = std::strtol(number.c_str(), &end, 10);
+    binding.use_midpoint = midpoint;
+    binding.source_column = static_cast<int32_t>(column + 1);
+    binding.column_as_int_key = true;
+    if (end != nullptr && *end != '\0') {
+      binding.int_delta = std::strtoll(end, nullptr, 10);
+    }
+    return binding;
+  }
+
+  if (pos < spec.size()) {
+    size_t offset_end = spec.find('.', pos);
+    if (offset_end == std::string::npos) offset_end = spec.size();
+    binding.source_offset = static_cast<uint32_t>(
+        std::strtoul(spec.substr(pos, offset_end - pos).c_str(), nullptr, 10));
+    pos = offset_end + 1;
+  }
+  if (pos < spec.size()) {
+    binding.source_length =
+        static_cast<uint32_t>(std::strtoul(spec.substr(pos).c_str(), nullptr, 10));
+  }
+  return binding;
+}
+
+static bool token_is_plan_binding(const std::string& token) {
+  if (token.size() < 4 || token[0] != 'B') return false;
+  size_t pos = 1;
+  while (pos < token.size() &&
+         std::isdigit(static_cast<unsigned char>(token[pos]))) {
+    ++pos;
+  }
+  return pos > 1 && pos < token.size() && token[pos] == '.';
+}
+
+static void append_plan_key_token(LineairDBProxy::ReadPlanStep *step,
+                                  const std::string& token,
+                                  bool end_key) {
+  if (step == nullptr || token.empty()) return;
+  if (token_is_plan_binding(token)) {
+    auto binding = parse_plan_binding(token);
+    if (end_key) {
+      step->end_bindings.push_back(std::move(binding));
+    } else {
+      step->bindings.push_back(std::move(binding));
+    }
+    return;
+  }
+
+  if (end_key) {
+    step->end_key_prefix += encode_plan_key_segment(token);
+  } else {
+    step->key_prefix += encode_plan_key_segment(token);
+  }
+}
+
+// Parse read-plan DSL: R=point, S=PK range/prefix scan, SI=secondary scan
+static std::vector<LineairDBProxy::ReadPlanStep> parse_plan_steps(
+    THD *thd, const std::string& plan_text) {
+  std::vector<LineairDBProxy::ReadPlanStep> steps;
+
+  for (const auto& step : split_plan_text(plan_text, ';')) {
+    if (step.empty()) continue;
+    const auto parts = split_plan_text(step, ':');
+    if (parts.size() < 2) continue;
+
+    LineairDBProxy::ReadPlanStep parsed;
+    parsed.table_name = normalize_plan_table_name(thd, parts[1]);
+    bool end_key = false;
+    size_t token_start = 2;
+    if (parts[0] == "R") {
+      parsed.is_scan = false;
+    } else if (parts[0] == "S") {
+      parsed.is_scan = true;
+    } else if (parts[0] == "SI") {
+      if (parts.size() < 3) continue;
+      parsed.is_scan = true;
+      parsed.index_name = parts[2];
+      token_start = 3;
+    } else if (parts[0] == "FE") {
+      parsed.for_each = true;
+    } else {
+      continue;
+    }
+
+    for (size_t i = token_start; i < parts.size(); ++i) {
+      const auto& token = parts[i];
+      if (token == "E") {
+        end_key = true;
+        continue;
+      }
+      if (token.rfind("limit=", 0) == 0) {
+        parsed.scan_limit = static_cast<uint64_t>(
+            std::strtoull(token.substr(6).c_str(), nullptr, 10));
+        continue;
+      }
+      if (token.rfind("reverse=", 0) == 0) {
+        parsed.reverse_scan = token.substr(8) == "1";
+        continue;
+      }
+      append_plan_key_token(&parsed, token, end_key);
+    }
+    if (!parsed.table_name.empty()) {
+      steps.push_back(std::move(parsed));
+    }
+  }
+
+  return steps;
+}
+
+// Read @_ldb_plan once and clear it so the next statement starts clean
+static std::string read_and_clear_ldb_plan(THD *thd) {
+  std::string plan;
+  if (thd == nullptr) return plan;
+
+  auto it = thd->user_vars.find("_ldb_plan");
+  if (it == thd->user_vars.end()) return plan;
+
+  auto *entry = it->second.get();
+  if (entry == nullptr || entry->ptr() == nullptr || entry->length() == 0) {
+    return plan;
+  }
+
+  plan.assign(entry->ptr(), entry->length());
+  entry->lock();
+  entry->set_null_value(STRING_RESULT);
+  entry->unlock();
+  return plan;
+}
+
+static void execute_oneshot_plan_if_present(THD *thd,
+                                            LineairDBTransaction *tx) {
+  if (tx == nullptr || !tx->is_oneshot_mode()) return;
+
+  const std::string plan_text = read_and_clear_ldb_plan(thd);
+  if (plan_text.empty()) return;
+
+  const auto steps = parse_plan_steps(thd, plan_text);
+  if (steps.empty()) return;
+  tx->execute_read_plan(steps);
 }
 
 // Push the SELECT WHERE into this transaction if LIMIT will depend on it
@@ -1781,9 +2093,14 @@ LineairDBTransaction *&ha_lineairdb::get_transaction(THD *thd) {
   if (ctx->tx == nullptr) {
     ctx->tx =
         new LineairDBTransaction(thd, ctx->proxy.get(), lineairdb_hton, FENCE);
+    const bool can_use_oneshot =
+        (srv_oneshot_execution && thd_can_use_oneshot(thd) &&
+         thd_has_ldb_plan(thd));
+    ctx->tx->set_oneshot_mode(can_use_oneshot);
   }
   if (ctx->tx->is_not_started()) {
     ctx->tx->begin_transaction();
+    execute_oneshot_plan_if_present(thd, ctx->tx);
   }
   return ctx->tx;
 }
@@ -3638,10 +3955,15 @@ static MYSQL_SYSVAR_STR(server_host, srv_server_host,
 static MYSQL_SYSVAR_ULONG(server_port, srv_server_port, PLUGIN_VAR_RQCMDARG,
                           "LineairDB server TCP port.", nullptr, nullptr, 9999,
                           1, 65535, 0);
+static MYSQL_SYSVAR_BOOL(oneshot_execution, srv_oneshot_execution,
+                         PLUGIN_VAR_OPCMDARG,
+                         "Enable experimental one-shot execution.", nullptr,
+                         nullptr, false);
 
 static SYS_VAR *lineairdb_system_variables[] = {
     MYSQL_SYSVAR(server_host),
     MYSQL_SYSVAR(server_port),
+    MYSQL_SYSVAR(oneshot_execution),
     MYSQL_SYSVAR(enum_var),
     MYSQL_SYSVAR(ulong_var),
     MYSQL_SYSVAR(double_var),

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -14,6 +14,49 @@
 #include "rpc_trace.hh"
 #include "../common/log.h"
 
+namespace {
+
+LineairDBProxy::RangeValidationEntry decode_range_validation_entry(
+    const LineairDB::Protocol::RangeValidationEntry& entry) {
+    LineairDBProxy::RangeValidationEntry out;
+    out.table_name = entry.table_name();
+    out.index_name = entry.index_name();
+    out.owner_ptr = entry.owner_ptr();
+    out.node_ptr = entry.node_ptr();
+    out.version = entry.version();
+    out.start_key = entry.start_key();
+    out.end_key = entry.end_key();
+    out.row_limit = entry.row_limit();
+    out.reverse_scan = entry.reverse_scan();
+    out.result_keys.reserve(entry.result_keys_size());
+    for (const auto& key : entry.result_keys()) out.result_keys.push_back(key);
+    out.result_primary_keys.reserve(entry.result_primary_keys_size());
+    for (const auto& key : entry.result_primary_keys()) {
+        out.result_primary_keys.push_back(key);
+    }
+    return out;
+}
+
+void encode_range_validation_entry(
+    const LineairDBProxy::RangeValidationEntry& entry,
+    LineairDB::Protocol::RangeValidationEntry* out) {
+    out->set_table_name(entry.table_name);
+    out->set_index_name(entry.index_name);
+    out->set_owner_ptr(entry.owner_ptr);
+    out->set_node_ptr(entry.node_ptr);
+    out->set_version(entry.version);
+    out->set_start_key(entry.start_key);
+    out->set_end_key(entry.end_key);
+    out->set_row_limit(entry.row_limit);
+    out->set_reverse_scan(entry.reverse_scan);
+    for (const auto& key : entry.result_keys) out->add_result_keys(key);
+    for (const auto& key : entry.result_primary_keys) {
+        out->add_result_primary_keys(key);
+    }
+}
+
+}  // namespace
+
 
 LineairDBProxy::LineairDBProxy(const std::string& host, int port)
     : socket_fd_(-1), connected_(false), host_(host), port_(port) {
@@ -303,39 +346,167 @@ bool LineairDBProxy::tx_batch_write(LineairDBTransaction* tx,
     return response.success();
 }
 
-std::vector<std::string> LineairDBProxy::tx_read_secondary_index(LineairDBTransaction* tx,
-                                                                  const std::string& index_name,
-                                                                  const std::string& secondary_key) {
-    int64_t tx_id = tx->get_tx_id();
-    LOG_DEBUG("CLIENT: tx_read_secondary_index called with tx_id=%ld, index=%s, key=%s",
-              tx_id, index_name.c_str(), secondary_key.c_str());
+LineairDBProxy::StatelessReadResult LineairDBProxy::tx_stateless_read(
+    const std::string& table_name, const std::string& key) {
+    StatelessReadResult result;
+    if (!connected_) {
+        LOG_ERROR("RPC failed: Not connected to server");
+        return result;
+    }
+
+    LineairDB::Protocol::TxStatelessRead::Request request;
+    LineairDB::Protocol::TxStatelessRead::Response response;
+    request.set_table_name(table_name);
+    request.set_key(key);
+
+    if (!send_protobuf_message(request, response,
+                               MessageType::TX_STATELESS_READ)) {
+        LOG_ERROR("RPC failed: Failed to send stateless_read message to server");
+        return result;
+    }
+
+    result.ok = true;
+    result.found = response.found();
+    result.tid = response.tid();
+    if (result.found) result.value = response.value();
+    return result;
+}
+
+std::vector<LineairDBProxy::StatelessReadResult>
+LineairDBProxy::tx_stateless_batch_read(
+    const std::vector<StatelessReadKey>& keys) {
     if (!connected_) {
         LOG_ERROR("RPC failed: Not connected to server");
         return {};
     }
 
-    LineairDB::Protocol::TxReadSecondaryIndex::Request request;
-    LineairDB::Protocol::TxReadSecondaryIndex::Response response;
+    LineairDB::Protocol::TxStatelessBatchRead::Request request;
+    LineairDB::Protocol::TxStatelessBatchRead::Response response;
+    for (const auto& key : keys) {
+        auto* op = request.add_ops();
+        op->set_table_name(key.table_name);
+        op->set_key(key.key);
+    }
 
-    request.set_transaction_id(tx_id);
-    request.set_table_name(tx->get_selected_table_name());
-    request.set_index_name(index_name);
-    request.set_secondary_key(secondary_key);
-
-    if (!send_protobuf_message(request, response, MessageType::TX_READ_SECONDARY_INDEX)) {
-        LOG_ERROR("RPC failed: Failed to send message to server");
+    if (!send_protobuf_message(request, response,
+                               MessageType::TX_STATELESS_BATCH_READ)) {
+        LOG_ERROR("RPC failed: Failed to send stateless_batch_read message to server");
         return {};
     }
 
-    tx->set_aborted(response.is_aborted());
+    std::vector<StatelessReadResult> results;
+    results.reserve(response.results_size());
+    for (const auto& r : response.results()) {
+        StatelessReadResult result;
+        result.ok = true;
+        result.found = r.found();
+        result.value = r.found() ? r.value() : "";
+        result.tid = r.tid();
+        results.push_back(std::move(result));
+    }
+    return results;
+}
 
-    std::vector<std::string> values;
-    for (const auto& v : response.values()) {
-        values.emplace_back(v);
+LineairDBProxy::StatelessRangeScanResult
+LineairDBProxy::tx_stateless_range_scan(const std::string& table_name,
+                                        const std::string& start_key,
+                                        const std::string& end_key,
+                                        uint64_t row_limit,
+                                        bool reverse_scan) {
+    StatelessRangeScanResult result;
+    if (!connected_) {
+        LOG_ERROR("RPC failed: Not connected to server");
+        return result;
     }
 
-    LOG_DEBUG("CLIENT: tx_read_secondary_index completed, found %zu values", values.size());
-    return values;
+    LineairDB::Protocol::TxStatelessRangeScan::Request request;
+    LineairDB::Protocol::TxStatelessRangeScan::Response response;
+    request.set_table_name(table_name);
+    request.set_start_key(start_key);
+    request.set_end_key(end_key);
+    request.set_row_limit(row_limit);
+    request.set_reverse_scan(reverse_scan);
+
+    if (!send_protobuf_message(request, response,
+                               MessageType::TX_STATELESS_RANGE_SCAN)) {
+        LOG_ERROR("RPC failed: Failed to send stateless range scan message to server");
+        return result;
+    }
+
+    result.ok = response.ok();
+    if (!result.ok) return result;
+    result.rows.reserve(response.rows_size());
+    for (const auto& row : response.rows()) {
+        result.rows.push_back({row.key(), row.value(), row.found(),
+                               row.tid()});
+    }
+
+    result.range_versions.reserve(response.range_versions_size());
+    for (const auto& entry : response.range_versions()) {
+        result.range_versions.push_back(decode_range_validation_entry(entry));
+    }
+
+    result.index_reads.reserve(response.index_reads_size());
+    for (const auto& entry : response.index_reads()) {
+        result.index_reads.push_back({entry.table_name(), entry.index_name(),
+                                      entry.key(), entry.tid(),
+                                      entry.found()});
+    }
+
+    return result;
+}
+
+LineairDBProxy::StatelessSecondaryRangeScanResult
+LineairDBProxy::tx_stateless_secondary_range_scan(
+        const std::string& table_name,
+        const std::string& index_name,
+        const std::string& start_key,
+        const std::string& end_key,
+        uint64_t row_limit,
+        bool reverse_scan) {
+    StatelessSecondaryRangeScanResult result;
+    if (!connected_) {
+        LOG_ERROR("RPC failed: Not connected to server");
+        return result;
+    }
+
+    LineairDB::Protocol::TxStatelessSecondaryRangeScan::Request request;
+    LineairDB::Protocol::TxStatelessSecondaryRangeScan::Response response;
+    request.set_table_name(table_name);
+    request.set_index_name(index_name);
+    request.set_start_key(start_key);
+    request.set_end_key(end_key);
+    request.set_row_limit(row_limit);
+    request.set_reverse_scan(reverse_scan);
+
+    if (!send_protobuf_message(
+            request, response,
+            MessageType::TX_STATELESS_SECONDARY_RANGE_SCAN)) {
+        LOG_ERROR("RPC failed: Failed to send stateless secondary range scan message to server");
+        return result;
+    }
+
+    result.ok = response.ok();
+    if (!result.ok) return result;
+    result.rows.reserve(response.rows_size());
+    for (const auto& row : response.rows()) {
+        result.rows.push_back({row.secondary_key(), row.primary_key(),
+                               row.value(), row.found(), row.tid()});
+    }
+
+    result.range_versions.reserve(response.range_versions_size());
+    for (const auto& entry : response.range_versions()) {
+        result.range_versions.push_back(decode_range_validation_entry(entry));
+    }
+
+    result.index_reads.reserve(response.index_reads_size());
+    for (const auto& entry : response.index_reads()) {
+        result.index_reads.push_back({entry.table_name(), entry.index_name(),
+                                      entry.key(), entry.tid(),
+                                      entry.found()});
+    }
+
+    return result;
 }
 
 bool LineairDBProxy::tx_write_secondary_index(LineairDBTransaction* tx,

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -509,6 +509,246 @@ LineairDBProxy::tx_stateless_secondary_range_scan(
     return result;
 }
 
+LineairDBProxy::ReadPlanResult LineairDBProxy::tx_execute_read_plan(
+    const std::vector<ReadPlanStep>& steps) {
+    ReadPlanResult result;
+    if (!connected_) {
+        LOG_ERROR("RPC failed: Not connected to server");
+        return result;
+    }
+
+    LineairDB::Protocol::TxExecuteReadPlan::Request request;
+    LineairDB::Protocol::TxExecuteReadPlan::Response response;
+    for (const auto& step : steps) {
+        auto* out = request.add_steps();
+        out->set_table_name(step.table_name);
+        out->set_key_prefix(step.key_prefix);
+        out->set_end_key_prefix(step.end_key_prefix);
+        out->set_is_scan(step.is_scan);
+        out->set_scan_limit(step.scan_limit);
+        out->set_index_name(step.index_name);
+        out->set_for_each(step.for_each);
+        out->set_reverse_scan(step.reverse_scan);
+        for (const auto& binding : step.bindings) {
+            auto* b = out->add_bindings();
+            b->set_source_step(binding.source_step);
+            b->set_source_row(binding.source_row);
+            b->set_source_offset(binding.source_offset);
+            b->set_source_length(binding.source_length);
+            b->set_use_midpoint(binding.use_midpoint);
+            b->set_from_key(binding.from_key);
+            b->set_source_column(binding.source_column);
+            b->set_column_as_int_key(binding.column_as_int_key);
+            b->set_int_delta(binding.int_delta);
+        }
+        for (const auto& binding : step.end_bindings) {
+            auto* b = out->add_end_bindings();
+            b->set_source_step(binding.source_step);
+            b->set_source_row(binding.source_row);
+            b->set_source_offset(binding.source_offset);
+            b->set_source_length(binding.source_length);
+            b->set_use_midpoint(binding.use_midpoint);
+            b->set_from_key(binding.from_key);
+            b->set_source_column(binding.source_column);
+            b->set_column_as_int_key(binding.column_as_int_key);
+            b->set_int_delta(binding.int_delta);
+        }
+    }
+
+    if (!send_protobuf_message(request, response,
+                               MessageType::TX_EXECUTE_READ_PLAN)) {
+        LOG_ERROR("RPC failed: Failed to send execute read plan message to server");
+        return result;
+    }
+
+    result.ok = response.ok();
+    if (!result.ok) return result;
+    result.steps.reserve(response.results_size());
+    for (const auto& step : response.results()) {
+        ReadPlanStepResult out;
+        out.found = step.found();
+        out.value = step.value();
+        out.tid = step.tid();
+        out.actual_key = step.actual_key();
+        out.actual_start_key = step.actual_start_key();
+        out.actual_end_key = step.actual_end_key();
+        out.scan_keys.reserve(step.scan_keys_size());
+        for (const auto& key : step.scan_keys()) out.scan_keys.push_back(key);
+        out.scan_values.reserve(step.scan_values_size());
+        for (const auto& value : step.scan_values()) out.scan_values.push_back(value);
+        out.scan_tids.reserve(step.scan_tids_size());
+        for (const auto tid : step.scan_tids()) out.scan_tids.push_back(tid);
+        out.secondary_keys.reserve(step.secondary_keys_size());
+        for (const auto& key : step.secondary_keys()) out.secondary_keys.push_back(key);
+        out.range_versions.reserve(step.range_versions_size());
+        for (const auto& entry : step.range_versions()) {
+            out.range_versions.push_back(decode_range_validation_entry(entry));
+        }
+        out.index_reads.reserve(step.index_reads_size());
+        for (const auto& entry : step.index_reads()) {
+            out.index_reads.push_back({entry.table_name(), entry.index_name(),
+                                       entry.key(), entry.tid(),
+                                       entry.found()});
+        }
+        result.steps.push_back(std::move(out));
+    }
+
+    result.range_versions.reserve(response.range_versions_size());
+    for (const auto& entry : response.range_versions()) {
+        result.range_versions.push_back(decode_range_validation_entry(entry));
+    }
+
+    result.index_reads.reserve(response.index_reads_size());
+    for (const auto& entry : response.index_reads()) {
+        result.index_reads.push_back({entry.table_name(), entry.index_name(),
+                                      entry.key(), entry.tid(),
+                                      entry.found()});
+    }
+
+    return result;
+}
+
+bool LineairDBProxy::tx_validate_and_commit(
+    const std::vector<StatelessReadKey>& reads,
+    const std::vector<uint64_t>& read_tids,
+    const std::vector<bool>& read_found,
+    const std::vector<RangeValidationEntry>& range_reads,
+    const std::vector<IndexValidationEntry>& index_reads,
+    const std::vector<BatchOp>& ops,
+    const std::vector<std::pair<std::string, int64_t>>& row_deltas,
+    bool isFence,
+    std::string* abort_reason) {
+    if (abort_reason != nullptr) abort_reason->clear();
+    if (!connected_) {
+        LOG_ERROR("RPC failed: Not connected to server");
+        return false;
+    }
+    if (reads.size() != read_tids.size() || reads.size() != read_found.size()) {
+        LOG_ERROR("validate_and_commit: read metadata size mismatch");
+        return false;
+    }
+
+    LineairDB::Protocol::TxValidateAndCommit::Request request;
+    LineairDB::Protocol::TxValidateAndCommit::Response response;
+    request.set_fence(isFence);
+
+    for (size_t i = 0; i < reads.size(); ++i) {
+        auto* read = request.add_reads();
+        read->set_table_name(reads[i].table_name);
+        read->set_key(reads[i].key);
+        read->set_tid(read_tids[i]);
+        read->set_found(read_found[i]);
+    }
+
+    for (const auto& entry : range_reads) {
+        auto* range = request.add_range_reads();
+        encode_range_validation_entry(entry, range);
+    }
+
+    for (const auto& entry : index_reads) {
+        auto* read = request.add_index_reads();
+        read->set_table_name(entry.table_name);
+        read->set_index_name(entry.index_name);
+        read->set_key(entry.key);
+        read->set_tid(entry.tid);
+        read->set_found(entry.found);
+    }
+
+    for (const auto& batch_op : ops) {
+        switch (batch_op.type) {
+            case BatchOp::Type::Write: {
+                auto* write = request.add_writes();
+                write->set_table_name(batch_op.table_name);
+                write->set_key(batch_op.key);
+                write->set_value(batch_op.value);
+                write->set_is_delete(false);
+                break;
+            }
+            case BatchOp::Type::Delete: {
+                auto* write = request.add_writes();
+                write->set_table_name(batch_op.table_name);
+                write->set_key(batch_op.key);
+                write->set_is_delete(true);
+                break;
+            }
+            case BatchOp::Type::SecondaryIndexWrite: {
+                auto* si = request.add_secondary_index_ops();
+                si->set_table_name(batch_op.table_name);
+                si->set_index_name(batch_op.index_name);
+                si->set_secondary_key(batch_op.secondary_key);
+                si->set_primary_key(batch_op.primary_key);
+                si->set_is_delete(false);
+                break;
+            }
+            case BatchOp::Type::SecondaryIndexDelete: {
+                auto* si = request.add_secondary_index_ops();
+                si->set_table_name(batch_op.table_name);
+                si->set_index_name(batch_op.index_name);
+                si->set_secondary_key(batch_op.secondary_key);
+                si->set_primary_key(batch_op.primary_key);
+                si->set_is_delete(true);
+                break;
+            }
+        }
+    }
+
+    for (const auto& [table, delta] : row_deltas) {
+        auto* rd = request.add_row_deltas();
+        rd->set_table_name(table);
+        rd->set_delta(delta);
+    }
+
+    if (!send_protobuf_message(request, response,
+                               MessageType::TX_VALIDATE_AND_COMMIT)) {
+        LOG_ERROR("RPC failed: Failed to send validate_and_commit message to server");
+        return false;
+    }
+
+    table_stats_cache_.clear();
+    for (const auto& ts : response.table_stats()) {
+        table_stats_cache_[ts.table_name()] = ts.row_count();
+    }
+    if (!response.committed() && abort_reason != nullptr) {
+        *abort_reason = response.abort_reason();
+    }
+    return response.committed();
+}
+
+std::vector<std::string> LineairDBProxy::tx_read_secondary_index(LineairDBTransaction* tx,
+                                                                  const std::string& index_name,
+                                                                  const std::string& secondary_key) {
+    int64_t tx_id = tx->get_tx_id();
+    LOG_DEBUG("CLIENT: tx_read_secondary_index called with tx_id=%ld, index=%s, key=%s",
+              tx_id, index_name.c_str(), secondary_key.c_str());
+    if (!connected_) {
+        LOG_ERROR("RPC failed: Not connected to server");
+        return {};
+    }
+
+    LineairDB::Protocol::TxReadSecondaryIndex::Request request;
+    LineairDB::Protocol::TxReadSecondaryIndex::Response response;
+
+    request.set_transaction_id(tx_id);
+    request.set_table_name(tx->get_selected_table_name());
+    request.set_index_name(index_name);
+    request.set_secondary_key(secondary_key);
+
+    if (!send_protobuf_message(request, response, MessageType::TX_READ_SECONDARY_INDEX)) {
+        LOG_ERROR("RPC failed: Failed to send message to server");
+        return {};
+    }
+
+    tx->set_aborted(response.is_aborted());
+
+    std::vector<std::string> values;
+    for (const auto& v : response.values()) {
+        values.emplace_back(v);
+    }
+
+    LOG_DEBUG("CLIENT: tx_read_secondary_index completed, found %zu values", values.size());
+    return values;
+}
+
 bool LineairDBProxy::tx_write_secondary_index(LineairDBTransaction* tx,
                                                const std::string& index_name,
                                                const std::string& secondary_key,

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -78,8 +78,10 @@ enum class MessageType : uint32_t {
     // Experimental one-shot operations
     TX_STATELESS_READ = 27,
     TX_STATELESS_BATCH_READ = 28,
+    TX_VALIDATE_AND_COMMIT = 29,
     TX_STATELESS_RANGE_SCAN = 30,
-    TX_STATELESS_SECONDARY_RANGE_SCAN = 31
+    TX_STATELESS_SECONDARY_RANGE_SCAN = 31,
+    TX_EXECUTE_READ_PLAN = 32
 };
 
 /**
@@ -169,6 +171,49 @@ public:
         std::vector<RangeValidationEntry> range_versions;
         std::vector<IndexValidationEntry> index_reads;
     };
+    struct ReadPlanKeyBinding {
+        uint32_t source_step = 0;
+        uint32_t source_row = 0;
+        uint32_t source_offset = 0;
+        uint32_t source_length = 0;
+        bool use_midpoint = false;
+        bool from_key = false;
+        int32_t source_column = 0;
+        bool column_as_int_key = false;
+        int64_t int_delta = 0;
+    };
+    struct ReadPlanStep {
+        std::string table_name;
+        std::string key_prefix;
+        std::string end_key_prefix;
+        bool is_scan = false;
+        uint64_t scan_limit = 0;
+        std::string index_name;
+        std::vector<ReadPlanKeyBinding> bindings;
+        std::vector<ReadPlanKeyBinding> end_bindings;
+        bool for_each = false;
+        bool reverse_scan = false;
+    };
+    struct ReadPlanStepResult {
+        bool found = false;
+        std::string value;
+        uint64_t tid = 0;
+        std::string actual_key;
+        std::vector<std::string> scan_keys;
+        std::vector<std::string> scan_values;
+        std::vector<uint64_t> scan_tids;
+        std::vector<std::string> secondary_keys;
+        std::string actual_start_key;
+        std::string actual_end_key;
+        std::vector<RangeValidationEntry> range_versions;
+        std::vector<IndexValidationEntry> index_reads;
+    };
+    struct ReadPlanResult {
+        bool ok = false;
+        std::vector<ReadPlanStepResult> steps;
+        std::vector<RangeValidationEntry> range_versions;
+        std::vector<IndexValidationEntry> index_reads;
+    };
     std::vector<BatchReadResult> tx_batch_read(LineairDBTransaction* tx,
                                                 const std::vector<std::string>& keys);
     struct BatchOp {
@@ -206,6 +251,19 @@ public:
         const std::string& end_key,
         uint64_t row_limit,
         bool reverse_scan);
+    ReadPlanResult tx_execute_read_plan(
+        const std::vector<ReadPlanStep>& steps);
+    bool tx_validate_and_commit(
+        const std::vector<StatelessReadKey>& reads,
+        const std::vector<uint64_t>& read_tids,
+        const std::vector<bool>& read_found,
+        const std::vector<RangeValidationEntry>& range_reads,
+        const std::vector<IndexValidationEntry>& index_reads,
+        const std::vector<BatchOp>& ops,
+        const std::vector<std::pair<std::string, int64_t>>& row_deltas,
+        bool isFence,
+        std::string* abort_reason = nullptr);
+
     // secondary index operations
     std::vector<std::string> tx_read_secondary_index(LineairDBTransaction* tx,
                                                      const std::string& index_name,

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -73,7 +73,13 @@ enum class MessageType : uint32_t {
 
     // Batch operations
     TX_BATCH_READ = 25,
-    TX_BATCH_WRITE = 26
+    TX_BATCH_WRITE = 26,
+
+    // Experimental one-shot operations
+    TX_STATELESS_READ = 27,
+    TX_STATELESS_BATCH_READ = 28,
+    TX_STATELESS_RANGE_SCAN = 30,
+    TX_STATELESS_SECONDARY_RANGE_SCAN = 31
 };
 
 /**
@@ -108,6 +114,61 @@ public:
         bool found;
         std::string value;
     };
+    struct StatelessReadResult {
+        bool ok = false;
+        bool found = false;
+        std::string value;
+        uint64_t tid = 0;
+    };
+    struct StatelessReadKey {
+        std::string table_name;
+        std::string key;
+    };
+    struct RangeValidationEntry {
+        std::string table_name;
+        std::string index_name;
+        uint64_t owner_ptr;
+        uint64_t node_ptr;
+        uint64_t version;
+        std::string start_key;
+        std::string end_key;
+        uint64_t row_limit = 0;
+        bool reverse_scan = false;
+        std::vector<std::string> result_keys;
+        std::vector<std::string> result_primary_keys;
+    };
+    struct IndexValidationEntry {
+        std::string table_name;
+        std::string index_name;
+        std::string key;
+        uint64_t tid;
+        bool found;
+    };
+    struct StatelessRangeScanRow {
+        std::string key;
+        std::string value;
+        bool found;
+        uint64_t tid;
+    };
+    struct StatelessRangeScanResult {
+        bool ok = false;
+        std::vector<StatelessRangeScanRow> rows;
+        std::vector<RangeValidationEntry> range_versions;
+        std::vector<IndexValidationEntry> index_reads;
+    };
+    struct StatelessSecondaryRangeScanRow {
+        std::string secondary_key;
+        std::string primary_key;
+        std::string value;
+        bool found;
+        uint64_t tid;
+    };
+    struct StatelessSecondaryRangeScanResult {
+        bool ok = false;
+        std::vector<StatelessSecondaryRangeScanRow> rows;
+        std::vector<RangeValidationEntry> range_versions;
+        std::vector<IndexValidationEntry> index_reads;
+    };
     std::vector<BatchReadResult> tx_batch_read(LineairDBTransaction* tx,
                                                 const std::vector<std::string>& keys);
     struct BatchOp {
@@ -128,7 +189,23 @@ public:
     bool tx_batch_write(LineairDBTransaction* tx,
                         const std::string& table_name,
                         const std::vector<BatchOp>& ops);
-
+    StatelessReadResult tx_stateless_read(const std::string& table_name,
+                                          const std::string& key);
+    std::vector<StatelessReadResult> tx_stateless_batch_read(
+        const std::vector<StatelessReadKey>& keys);
+    StatelessRangeScanResult tx_stateless_range_scan(
+        const std::string& table_name,
+        const std::string& start_key,
+        const std::string& end_key,
+        uint64_t row_limit,
+        bool reverse_scan);
+    StatelessSecondaryRangeScanResult tx_stateless_secondary_range_scan(
+        const std::string& table_name,
+        const std::string& index_name,
+        const std::string& start_key,
+        const std::string& end_key,
+        uint64_t row_limit,
+        bool reverse_scan);
     // secondary index operations
     std::vector<std::string> tx_read_secondary_index(LineairDBTransaction* tx,
                                                      const std::string& index_name,

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -3,6 +3,57 @@
 #include "../common/log.h"
 
 #include <thread>
+#include <unordered_set>
+
+namespace {
+
+std::string next_lexicographic_key(std::string key) {
+  for (size_t i = key.size(); i-- > 0;) {
+    auto byte = static_cast<unsigned char>(key[i]);
+    if (byte != 0xFF) {
+      key[i] = static_cast<char>(byte + 1);
+      key.resize(i + 1);
+      return key;
+    }
+  }
+  return {};
+}
+
+bool range_validation_is_logical(
+    const LineairDBProxy::RangeValidationEntry& entry) {
+  return !entry.end_key.empty();
+}
+
+bool range_validation_can_be_sliced(
+    const std::vector<LineairDBProxy::RangeValidationEntry>& ranges,
+    const std::vector<LineairDBProxy::IndexValidationEntry>& indexes) {
+  if (!indexes.empty()) return false;
+  for (const auto& range : ranges) {
+    if (!range_validation_is_logical(range)) return false;
+  }
+  return !ranges.empty();
+}
+
+std::string trace_count_event(const char* kind, const std::string& table_name,
+                              size_t count) {
+  return std::string(kind) + ":" + table_name + ":n=" +
+         std::to_string(count);
+}
+
+std::string trace_plan_scan_event(const std::string& table_name,
+                                  const std::string& index_name,
+                                  size_t keys, size_t values,
+                                  uint64_t limit, bool for_each) {
+  std::string event = "plan_fetch:S:" + table_name;
+  if (!index_name.empty()) event += ":" + index_name;
+  event += ":keys=" + std::to_string(keys);
+  event += ":vals=" + std::to_string(values);
+  if (limit > 0) event += ":lim=" + std::to_string(limit);
+  if (for_each) event += ":each";
+  return event;
+}
+
+}  // namespace
 
 LineairDBTransaction::LineairDBTransaction(THD* thd, 
                                             LineairDBProxy* lineairdb_proxy,
@@ -49,13 +100,20 @@ LineairDBTransaction::read(std::string key) {
   // Repeat exact-key reads can use the local read set
   if (auto entry = lookup_local_read_set(db_table_key, key)) {
     rpc_trace_.record_local_view("read_cache_hit");
+    activate_local_read(*entry);
     if (!entry->found) return {nullptr, 0};
     last_read_value_ = entry->value;
     return {reinterpret_cast<const std::byte*>(last_read_value_.data()), last_read_value_.size()};
   }
 
-  // First exact-key read goes to the server and enters the local read set
+  // Normal path misses go to the server; oneshot plans must prefetch them
   rpc_trace_.record_local_view("read_miss");
+  if (oneshot_mode_) {
+    rpc_trace_.record_local_view("abort_oneshot_read_miss");
+    is_aborted_ = true;
+    return std::pair<const std::byte *const, const size_t>{nullptr, 0};
+  }
+
   last_read_value_ = lineairdb_proxy->tx_read(this, key);
   if (last_read_value_.empty()) {
     record_local_read(db_table_key, key, false, ""); // value unused when not found
@@ -88,6 +146,7 @@ LineairDBTransaction::batch_read(const std::vector<std::string>& keys) {
     }
     if (auto entry = lookup_local_read_set(db_table_key, keys[i])) {
       rpc_trace_.record_local_view("batch_cache_hit");
+      activate_local_read(*entry);
       pairs[i] = {entry->found, entry->value};
       continue;
     }
@@ -96,11 +155,23 @@ LineairDBTransaction::batch_read(const std::vector<std::string>& keys) {
     rpc_keys.push_back(keys[i]);
   }
 
+  // Oneshot plans must fetch every key up front; misses mean the plan is short
+  if (oneshot_mode_ && !rpc_keys.empty()) {
+    rpc_trace_.record_local_view("abort_oneshot_batch_miss");
+    is_aborted_ = true;
+    return pairs;
+  }
+
   // Fetch only cache misses; tx_batch_read() returns rows in rpc_keys order
   //   Example: keys=[A,B,C], B is local -> rpc_keys=[A,C],
   //            rpc_positions=[0,2], so RPC results fill pairs[0] and pairs[2].
   if (!rpc_keys.empty()) {
     auto results = lineairdb_proxy->tx_batch_read(this, rpc_keys);
+    if (results.size() != rpc_keys.size()) {
+      rpc_trace_.record_local_view("abort_batch_size_mismatch");
+      is_aborted_ = true;
+      return pairs;
+    }
     for (size_t i = 0; i < results.size(); ++i) {
       // Map each RPC result back to the original keys[] position
       const size_t pos = rpc_positions[i];
@@ -111,15 +182,162 @@ LineairDBTransaction::batch_read(const std::vector<std::string>& keys) {
   return pairs;
 }
 
+void LineairDBTransaction::prefetch_stateless_reads(
+    const std::vector<LineairDBProxy::StatelessReadKey>& reads) {
+  if (!oneshot_mode_ || reads.empty()) return;
+
+  std::vector<LineairDBProxy::StatelessReadKey> rpc_reads;
+  rpc_reads.reserve(reads.size());
+  std::unordered_set<std::string> seen;
+  seen.reserve(reads.size());
+
+  // Keep the plan prefetch to rows not already covered by the local view
+  for (const auto& read : reads) {
+    const std::string seen_key = read.table_name + '\0' + read.key;
+    if (!seen.insert(seen_key).second) continue;
+    if (lookup_local_write_set(read.table_name, read.key)) continue;
+    if (lookup_local_read_set(read.table_name, read.key)) continue;
+    rpc_reads.push_back(read);
+  }
+
+  if (rpc_reads.empty()) return;
+
+  auto results = lineairdb_proxy->tx_stateless_batch_read(rpc_reads);
+  if (results.size() != rpc_reads.size()) {
+    rpc_trace_.record_local_view("abort_prefetch_size_mismatch");
+    is_aborted_ = true;
+    return;
+  }
+
+  // Store prefetched rows in the local cache; validate them only if MySQL reads them
+  for (size_t i = 0; i < rpc_reads.size(); ++i) {
+    const auto& read = rpc_reads[i];
+    auto& result = results[i];
+    if (!result.ok) {
+      rpc_trace_.record_local_view("abort_prefetch_rpc");
+      is_aborted_ = true;
+      return;
+    }
+    if (result.found) {
+      record_local_read(read.table_name, read.key, true, result.value,
+                        result.tid, true);
+    } else {
+      record_local_read(read.table_name, read.key, false, "",
+                        result.tid, true); // value unused when not found
+    }
+  }
+}
+
+void LineairDBTransaction::execute_read_plan(
+    const std::vector<LineairDBProxy::ReadPlanStep>& steps) {
+  if (!oneshot_mode_ || steps.empty()) return;
+
+  rpc_trace_.record_local_view("plan_request:steps=" +
+                               std::to_string(steps.size()));
+  auto result = lineairdb_proxy->tx_execute_read_plan(steps);
+  if (!result.ok || result.steps.size() != steps.size()) {
+    rpc_trace_.record_local_view("abort_read_plan_rpc");
+    is_aborted_ = true;
+    return;
+  }
+
+  for (size_t i = 0; i < result.steps.size() && i < steps.size(); ++i) {
+    const auto& step = steps[i];
+    const auto& step_result = result.steps[i];
+
+    if (!step.is_scan && !step.for_each) {
+      rpc_trace_.record_local_view(trace_count_event(
+          step_result.found ? "plan_fetch:R:hit" : "plan_fetch:R:miss",
+          step.table_name, 1));
+      if (step_result.found) {
+        record_local_read(step.table_name, step_result.actual_key, true,
+                          step_result.value, step_result.tid, true);
+      } else {
+        record_local_read(step.table_name, step_result.actual_key, false, "",
+                          step_result.tid, true);
+      }
+      continue;
+    }
+
+    rpc_trace_.record_local_view(trace_plan_scan_event(
+        step.table_name, step.index_name, step_result.scan_keys.size(),
+        step_result.scan_values.size(), step.scan_limit, step.for_each));
+
+    std::vector<std::pair<std::string, std::string>> rows;
+    std::vector<uint64_t> row_tids;
+    rows.reserve(step_result.scan_keys.size());
+    row_tids.reserve(step_result.scan_keys.size());
+    for (size_t j = 0; j < step_result.scan_keys.size(); ++j) {
+      const std::string& key = step_result.scan_keys[j];
+      const std::string value =
+          j < step_result.scan_values.size() ? step_result.scan_values[j] : "";
+      const uint64_t tid =
+          j < step_result.scan_tids.size() ? step_result.scan_tids[j] : 0;
+      const bool found = !value.empty();
+      record_local_read(step.table_name, key, found, value, tid, true);
+      if (found) {
+        rows.emplace_back(key, value);
+        row_tids.push_back(tid);
+      }
+    }
+
+    if (step.for_each) continue;
+
+    if (step.index_name.empty()) {
+      local_range_scans_.push_back(
+          {step.table_name, step_result.actual_start_key,
+           step_result.actual_end_key, step.reverse_scan, step.scan_limit,
+           std::move(rows), std::move(row_tids), step_result.range_versions,
+           step_result.index_reads});
+    } else {
+      LocalSecondaryScanEntry cached;
+      cached.table_name = step.table_name;
+      cached.index_name = step.index_name;
+      cached.start_key = step_result.actual_start_key;
+      cached.end_key = step_result.actual_end_key;
+      cached.reverse_scan = step.reverse_scan;
+      cached.row_limit = step.scan_limit;
+      cached.secondary_keys.reserve(step_result.secondary_keys.size());
+      cached.primary_keys.reserve(step_result.scan_keys.size());
+      for (const auto& key : step_result.secondary_keys) {
+        cached.secondary_keys.push_back(key);
+      }
+      for (const auto& key : step_result.scan_keys) {
+        cached.primary_keys.push_back(key);
+      }
+      cached.range_versions = step_result.range_versions;
+      cached.index_reads = step_result.index_reads;
+      local_secondary_scans_.push_back(std::move(cached));
+    }
+  }
+}
+
 bool LineairDBTransaction::batch_write(
     const std::string& table_name,
     const std::vector<LineairDBProxy::BatchOp>& ops) {
+  if (oneshot_mode_) {
+    for (auto op : ops) {
+      if (op.table_name.empty()) op.table_name = table_name;
+      if (op.type == LineairDBProxy::BatchOp::Type::Write) {
+        record_local_write(op.table_name, op.key, true, op.value);
+      } else if (op.type == LineairDBProxy::BatchOp::Type::Delete) {
+        record_local_write(op.table_name, op.key, false, ""); // value unused when not found
+      } else if (op.type == LineairDBProxy::BatchOp::Type::SecondaryIndexWrite ||
+                 op.type == LineairDBProxy::BatchOp::Type::SecondaryIndexDelete) {
+        drop_local_secondary_scans(op.table_name, op.index_name);
+      }
+      write_buffer_ops_.push_back(std::move(op));
+    }
+    return true;
+  }
+
   return lineairdb_proxy->tx_batch_write(this, table_name, ops);
 }
 
 std::vector<std::string>
 LineairDBTransaction::get_all_keys() {
   if (table_is_not_chosen()) return {};
+  if (!fallback_to_normal_transaction("get_all_keys")) return {};
   flush_write_buffer_for_table(db_table_key);
 
   auto key_value_pairs = lineairdb_proxy->tx_get_matching_keys_and_values_from_prefix(this, "");
@@ -135,6 +353,7 @@ LineairDBTransaction::get_all_keys() {
 std::vector<std::string>
 LineairDBTransaction::get_matching_keys(std::string first_key_part) {
   if (table_is_not_chosen()) return {};
+  if (!fallback_to_normal_transaction("get_matching_keys")) return {};
   flush_write_buffer_for_table(db_table_key);
 
   auto key_value_pairs = lineairdb_proxy->tx_get_matching_keys_and_values_from_prefix(this, first_key_part);
@@ -149,6 +368,10 @@ LineairDBTransaction::get_matching_keys(std::string first_key_part) {
 
 bool LineairDBTransaction::write(std::string key, const std::string value) {
   if (table_is_not_chosen()) return false;
+  if (oneshot_mode_) {
+    buffer_write(db_table_key, key, value);
+    return true;
+  }
 
   const bool ok = lineairdb_proxy->tx_write(this, key, value);
   if (ok) record_local_write(db_table_key, key, true, value);
@@ -157,6 +380,10 @@ bool LineairDBTransaction::write(std::string key, const std::string value) {
 
 bool LineairDBTransaction::delete_value(std::string key) {
   if (table_is_not_chosen()) return false;
+  if (oneshot_mode_) {
+    buffer_delete(db_table_key, key);
+    return true;
+  }
 
   const bool ok = lineairdb_proxy->tx_delete(this, key);
   if (ok) record_local_write(db_table_key, key, false, ""); // value unused when not found
@@ -169,6 +396,18 @@ std::vector<std::string>
 LineairDBTransaction::read_secondary_index(std::string index_name,
                                            std::string secondary_key) {
   if (table_is_not_chosen()) return {};
+  if (oneshot_mode_) {
+    const std::string end_key = next_lexicographic_key(secondary_key);
+    if (end_key.empty()) {
+      rpc_trace_.record_local_view("abort_secondary_key_end");
+      is_aborted_ = true;
+      return {};
+    }
+    return get_matching_primary_keys_in_range(index_name, secondary_key,
+                                              end_key);
+  }
+
+  if (!fallback_to_normal_transaction("read_secondary_index")) return {};
   flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_read_secondary_index(this, index_name, secondary_key);
@@ -178,6 +417,11 @@ bool LineairDBTransaction::write_secondary_index(std::string index_name,
                                                  std::string secondary_key,
                                                  const std::string primary_key) {
   if (table_is_not_chosen()) return false;
+  if (oneshot_mode_) {
+    buffer_write_secondary_index(db_table_key, index_name, secondary_key,
+                                 primary_key);
+    return true;
+  }
 
   return lineairdb_proxy->tx_write_secondary_index(this, index_name, secondary_key, primary_key);
 }
@@ -186,6 +430,11 @@ bool LineairDBTransaction::delete_secondary_index(std::string index_name,
                                                   std::string secondary_key,
                                                   const std::string primary_key) {
   if (table_is_not_chosen()) return false;
+  if (oneshot_mode_) {
+    buffer_delete_secondary_index(db_table_key, index_name, secondary_key,
+                                  primary_key);
+    return true;
+  }
 
   return lineairdb_proxy->tx_delete_secondary_index(this, index_name, secondary_key, primary_key);
 }
@@ -195,6 +444,13 @@ bool LineairDBTransaction::update_secondary_index(std::string index_name,
                                                   std::string new_secondary_key,
                                                   const std::string primary_key) {
   if (table_is_not_chosen()) return false;
+  if (oneshot_mode_) {
+    buffer_delete_secondary_index(db_table_key, index_name, old_secondary_key,
+                                  primary_key);
+    buffer_write_secondary_index(db_table_key, index_name, new_secondary_key,
+                                 primary_key);
+    return true;
+  }
 
   return lineairdb_proxy->tx_update_secondary_index(this, index_name, old_secondary_key, new_secondary_key, primary_key);
 }
@@ -205,6 +461,39 @@ std::vector<std::string>
 LineairDBTransaction::get_matching_keys_in_range(std::string start_key,
                                                  std::string end_key) {
   if (table_is_not_chosen()) return {};
+  if (oneshot_mode_) {
+    if (auto cached =
+            lookup_local_range_scan(db_table_key, start_key, end_key, false, 0)) {
+      std::vector<std::pair<std::string, std::string>> rows = cached->rows;
+      rpc_trace_.record_local_view(
+          trace_count_event("use_pk_key_scan", db_table_key, rows.size()));
+      for (size_t i = 0; i < rows.size() && i < cached->row_tids.size(); ++i) {
+        record_stateless_read(db_table_key, rows[i].first, true,
+                              cached->row_tids[i]);
+      }
+      merge_pending_rows_into_range_scan(rows, start_key, end_key, false);
+      auto range_versions = cached->range_versions;
+      for (auto& range : range_versions) {
+        if (!range_validation_is_logical(range)) continue;
+        range.result_keys.clear();
+        range.result_primary_keys.clear();
+        for (const auto& row : rows) {
+          range.result_keys.push_back(row.first);
+        }
+      }
+      activate_range_validation(range_versions, cached->index_reads);
+      std::vector<std::string> keys;
+      keys.reserve(rows.size());
+      for (const auto& row : rows) keys.push_back(row.first);
+      return keys;
+    }
+
+    rpc_trace_.record_local_view("abort_oneshot_pk_key_scan_miss");
+    is_aborted_ = true;
+    return {};
+  }
+
+  if (!fallback_to_normal_transaction("get_matching_keys_in_range")) return {};
   flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_get_matching_keys_in_range(this, start_key, end_key);
@@ -216,6 +505,48 @@ LineairDBTransaction::get_matching_keys_and_values_in_range(std::string start_ke
                                                             uint64_t row_limit,
                                                             bool reverse_scan) {
   if (table_is_not_chosen()) return {};
+  if (oneshot_mode_) {
+    if (auto cached = lookup_local_range_scan(
+            db_table_key, start_key, end_key, reverse_scan, row_limit)) {
+      std::vector<std::pair<std::string, std::string>> pairs = cached->rows;
+      for (size_t i = 0; i < cached->rows.size() && i < cached->row_tids.size();
+           ++i) {
+        record_stateless_read(db_table_key, cached->rows[i].first, true,
+                              cached->row_tids[i]);
+      }
+      merge_pending_rows_into_range_scan(pairs, start_key, end_key,
+                                         reverse_scan);
+      auto range_versions = cached->range_versions;
+      if (row_limit > 0 && pairs.size() > row_limit) {
+        pairs.resize(static_cast<size_t>(row_limit));
+      }
+      rpc_trace_.record_local_view(
+          trace_count_event("use_pk_value_scan", db_table_key, pairs.size()));
+      for (auto& range : range_versions) {
+        if (!range_validation_is_logical(range)) continue;
+        range.start_key = start_key;
+        range.end_key = end_key;
+        range.result_keys.clear();
+        range.result_primary_keys.clear();
+        for (const auto& pair : pairs) {
+          range.result_keys.push_back(pair.first);
+        }
+        if (row_limit > 0) {
+          range.row_limit = row_limit;
+        }
+      }
+      activate_range_validation(range_versions, cached->index_reads);
+      return pairs;
+    }
+
+    rpc_trace_.record_local_view("abort_oneshot_pk_value_scan_miss:" +
+                                 std::to_string(start_key.size()) + ":" +
+                                 std::to_string(end_key.size()));
+    is_aborted_ = true;
+    return {};
+  }
+
+  if (!fallback_to_normal_transaction("get_matching_keys_and_values_in_range")) return {};
   const bool can_merge_local_rows = (row_limit == 0 && pushed_filter_.empty());
   // LIMIT / pushed filter scans must see only server-filtered rows
   if (!can_merge_local_rows) {
@@ -239,6 +570,17 @@ LineairDBTransaction::get_matching_keys_and_values_in_range(std::string start_ke
 std::vector<std::pair<std::string, std::string>>
 LineairDBTransaction::get_matching_keys_and_values_from_prefix(std::string prefix) {
   if (table_is_not_chosen()) return {};
+  if (oneshot_mode_) {
+    const std::string prefix_end = next_lexicographic_key(prefix);
+    if (prefix_end.empty()) {
+      rpc_trace_.record_local_view("abort_pk_prefix_end");
+      is_aborted_ = true;
+      return {};
+    }
+    return get_matching_keys_and_values_in_range(prefix, prefix_end);
+  }
+
+  if (!fallback_to_normal_transaction("get_matching_keys_and_values_from_prefix")) return {};
   const bool can_merge_local_rows = pushed_filter_.empty();
   // Pushed filter scans must see only server-filtered rows
   if (!can_merge_local_rows) {
@@ -262,6 +604,7 @@ std::optional<std::string>
 LineairDBTransaction::fetch_last_key_in_range(const std::string &start_key,
                                               const std::string &end_key) {
   if (table_is_not_chosen()) return std::nullopt;
+  if (!fallback_to_normal_transaction("fetch_last_key_in_range")) return std::nullopt;
   flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_fetch_last_key_in_range(this, start_key, end_key);
@@ -271,6 +614,7 @@ std::optional<std::string>
 LineairDBTransaction::fetch_first_key_with_prefix(const std::string &prefix,
                                                   const std::string &prefix_end) {
   if (table_is_not_chosen()) return std::nullopt;
+  if (!fallback_to_normal_transaction("fetch_first_key_with_prefix")) return std::nullopt;
   flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_fetch_first_key_with_prefix(this, prefix, prefix_end);
@@ -280,6 +624,7 @@ std::optional<std::string>
 LineairDBTransaction::fetch_next_key_with_prefix(const std::string &last_key,
                                                  const std::string &prefix_end) {
   if (table_is_not_chosen()) return std::nullopt;
+  if (!fallback_to_normal_transaction("fetch_next_key_with_prefix")) return std::nullopt;
   flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_fetch_next_key_with_prefix(this, last_key, prefix_end);
@@ -292,6 +637,32 @@ LineairDBTransaction::get_matching_primary_keys_in_range(std::string index_name,
                                                          std::string start_key,
                                                          std::string end_key) {
   if (table_is_not_chosen()) return {};
+  if (oneshot_mode_) {
+    if (has_pending_secondary_ops_for_index(db_table_key, index_name)) {
+      rpc_trace_.record_local_view("abort_secondary_scan_after_secondary_write:" +
+                                   index_name);
+      is_aborted_ = true;
+      return {};
+    }
+
+    if (auto cached = lookup_local_secondary_scan(
+            db_table_key, index_name, start_key, end_key, false, 0)) {
+      rpc_trace_.record_local_view("use_si_scan:" + db_table_key + ":" +
+                                   index_name + ":n=" +
+                                   std::to_string(cached->primary_keys.size()));
+      activate_range_validation(cached->range_versions, cached->index_reads);
+      return cached->primary_keys;
+    }
+
+    rpc_trace_.record_local_view("abort_oneshot_secondary_scan_miss:" +
+                                 index_name + ":" +
+                                 std::to_string(start_key.size()) + ":" +
+                                 std::to_string(end_key.size()));
+    is_aborted_ = true;
+    return {};
+  }
+
+  if (!fallback_to_normal_transaction("get_matching_primary_keys_in_range")) return {};
   flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_get_matching_primary_keys_in_range(this, index_name, start_key, end_key);
@@ -301,6 +672,17 @@ std::vector<std::string>
 LineairDBTransaction::get_matching_primary_keys_from_prefix(std::string index_name,
                                                             std::string prefix) {
   if (table_is_not_chosen()) return {};
+  if (oneshot_mode_) {
+    const std::string prefix_end = next_lexicographic_key(prefix);
+    if (prefix_end.empty()) {
+      rpc_trace_.record_local_view("abort_secondary_prefix_end");
+      is_aborted_ = true;
+      return {};
+    }
+    return get_matching_primary_keys_in_range(index_name, prefix, prefix_end);
+  }
+
+  if (!fallback_to_normal_transaction("get_matching_primary_keys_from_prefix")) return {};
   flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_get_matching_primary_keys_from_prefix(this, index_name, prefix);
@@ -311,6 +693,7 @@ LineairDBTransaction::fetch_last_primary_key_in_secondary_range(const std::strin
                                                                 const std::string &start_key,
                                                                 const std::string &end_key) {
   if (table_is_not_chosen()) return std::nullopt;
+  if (!fallback_to_normal_transaction("fetch_last_primary_key_in_secondary_range")) return std::nullopt;
   flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_fetch_last_primary_key_in_secondary_range(this, index_name, start_key, end_key);
@@ -321,6 +704,7 @@ LineairDBTransaction::fetch_last_secondary_entry_in_range(const std::string &ind
                                                           const std::string &start_key,
                                                           const std::string &end_key) {
   if (table_is_not_chosen()) return std::nullopt;
+  if (!fallback_to_normal_transaction("fetch_last_secondary_entry_in_range")) return std::nullopt;
   flush_write_buffer_for_table(db_table_key);
 
   return lineairdb_proxy->tx_fetch_last_secondary_entry_in_range(this, index_name, start_key, end_key);
@@ -366,7 +750,7 @@ void LineairDBTransaction::buffer_write(const std::string& table_name,
   write_buffer_ops_.push_back(std::move(op));
   record_local_write(table_name, key, true, value);
 
-  if (write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
+  if (!oneshot_mode_ && write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
     flush_write_buffer();
   }
 }
@@ -382,8 +766,9 @@ void LineairDBTransaction::buffer_write_secondary_index(const std::string& table
   op.primary_key = primary_key;
   op.table_name = table_name;
   write_buffer_ops_.push_back(std::move(op));
+  drop_local_secondary_scans(table_name, index_name);
 
-  if (write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
+  if (!oneshot_mode_ && write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
     flush_write_buffer();
   }
 }
@@ -397,7 +782,7 @@ void LineairDBTransaction::buffer_delete(const std::string& table_name,
   write_buffer_ops_.push_back(std::move(op));
   record_local_write(table_name, key, false, ""); // value unused when not found
 
-  if (write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
+  if (!oneshot_mode_ && write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
     flush_write_buffer();
   }
 }
@@ -414,14 +799,16 @@ void LineairDBTransaction::buffer_delete_secondary_index(
   op.primary_key = primary_key;
   op.table_name = table_name;
   write_buffer_ops_.push_back(std::move(op));
+  drop_local_secondary_scans(table_name, index_name);
 
-  if (write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
+  if (!oneshot_mode_ && write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
     flush_write_buffer();
   }
 }
 
 bool LineairDBTransaction::flush_write_buffer() {
   if (write_buffer_ops_.empty()) return true;
+  if (oneshot_mode_) return true;
   if (is_aborted_) {
     write_buffer_ops_.clear();
     return false;
@@ -435,6 +822,7 @@ bool LineairDBTransaction::flush_write_buffer() {
 bool LineairDBTransaction::flush_write_buffer_for_table(
     const std::string& table_name) {
   if (write_buffer_ops_.empty()) return true;
+  if (oneshot_mode_) return true;
   if (is_aborted_) {
     write_buffer_ops_.clear();
     return false;
@@ -583,6 +971,46 @@ void LineairDBTransaction::merge_pending_rows_into_prefix_scan(
   }
 }
 
+bool LineairDBTransaction::has_pending_ops_for_table(
+    const std::string& table_name) const {
+  for (const auto& op : write_buffer_ops_) {
+    if (op.table_name == table_name) return true;
+  }
+  return false;
+}
+
+bool LineairDBTransaction::has_pending_secondary_ops_for_index(
+    const std::string& table_name,
+    const std::string& index_name) const {
+  for (const auto& op : write_buffer_ops_) {
+    const bool same_index =
+        op.table_name == table_name && op.index_name == index_name;
+    if (!same_index) continue;
+
+    if (op.type == LineairDBProxy::BatchOp::Type::SecondaryIndexWrite ||
+        op.type == LineairDBProxy::BatchOp::Type::SecondaryIndexDelete) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void LineairDBTransaction::drop_local_secondary_scans(
+    const std::string& table_name,
+    const std::string& index_name) {
+  std::vector<LocalSecondaryScanEntry> kept;
+  kept.reserve(local_secondary_scans_.size());
+
+  // A buffered SI write/delete can make old scan results incomplete
+  for (const auto& entry : local_secondary_scans_) {
+    if (entry.table_name == table_name && entry.index_name == index_name) {
+      continue;
+    }
+    kept.push_back(entry);
+  }
+  local_secondary_scans_.swap(kept);
+}
+
 void LineairDBTransaction::record_local_write(const std::string& table_name,
                                               const std::string& key,
                                               bool found,
@@ -603,21 +1031,294 @@ void LineairDBTransaction::record_local_write(const std::string& table_name,
 void LineairDBTransaction::record_local_read(const std::string& table_name,
                                              const std::string& key,
                                              bool found,
-                                             const std::string& value) {
+                                             const std::string& value,
+                                             uint64_t tid,
+                                             bool validate_on_use) {
   for (auto& entry : local_read_set_) {
     if (entry.table_name == table_name && entry.key == key) {
       entry.found = found;
       entry.value = value;
+      entry.tid = tid;
+      entry.validate_on_use = validate_on_use;
       return;
     }
   }
-  local_read_set_.push_back({table_name, key, found, value});
+  local_read_set_.push_back(
+      {table_name, key, found, value, tid, validate_on_use});
+}
+
+void LineairDBTransaction::record_stateless_read(const std::string& table_name,
+                                                 const std::string& key,
+                                                 bool found,
+                                                 uint64_t tid) {
+  for (auto& entry : stateless_read_set_) {
+    if (entry.table_name == table_name && entry.key == key) {
+      entry.found = found;
+      entry.tid = tid;
+      return;
+    }
+  }
+  stateless_read_set_.push_back({table_name, key, tid, found});
+}
+
+void LineairDBTransaction::activate_local_read(const LocalRowEntry& entry) {
+  if (!entry.validate_on_use) return;
+  rpc_trace_.record_local_view(
+      trace_count_event("use_point_read", entry.table_name, 1));
+  record_stateless_read(entry.table_name, entry.key, entry.found, entry.tid);
+}
+
+void LineairDBTransaction::activate_range_validation(
+    const std::vector<LineairDBProxy::RangeValidationEntry>& ranges,
+    const std::vector<LineairDBProxy::IndexValidationEntry>& indexes) {
+  for (const auto& range : ranges) {
+    bool found = false;
+    for (const auto& active : range_validation_set_) {
+      const bool same_node =
+          active.table_name == range.table_name &&
+          active.index_name == range.index_name &&
+          active.owner_ptr == range.owner_ptr &&
+          active.node_ptr == range.node_ptr &&
+          active.version == range.version;
+      const bool same_logical =
+          active.start_key == range.start_key &&
+          active.end_key == range.end_key &&
+          active.row_limit == range.row_limit &&
+          active.reverse_scan == range.reverse_scan &&
+          active.result_keys == range.result_keys &&
+          active.result_primary_keys == range.result_primary_keys;
+      if (same_node && same_logical) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) range_validation_set_.push_back(range);
+  }
+
+  for (const auto& index : indexes) {
+    bool found = false;
+    for (const auto& active : index_validation_set_) {
+      if (active.table_name == index.table_name &&
+          active.index_name == index.index_name &&
+          active.key == index.key &&
+          active.tid == index.tid &&
+          active.found == index.found) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) index_validation_set_.push_back(index);
+  }
+}
+
+std::optional<LineairDBTransaction::LocalRangeScanEntry>
+LineairDBTransaction::lookup_local_range_scan(
+    const std::string& table_name, const std::string& start_key,
+    const std::string& end_key, bool reverse_scan, uint64_t row_limit) const {
+  for (auto it = local_range_scans_.rbegin();
+       it != local_range_scans_.rend(); ++it) {
+    const bool same_table = it->table_name == table_name;
+    const bool same_direction = it->reverse_scan == reverse_scan;
+    const bool same_limit = it->row_limit == row_limit;
+    const bool covers_range =
+        it->start_key <= start_key && end_key <= it->end_key;
+    const bool exact_range =
+        it->start_key == start_key && it->end_key == end_key;
+    const bool can_slice_validation =
+        range_validation_can_be_sliced(it->range_versions, it->index_reads);
+    if (same_table && same_direction && same_limit && covers_range &&
+        (exact_range || can_slice_validation)) {
+      LocalRangeScanEntry cached = *it;
+      cached.start_key = start_key;
+      cached.end_key = end_key;
+      cached.row_limit = row_limit;
+      std::vector<std::pair<std::string, std::string>> rows;
+      std::vector<uint64_t> row_tids;
+      rows.reserve(cached.rows.size());
+      row_tids.reserve(cached.row_tids.size());
+      for (size_t i = 0; i < cached.rows.size(); ++i) {
+        const auto& row = cached.rows[i];
+        if (row.first >= start_key && row.first < end_key) {
+          rows.push_back(row);
+          if (i < cached.row_tids.size()) row_tids.push_back(cached.row_tids[i]);
+        }
+      }
+      cached.rows = std::move(rows);
+      cached.row_tids = std::move(row_tids);
+      for (auto& range : cached.range_versions) {
+        if (!range_validation_is_logical(range)) continue;
+        range.start_key = start_key;
+        range.end_key = end_key;
+        range.result_keys.clear();
+        range.result_primary_keys.clear();
+        for (const auto& row : cached.rows) {
+          range.result_keys.push_back(row.first);
+        }
+      }
+      return cached;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<LineairDBTransaction::LocalSecondaryScanEntry>
+LineairDBTransaction::lookup_local_secondary_scan(
+    const std::string& table_name, const std::string& index_name,
+    const std::string& start_key, const std::string& end_key,
+    bool reverse_scan, uint64_t row_limit) const {
+  (void)reverse_scan; // SI cache keeps the query-specific order from the plan
+
+  for (auto it = local_secondary_scans_.rbegin();
+       it != local_secondary_scans_.rend(); ++it) {
+    const bool same_index =
+        it->table_name == table_name && it->index_name == index_name;
+    const bool same_limit = it->row_limit == row_limit;
+    const bool covers_range =
+        it->start_key <= start_key && end_key <= it->end_key;
+    const bool exact_range =
+        it->start_key == start_key && it->end_key == end_key;
+    const bool can_slice_validation =
+        range_validation_can_be_sliced(it->range_versions, it->index_reads);
+    if (same_index && same_limit && covers_range &&
+        (exact_range || can_slice_validation)) {
+      LocalSecondaryScanEntry cached = *it;
+      cached.start_key = start_key;
+      cached.end_key = end_key;
+      cached.row_limit = row_limit;
+      if (cached.secondary_keys.size() == cached.primary_keys.size()) {
+        std::vector<std::string> secondary_keys;
+        std::vector<std::string> primary_keys;
+        secondary_keys.reserve(cached.secondary_keys.size());
+        primary_keys.reserve(cached.primary_keys.size());
+        for (size_t i = 0; i < cached.secondary_keys.size(); ++i) {
+          if (cached.secondary_keys[i] >= start_key &&
+              cached.secondary_keys[i] < end_key) {
+            secondary_keys.push_back(cached.secondary_keys[i]);
+            primary_keys.push_back(cached.primary_keys[i]);
+          }
+        }
+        cached.secondary_keys = std::move(secondary_keys);
+        cached.primary_keys = std::move(primary_keys);
+      }
+      for (auto& range : cached.range_versions) {
+        if (!range_validation_is_logical(range)) continue;
+        range.start_key = start_key;
+        range.end_key = end_key;
+        range.result_keys = cached.secondary_keys;
+        range.result_primary_keys = cached.primary_keys;
+      }
+      return cached;
+    }
+  }
+  return std::nullopt;
+}
+
+bool LineairDBTransaction::fallback_to_normal_transaction(const char* reason) {
+  if (!oneshot_mode_) return true;
+
+  // A clean transaction can still switch to the normal scan-capable path
+  const bool has_oneshot_state =
+      !stateless_read_set_.empty() || !write_buffer_ops_.empty() ||
+      !rowcount_deltas_.empty() || !local_read_set_.empty() ||
+      !local_write_set_.empty() || !range_validation_set_.empty() ||
+      !index_validation_set_.empty() || !local_range_scans_.empty() ||
+      !local_secondary_scans_.empty();
+  if (!has_oneshot_state) {
+    oneshot_mode_ = false;
+    oneshot_registered_ = false;
+    begin_transaction();
+    return !is_aborted_;
+  }
+
+  // Mixing stateless point reads with scans would need phantom tracking
+  LOG_WARNING("Oneshot fallback blocked by prior local state: %s", reason);
+  rpc_trace_.record_local_view(std::string("abort_fallback_") + reason);
+  is_aborted_ = true;
+  return false;
+}
+
+bool LineairDBTransaction::oneshot_validate_and_commit() {
+  bool was_aborted = is_aborted_;
+
+  std::vector<LineairDBProxy::StatelessReadKey> reads;
+  std::vector<uint64_t> read_tids;
+  std::vector<bool> read_found;
+  if (!was_aborted) {
+    reads.reserve(stateless_read_set_.size());
+    read_tids.reserve(stateless_read_set_.size());
+    read_found.reserve(stateless_read_set_.size());
+    for (const auto& entry : stateless_read_set_) {
+      reads.push_back({entry.table_name, entry.key});
+      read_tids.push_back(entry.tid);
+      read_found.push_back(entry.found);
+    }
+  }
+
+  std::vector<std::pair<std::string, int64_t>> server_deltas;
+  if (!was_aborted && !rowcount_deltas_.empty()) {
+    server_deltas.reserve(rowcount_deltas_.size());
+    for (const auto& entry : rowcount_deltas_) {
+      if (entry.share != nullptr && entry.delta != 0)
+        server_deltas.emplace_back(entry.table_name, entry.delta);
+    }
+  }
+
+  bool committed = false;
+  std::string abort_reason;
+  if (!was_aborted) {
+    committed = lineairdb_proxy->tx_validate_and_commit(
+        reads, read_tids, read_found, range_validation_set_,
+        index_validation_set_,
+        write_buffer_ops_, server_deltas, isFence, &abort_reason);
+    if (!committed && !abort_reason.empty()) {
+      rpc_trace_.record_local_view("abort_validate_" + abort_reason);
+    }
+  }
+  if (!committed) {
+    thd_mark_transaction_to_rollback(thread, 1);
+  }
+
+  if (!was_aborted && committed && !rowcount_deltas_.empty()) {
+    const uint64_t tid = static_cast<uint64_t>(thread->thread_id());
+    const size_t shard =
+        static_cast<size_t>(tid) & (LineairDB_share::kRowCountShards - 1);
+
+    for (const auto& entry : rowcount_deltas_) {
+      if (entry.share == nullptr || entry.delta == 0)
+        continue;
+
+      entry.share->rowcount_shards[shard].delta.fetch_add(
+          entry.delta, std::memory_order_relaxed);
+    }
+  }
+
+  if (rpc_trace_.active()) {
+    RpcTraceLogger::instance().log_line(
+        rpc_trace_.finalize_jsonl(committed && !was_aborted));
+  }
+  lineairdb_proxy->set_current_trace(nullptr);
+
+  delete this;
+  return committed;
 }
 
 void LineairDBTransaction::begin_transaction() {
   assert(is_not_started());
   rpc_trace_.start(-1, std::this_thread::get_id());
   lineairdb_proxy->set_current_trace(&rpc_trace_);
+
+  if (oneshot_mode_) {
+    oneshot_registered_ = true;
+    is_aborted_ = false;
+    if (thd_is_transaction()) {
+      isTransaction = true;
+      register_transaction_to_mysql();
+    }
+    else {
+      register_single_statement_to_mysql();
+    }
+    return;
+  }
 
   tx_id = lineairdb_proxy->tx_begin_transaction();
   // TODO: maybe need error handling when tx_id == -1
@@ -635,6 +1336,10 @@ void LineairDBTransaction::begin_transaction() {
 }
 
 void LineairDBTransaction::set_status_to_abort() {
+  if (oneshot_mode_ || tx_id == -1) {
+    is_aborted_ = true;
+    return;
+  }
   // Skip TX_ABORT RPC if the server already knows (is_aborted_ was set from an RPC response).
   if (!is_aborted_) {
     lineairdb_proxy->tx_abort(tx_id);
@@ -643,6 +1348,10 @@ void LineairDBTransaction::set_status_to_abort() {
 }
 
 bool LineairDBTransaction::end_transaction() {
+  if (oneshot_mode_) {
+    return oneshot_validate_and_commit();
+  }
+
   assert(tx_id != -1);
   flush_write_buffer();
   bool was_aborted = is_aborted_;

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -89,9 +89,14 @@ public:
   void set_status_to_abort();
   bool end_transaction();
   void fence() const;
-  
+  void set_oneshot_mode(bool enabled) { oneshot_mode_ = enabled; }
+  bool is_oneshot_mode() const { return oneshot_mode_; }
+  void prefetch_stateless_reads(
+      const std::vector<LineairDBProxy::StatelessReadKey>& reads);
+  void execute_read_plan(const std::vector<LineairDBProxy::ReadPlanStep>& steps);
 
   inline bool is_not_started() const {
+    if (oneshot_mode_) return !oneshot_registered_;
     if (tx_id == -1) return true;
     return false;
   }
@@ -122,6 +127,7 @@ public:
 
   // RPC trace statement boundary; TxRpcTrace dedupes repeated SQL strings.
   void on_stmt_boundary(const std::string& sql) { rpc_trace_.on_stmt(sql); }
+  bool fallback_to_normal_transaction(const char* reason);
 
   LineairDBTransaction(THD* thd, 
                        LineairDBProxy* lineairdb_proxy, 
@@ -137,6 +143,8 @@ private:
   bool isTransaction;
   handlerton* hton;
   bool isFence;
+  bool oneshot_mode_{false};
+  bool oneshot_registered_{false};
 
   // stores the last RPC read result to maintain data pointer validity
   std::string last_read_value_;
@@ -156,11 +164,52 @@ private:
     std::string key;
     bool found;
     std::string value;
+    uint64_t tid = 0;
+    bool validate_on_use = false;
   };
+  // These sets live only inside one LineairDBTransaction.
+  // commit/abort deletes the object, so prefetched rows never cross txs.
+
   // Proxy-side read set for exact primary-key reads
   std::vector<LocalRowEntry> local_read_set_;
   // Proxy-side write set for exact primary-key writes/deletes
   std::vector<LocalRowEntry> local_write_set_;
+
+  struct StatelessReadEntry {
+    std::string table_name;
+    std::string key;
+    uint64_t tid;
+    bool found;
+  };
+  std::vector<StatelessReadEntry> stateless_read_set_;
+  std::vector<LineairDBProxy::RangeValidationEntry> range_validation_set_;
+  std::vector<LineairDBProxy::IndexValidationEntry> index_validation_set_;
+
+  struct LocalRangeScanEntry {
+    std::string table_name;
+    std::string start_key;
+    std::string end_key;
+    bool reverse_scan;
+    uint64_t row_limit = 0;
+    std::vector<std::pair<std::string, std::string>> rows;
+    std::vector<uint64_t> row_tids;
+    std::vector<LineairDBProxy::RangeValidationEntry> range_versions;
+    std::vector<LineairDBProxy::IndexValidationEntry> index_reads;
+  };
+  struct LocalSecondaryScanEntry {
+    std::string table_name;
+    std::string index_name;
+    std::string start_key;
+    std::string end_key;
+    bool reverse_scan;
+    uint64_t row_limit = 0;
+    std::vector<std::string> secondary_keys;
+    std::vector<std::string> primary_keys;
+    std::vector<LineairDBProxy::RangeValidationEntry> range_versions;
+    std::vector<LineairDBProxy::IndexValidationEntry> index_reads;
+  };
+  std::vector<LocalRangeScanEntry> local_range_scans_;
+  std::vector<LocalSecondaryScanEntry> local_secondary_scans_;
 
   // Predicate pushdown: serialized PushedPredicate for scan filtering
   std::string pushed_filter_;
@@ -196,12 +245,34 @@ private:
   void merge_pending_rows_into_prefix_scan(
       std::vector<std::pair<std::string, std::string>>& rows,
       const std::string& prefix) const;
+  bool has_pending_ops_for_table(const std::string& table_name) const;
+  bool has_pending_secondary_ops_for_index(
+      const std::string& table_name,
+      const std::string& index_name) const;
+  void drop_local_secondary_scans(const std::string& table_name,
+                                  const std::string& index_name);
   void record_local_write(const std::string& table_name,
                           const std::string& key, bool found,
                           const std::string& value);
   void record_local_read(const std::string& table_name,
                          const std::string& key, bool found,
-                         const std::string& value);
+                         const std::string& value, uint64_t tid = 0,
+                         bool validate_on_use = false);
+  void record_stateless_read(const std::string& table_name,
+                             const std::string& key, bool found,
+                             uint64_t tid);
+  void activate_local_read(const LocalRowEntry& entry);
+  void activate_range_validation(
+      const std::vector<LineairDBProxy::RangeValidationEntry>& ranges,
+      const std::vector<LineairDBProxy::IndexValidationEntry>& indexes);
+  std::optional<LocalRangeScanEntry> lookup_local_range_scan(
+      const std::string& table_name, const std::string& start_key,
+      const std::string& end_key, bool reverse_scan, uint64_t row_limit) const;
+  std::optional<LocalSecondaryScanEntry> lookup_local_secondary_scan(
+      const std::string& table_name, const std::string& index_name,
+      const std::string& start_key, const std::string& end_key,
+      bool reverse_scan, uint64_t row_limit) const;
+  bool oneshot_validate_and_commit();
   bool thd_is_transaction() const;
   void register_transaction_to_mysql();
   void register_single_statement_to_mysql();

--- a/proxy/rpc_trace.cc
+++ b/proxy/rpc_trace.cc
@@ -83,6 +83,14 @@ const char* message_type_name(MessageType t) {
       return "TX_BATCH_READ";
     case MessageType::TX_BATCH_WRITE:
       return "TX_BATCH_WRITE";
+    case MessageType::TX_STATELESS_READ:
+      return "TX_STATELESS_READ";
+    case MessageType::TX_STATELESS_BATCH_READ:
+      return "TX_STATELESS_BATCH_READ";
+    case MessageType::TX_STATELESS_RANGE_SCAN:
+      return "TX_STATELESS_RANGE_SCAN";
+    case MessageType::TX_STATELESS_SECONDARY_RANGE_SCAN:
+      return "TX_STATELESS_SECONDARY_RANGE_SCAN";
   }
   return "UNDEFINED";
 }

--- a/proxy/rpc_trace.cc
+++ b/proxy/rpc_trace.cc
@@ -87,10 +87,14 @@ const char* message_type_name(MessageType t) {
       return "TX_STATELESS_READ";
     case MessageType::TX_STATELESS_BATCH_READ:
       return "TX_STATELESS_BATCH_READ";
+    case MessageType::TX_VALIDATE_AND_COMMIT:
+      return "TX_VALIDATE_AND_COMMIT";
     case MessageType::TX_STATELESS_RANGE_SCAN:
       return "TX_STATELESS_RANGE_SCAN";
     case MessageType::TX_STATELESS_SECONDARY_RANGE_SCAN:
       return "TX_STATELESS_SECONDARY_RANGE_SCAN";
+    case MessageType::TX_EXECUTE_READ_PLAN:
+      return "TX_EXECUTE_READ_PLAN";
   }
   return "UNDEFINED";
 }

--- a/server/protocol/message.hh
+++ b/server/protocol/message.hh
@@ -51,5 +51,13 @@ enum class MessageType : uint32_t {
 
     // Batch operations
     TX_BATCH_READ = 25,
-    TX_BATCH_WRITE = 26
+    TX_BATCH_WRITE = 26,
+
+    // Experimental one-shot operations
+    TX_STATELESS_READ = 27,
+    TX_STATELESS_BATCH_READ = 28,
+    TX_VALIDATE_AND_COMMIT = 29,
+    TX_STATELESS_RANGE_SCAN = 30,
+    TX_STATELESS_SECONDARY_RANGE_SCAN = 31,
+    TX_EXECUTE_READ_PLAN = 32
 };

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -8,6 +8,33 @@
 
 #include "lineairdb.pb.h"
 
+namespace {
+
+// Copy range-scan node-version snapshots into the proto repeated field.
+void to_proto_range_versions(
+    const std::vector<LineairDB::ExternalRangeValidationEntry>& in,
+    google::protobuf::RepeatedPtrField<
+        LineairDB::Protocol::RangeValidationEntry>* out_entries) {
+    for (const auto& entry : in) {
+        auto* out = out_entries->Add();
+        out->set_table_name(entry.table_name);
+        out->set_index_name(entry.index_name);
+        out->set_owner_ptr(entry.owner_ptr);
+        out->set_node_ptr(entry.node_ptr);
+        out->set_version(entry.version);
+        out->set_start_key(entry.start_key);
+        out->set_end_key(entry.end_key);
+        out->set_row_limit(entry.row_limit);
+        out->set_reverse_scan(entry.reverse_scan);
+        for (const auto& key : entry.result_keys) out->add_result_keys(key);
+        for (const auto& key : entry.result_primary_keys) {
+            out->add_result_primary_keys(key);
+        }
+    }
+}
+
+}  // namespace
+
 LineairDBRpc::LineairDBRpc(std::shared_ptr<DatabaseManager> db_manager,
                            std::shared_ptr<TransactionManager> tx_manager,
                            std::shared_ptr<TableRowCounts> row_counts)
@@ -36,6 +63,18 @@ void LineairDBRpc::handle_rpc(uint64_t sender_id, MessageType message_type,
             return;
         case MessageType::TX_BATCH_WRITE:
             handleTxBatchWrite(message, result);
+            return;
+        case MessageType::TX_STATELESS_READ:
+            handleTxStatelessRead(message, result);
+            return;
+        case MessageType::TX_STATELESS_BATCH_READ:
+            handleTxStatelessBatchRead(message, result);
+            return;
+        case MessageType::TX_STATELESS_RANGE_SCAN:
+            handleTxStatelessRangeScan(message, result);
+            return;
+        case MessageType::TX_STATELESS_SECONDARY_RANGE_SCAN:
+            handleTxStatelessSecondaryRangeScan(message, result);
             return;
         case MessageType::TX_WRITE:
             handleTxWrite(message, result);
@@ -292,6 +331,126 @@ void LineairDBRpc::handleTxBatchWrite(const std::string& message, std::string& r
         response.set_success(false);
         response.set_is_aborted(true);
         LOG_WARNING("Transaction not found for batch_write: %ld", tx_id);
+    }
+
+    result = response.SerializeAsString();
+}
+
+void LineairDBRpc::handleTxStatelessRead(const std::string& message,
+                                         std::string& result) {
+    LineairDB::Protocol::TxStatelessRead::Request request;
+    LineairDB::Protocol::TxStatelessRead::Response response;
+
+    request.ParseFromString(message);
+
+    auto read_result =
+        db_manager_->get_database()->StatelessRead(request.table_name(),
+                                                   request.key());
+    response.set_found(read_result.found);
+    response.set_tid(read_result.tid);
+    if (read_result.found) {
+        response.set_value(std::move(read_result.value));
+    }
+
+    result = response.SerializeAsString();
+}
+
+void LineairDBRpc::handleTxStatelessBatchRead(const std::string& message,
+                                              std::string& result) {
+    LineairDB::Protocol::TxStatelessBatchRead::Request request;
+    LineairDB::Protocol::TxStatelessBatchRead::Response response;
+
+    request.ParseFromString(message);
+
+    std::vector<std::pair<std::string, std::string>> keys;
+    keys.reserve(request.ops_size());
+    for (const auto& op : request.ops()) {
+        keys.emplace_back(op.table_name(), op.key());
+    }
+
+    auto read_results = db_manager_->get_database()->StatelessBatchRead(keys);
+    for (auto& read_result : read_results) {
+        auto* out = response.add_results();
+        out->set_found(read_result.found);
+        out->set_tid(read_result.tid);
+        if (read_result.found) {
+            out->set_value(std::move(read_result.value));
+        }
+    }
+
+    result = response.SerializeAsString();
+}
+
+void LineairDBRpc::handleTxStatelessRangeScan(const std::string& message,
+                                              std::string& result) {
+    LineairDB::Protocol::TxStatelessRangeScan::Request request;
+    LineairDB::Protocol::TxStatelessRangeScan::Response response;
+
+    request.ParseFromString(message);
+
+    auto scan_result = db_manager_->get_database()->StatelessRangeScan(
+        request.table_name(), request.start_key(), request.end_key(),
+        request.row_limit(), request.reverse_scan());
+    response.set_ok(scan_result.ok);
+    if (!scan_result.ok) {
+        result = response.SerializeAsString();
+        return;
+    }
+
+    for (const auto& row : scan_result.rows) {
+        auto* out = response.add_rows();
+        out->set_key(row.key);
+        out->set_value(row.value);
+        out->set_tid(row.tid);
+        out->set_found(row.found);
+    }
+    to_proto_range_versions(scan_result.range_versions,
+                          response.mutable_range_versions());
+    for (const auto& entry : scan_result.index_reads) {
+        auto* out = response.add_index_reads();
+        out->set_table_name(entry.table_name);
+        out->set_index_name(entry.index_name);
+        out->set_key(entry.key);
+        out->set_tid(entry.tid);
+        out->set_found(entry.found);
+    }
+
+    result = response.SerializeAsString();
+}
+
+void LineairDBRpc::handleTxStatelessSecondaryRangeScan(
+    const std::string& message, std::string& result) {
+    LineairDB::Protocol::TxStatelessSecondaryRangeScan::Request request;
+    LineairDB::Protocol::TxStatelessSecondaryRangeScan::Response response;
+
+    request.ParseFromString(message);
+
+    auto scan_result = db_manager_->get_database()->StatelessSecondaryRangeScan(
+        request.table_name(), request.index_name(), request.start_key(),
+        request.end_key(), request.row_limit(), request.reverse_scan());
+    response.set_ok(scan_result.ok);
+    if (!scan_result.ok) {
+        result = response.SerializeAsString();
+        return;
+    }
+
+    for (const auto& row : scan_result.rows) {
+        auto* out = response.add_rows();
+        out->set_secondary_key(row.secondary_key);
+        out->set_primary_key(row.primary_key);
+        out->set_value(row.value);
+        out->set_tid(row.tid);
+        out->set_found(row.found);
+    }
+    to_proto_range_versions(scan_result.range_versions,
+                          response.mutable_range_versions());
+    for (const auto& entry : scan_result.index_reads) {
+        auto* out = response.add_index_reads();
+        out->set_table_name(entry.table_name);
+        out->set_index_name(entry.index_name);
+        out->set_key(entry.key);
+        out->set_tid(entry.tid);
+        out->set_found(entry.found);
     }
 
     result = response.SerializeAsString();

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -5,6 +5,8 @@
 #include <iostream>
 #include <vector>
 #include <cstring>
+#include <algorithm>
+#include <cstdlib>
 
 #include "lineairdb.pb.h"
 
@@ -31,6 +33,187 @@ void to_proto_range_versions(
             out->add_result_primary_keys(key);
         }
     }
+}
+
+// Copy exact index-entry snapshots into the proto repeated field.
+void to_proto_index_reads(
+    const std::vector<LineairDB::ExternalIndexValidationEntry>& in,
+    google::protobuf::RepeatedPtrField<
+        LineairDB::Protocol::IndexValidationEntry>* out_entries) {
+    for (const auto& entry : in) {
+        auto* out = out_entries->Add();
+        out->set_table_name(entry.table_name);
+        out->set_index_name(entry.index_name);
+        out->set_key(entry.key);
+        out->set_tid(entry.tid);
+        out->set_found(entry.found);
+    }
+}
+
+// Bump the byte string to its lexicographic successor; returns empty on overflow.
+std::string next_lexicographic_key(std::string key) {
+    for (size_t i = key.size(); i-- > 0;) {
+        auto byte = static_cast<unsigned char>(key[i]);
+        if (byte != 0xFF) {
+            key[i] = static_cast<char>(byte + 1);
+            key.resize(i + 1);
+            return key;
+        }
+    }
+    return {};
+}
+
+// Return the bytes of column `column_index` from a serialized MySQL row payload.
+std::string_view extract_value_column(const std::string& row,
+                                      int column_index) {
+    size_t offset = 0;
+    int field_index = 0;
+    const int target_field = column_index + 1; // field 0 is null flags.
+
+    while (offset < row.size()) {
+        const auto byte_size = static_cast<unsigned char>(row[offset]);
+        ++offset;
+        if (byte_size == 0xFF) {
+            if (field_index == target_field) return {};
+            ++field_index;
+            continue;
+        }
+        if (offset + byte_size > row.size()) return {};
+
+        size_t value_length = 0;
+        for (unsigned int i = 0; i < byte_size; ++i) {
+            value_length |= static_cast<size_t>(
+                static_cast<unsigned char>(row[offset + i])) << (8 * i);
+        }
+        offset += byte_size;
+        if (offset + value_length > row.size()) return {};
+
+        if (field_index == target_field) {
+            return std::string_view(row.data() + offset, value_length);
+        }
+        offset += value_length;
+        ++field_index;
+    }
+    return {};
+}
+
+// Build the int-keyed primary key bytes. Mirrors the layout produced by
+// ha_lineairdb::append_key_part_encoding, so server-side read-plan scan
+// boundaries match what the proxy wrote into LineairDB:
+//   [0x00 not-null marker | 0x10 INT type tag | 2-byte big-endian length=4
+//    | 4-byte signed int with top bit flipped]
+// Flipping the top bit makes byte-wise lexicographic sort agree with signed
+// integer order, so Masstree can sort without knowing the column type.
+// TODO: factor this and ha_lineairdb's encoder into a shared encoder so the
+// two ends cannot drift.
+std::string encode_int_key_part(int64_t value) {
+    const auto encoded = static_cast<uint32_t>(static_cast<int32_t>(value)) ^
+                         0x80000000U;
+    std::string out;
+    out.push_back(static_cast<char>(0x00));
+    out.push_back(static_cast<char>(0x10));
+    out.push_back(static_cast<char>(0x00));
+    out.push_back(static_cast<char>(0x04));
+    out.push_back(static_cast<char>((encoded >> 24) & 0xFF));
+    out.push_back(static_cast<char>((encoded >> 16) & 0xFF));
+    out.push_back(static_cast<char>((encoded >> 8) & 0xFF));
+    out.push_back(static_cast<char>(encoded & 0xFF));
+    return out;
+}
+
+// Parse a decimal-string column and encode it as int-keyed primary key bytes.
+std::string encode_column_as_int_key(std::string_view column,
+                                     int64_t int_delta) {
+    std::string tmp(column);
+    int64_t value = std::strtoll(tmp.c_str(), nullptr, 10);
+    return encode_int_key_part(value + int_delta);
+}
+
+// Pick the source byte string for a binding (from a step's scan key, scan value, or value).
+const std::string* select_source_bytes(
+    const LineairDB::Protocol::TxExecuteReadPlan::StepResult& source,
+    const LineairDB::Protocol::TxExecuteReadPlan::KeyBinding& binding,
+    bool from_key, int row_override) {
+    if (from_key) {
+        if (source.scan_keys_size() == 0) return nullptr;
+        int row = row_override >= 0 ? row_override : binding.source_row();
+        if (binding.use_midpoint()) row = (source.scan_keys_size() - 1) / 2;
+        row = std::min(row, source.scan_keys_size() - 1);
+        return &source.scan_keys(row);
+    }
+
+    if (source.scan_values_size() > 0) {
+        int row = row_override >= 0 ? row_override : binding.source_row();
+        if (binding.use_midpoint()) row = (source.scan_values_size() - 1) / 2;
+        row = std::min(row, source.scan_values_size() - 1);
+        return &source.scan_values(row);
+    }
+    return &source.value();
+}
+
+// Compose a read-plan key prefix plus all bindings into the actual scan key.
+std::string build_plan_key(
+    const std::string& prefix,
+    const google::protobuf::RepeatedPtrField<
+        LineairDB::Protocol::TxExecuteReadPlan::KeyBinding>& bindings,
+    const std::vector<LineairDB::Protocol::TxExecuteReadPlan::StepResult*>&
+        previous_results,
+    int row_override = -1,
+    bool *complete = nullptr) {
+    if (complete != nullptr) *complete = true;
+    std::string key = prefix;
+    for (const auto& binding : bindings) {
+        const int source_step = static_cast<int>(binding.source_step());
+        if (source_step < 0 ||
+            source_step >= static_cast<int>(previous_results.size())) {
+            if (complete != nullptr) *complete = false;
+            continue;
+        }
+
+        const auto& source = *previous_results[source_step];
+        std::string scratch;
+        std::string_view extracted;
+        if (binding.source_column() > 0) {
+            const std::string* bytes =
+                select_source_bytes(source, binding, false, row_override);
+            if (bytes != nullptr) {
+                extracted =
+                    extract_value_column(*bytes, binding.source_column() - 1);
+                if (binding.column_as_int_key()) {
+                    scratch =
+                        encode_column_as_int_key(extracted,
+                                                 binding.int_delta());
+                    extracted = scratch;
+                }
+            } else if (complete != nullptr) {
+                *complete = false;
+            }
+        } else {
+            const std::string* bytes =
+                select_source_bytes(source, binding, binding.from_key(),
+                                    row_override);
+            if (bytes != nullptr) {
+                uint32_t offset = binding.source_offset();
+                uint32_t length = binding.source_length();
+                if (offset < bytes->size()) {
+                    if (length == 0) length = bytes->size() - offset;
+                    length = std::min<uint32_t>(
+                        length, static_cast<uint32_t>(bytes->size() - offset));
+                    extracted = std::string_view(bytes->data() + offset,
+                                                 length);
+                } else if (complete != nullptr) {
+                    *complete = false;
+                }
+            } else if (complete != nullptr) {
+                *complete = false;
+            }
+        }
+        if (bindings.size() > 0 && extracted.empty() && complete != nullptr) {
+            *complete = false;
+        }
+        key.append(extracted.data(), extracted.size());
+    }
+    return key;
 }
 
 }  // namespace
@@ -75,6 +258,12 @@ void LineairDBRpc::handle_rpc(uint64_t sender_id, MessageType message_type,
             return;
         case MessageType::TX_STATELESS_SECONDARY_RANGE_SCAN:
             handleTxStatelessSecondaryRangeScan(message, result);
+            return;
+        case MessageType::TX_EXECUTE_READ_PLAN:
+            handleTxExecuteReadPlan(message, result);
+            return;
+        case MessageType::TX_VALIDATE_AND_COMMIT:
+            handleTxValidateAndCommit(message, result);
             return;
         case MessageType::TX_WRITE:
             handleTxWrite(message, result);
@@ -451,6 +640,218 @@ void LineairDBRpc::handleTxStatelessSecondaryRangeScan(
         out->set_key(entry.key);
         out->set_tid(entry.tid);
         out->set_found(entry.found);
+    }
+
+    result = response.SerializeAsString();
+}
+
+void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
+                                           std::string& result) {
+    LineairDB::Protocol::TxExecuteReadPlan::Request request;
+    LineairDB::Protocol::TxExecuteReadPlan::Response response;
+    request.ParseFromString(message);
+    response.set_ok(true);
+
+    std::vector<LineairDB::Protocol::TxExecuteReadPlan::StepResult*>
+        previous_results;
+    previous_results.reserve(request.steps_size());
+
+    for (const auto& step : request.steps()) {
+        auto* step_result = response.add_results();
+        previous_results.push_back(step_result);
+
+        bool start_complete = true;
+        bool end_complete = true;
+        const std::string start_key =
+            build_plan_key(step.key_prefix(), step.bindings(),
+                           previous_results, -1, &start_complete);
+        std::string end_key =
+            build_plan_key(step.end_key_prefix(), step.end_bindings(),
+                           previous_results, -1, &end_complete);
+        if (!start_complete || !end_complete) continue;
+        if (step.is_scan() && end_key.empty()) {
+            end_key = next_lexicographic_key(start_key);
+        }
+
+        if (step.for_each()) {
+            int source_step = -1;
+            if (step.bindings_size() > 0) {
+                source_step = static_cast<int>(step.bindings(0).source_step());
+            }
+            if (source_step < 0 ||
+                source_step >= static_cast<int>(previous_results.size()) - 1) {
+                continue;
+            }
+
+            const auto* source = previous_results[source_step];
+            const int row_count =
+                std::max(source->scan_keys_size(), source->scan_values_size());
+            for (int row = 0; row < row_count; ++row) {
+                bool row_complete = true;
+                const std::string row_key =
+                    build_plan_key(step.key_prefix(), step.bindings(),
+                                   previous_results, row, &row_complete);
+                if (!row_complete) continue;
+                auto read_result =
+                    db_manager_->get_database()->StatelessRead(
+                        step.table_name(), row_key);
+                step_result->add_scan_keys(row_key);
+                step_result->add_scan_tids(read_result.tid);
+                if (read_result.found) {
+                    step_result->add_scan_values(
+                        std::move(read_result.value));
+                } else {
+                    step_result->add_scan_values("");
+                }
+            }
+            continue;
+        }
+
+        if (!step.is_scan()) {
+            auto read_result =
+                db_manager_->get_database()->StatelessRead(
+                    step.table_name(), start_key);
+            step_result->set_actual_key(start_key);
+            step_result->set_actual_start_key(start_key);
+            step_result->set_found(read_result.found);
+            step_result->set_tid(read_result.tid);
+            if (read_result.found) {
+                step_result->set_value(std::move(read_result.value));
+            }
+            continue;
+        }
+
+        if (step.index_name().empty()) {
+            step_result->set_actual_start_key(start_key);
+            step_result->set_actual_end_key(end_key);
+            auto scan_result =
+                db_manager_->get_database()->StatelessRangeScan(
+                    step.table_name(), start_key, end_key,
+                    step.scan_limit(), step.reverse_scan());
+            if (!scan_result.ok) {
+                response.set_ok(false);
+                result = response.SerializeAsString();
+                return;
+            }
+            for (auto& row : scan_result.rows) {
+                step_result->add_scan_keys(std::move(row.key));
+                step_result->add_scan_values(std::move(row.value));
+                step_result->add_scan_tids(row.tid);
+            }
+            to_proto_range_versions(scan_result.range_versions,
+                                  step_result->mutable_range_versions());
+            to_proto_index_reads(scan_result.index_reads,
+                               step_result->mutable_index_reads());
+        } else {
+            step_result->set_actual_start_key(start_key);
+            step_result->set_actual_end_key(end_key);
+            auto scan_result =
+                db_manager_->get_database()->StatelessSecondaryRangeScan(
+                    step.table_name(), step.index_name(), start_key, end_key,
+                    step.scan_limit(), step.reverse_scan());
+            if (!scan_result.ok) {
+                response.set_ok(false);
+                result = response.SerializeAsString();
+                return;
+            }
+            for (auto& row : scan_result.rows) {
+                step_result->add_secondary_keys(std::move(row.secondary_key));
+                step_result->add_scan_keys(std::move(row.primary_key));
+                step_result->add_scan_values(std::move(row.value));
+                step_result->add_scan_tids(row.tid);
+            }
+            to_proto_range_versions(scan_result.range_versions,
+                                  step_result->mutable_range_versions());
+            to_proto_index_reads(scan_result.index_reads,
+                               step_result->mutable_index_reads());
+        }
+    }
+
+    result = response.SerializeAsString();
+}
+
+void LineairDBRpc::handleTxValidateAndCommit(const std::string& message,
+                                             std::string& result) {
+    LineairDB::Protocol::TxValidateAndCommit::Request request;
+    LineairDB::Protocol::TxValidateAndCommit::Response response;
+
+    request.ParseFromString(message);
+
+    std::vector<LineairDB::ExternalReadEntry> reads;
+    reads.reserve(request.reads_size());
+    for (const auto& read : request.reads()) {
+        reads.push_back({read.table_name(), read.key(), read.tid(),
+                         read.found()});
+    }
+
+    std::vector<LineairDB::ExternalIndexValidationEntry> index_reads;
+    index_reads.reserve(request.index_reads_size());
+    for (const auto& read : request.index_reads()) {
+        index_reads.push_back({read.table_name(), read.index_name(),
+                               read.key(), read.tid(), read.found()});
+    }
+
+    std::vector<LineairDB::ExternalWriteEntry> writes;
+    writes.reserve(request.writes_size() + request.deletes_size());
+    for (const auto& write : request.writes()) {
+        writes.push_back({write.table_name(), write.key(), write.value(),
+                          write.is_delete()});
+    }
+    for (const auto& del : request.deletes()) {
+        writes.push_back({del.table_name(), del.key(), "", true});
+    }
+
+    std::vector<LineairDB::ExternalSecondaryIndexEntry> si_ops;
+    si_ops.reserve(request.secondary_index_ops_size());
+    for (const auto& op : request.secondary_index_ops()) {
+        si_ops.push_back({op.table_name(), op.index_name(),
+                          op.secondary_key(), op.primary_key(),
+                          op.is_delete()});
+    }
+
+    std::vector<LineairDB::ExternalRangeValidationEntry> range_reads;
+    range_reads.reserve(request.range_reads_size());
+    for (const auto& range : request.range_reads()) {
+        LineairDB::ExternalRangeValidationEntry entry{
+            range.table_name(), range.index_name(), range.owner_ptr(),
+            range.node_ptr(), range.version()};
+        entry.start_key = range.start_key();
+        entry.end_key = range.end_key();
+        entry.row_limit = range.row_limit();
+        entry.reverse_scan = range.reverse_scan();
+        entry.result_keys.reserve(range.result_keys_size());
+        for (const auto& key : range.result_keys()) {
+            entry.result_keys.push_back(key);
+        }
+        entry.result_primary_keys.reserve(range.result_primary_keys_size());
+        for (const auto& key : range.result_primary_keys()) {
+            entry.result_primary_keys.push_back(key);
+        }
+        range_reads.push_back(std::move(entry));
+    }
+
+    std::string abort_reason;
+    const bool committed =
+        db_manager_->get_database()->ValidateAndCommit(reads, writes, si_ops,
+                                                       range_reads,
+                                                       index_reads,
+                                                       &abort_reason);
+    response.set_committed(committed);
+    if (!committed && !abort_reason.empty()) {
+        response.set_abort_reason(abort_reason);
+    }
+
+    if (committed && request.row_deltas_size() > 0) {
+        row_counts_->apply_deltas(request.row_deltas());
+    }
+    if (committed && request.fence()) {
+        db_manager_->get_database()->Fence();
+    }
+
+    for (const auto& [name, count] : row_counts_->snapshot()) {
+        auto* ts = response.add_table_stats();
+        ts->set_table_name(name);
+        ts->set_row_count(count);
     }
 
     result = response.SerializeAsString();

--- a/server/rpc/lineairdb_rpc.hh
+++ b/server/rpc/lineairdb_rpc.hh
@@ -54,6 +54,10 @@ private:
     void handleTxRead(const std::string& message, std::string& result);
     void handleTxBatchRead(const std::string& message, std::string& result);
     void handleTxBatchWrite(const std::string& message, std::string& result);
+    void handleTxStatelessRead(const std::string& message, std::string& result);
+    void handleTxStatelessBatchRead(const std::string& message, std::string& result);
+    void handleTxStatelessRangeScan(const std::string& message, std::string& result);
+    void handleTxStatelessSecondaryRangeScan(const std::string& message, std::string& result);
     void handleTxWrite(const std::string& message, std::string& result);
     void handleTxDelete(const std::string& message, std::string& result);
 

--- a/server/rpc/lineairdb_rpc.hh
+++ b/server/rpc/lineairdb_rpc.hh
@@ -58,6 +58,8 @@ private:
     void handleTxStatelessBatchRead(const std::string& message, std::string& result);
     void handleTxStatelessRangeScan(const std::string& message, std::string& result);
     void handleTxStatelessSecondaryRangeScan(const std::string& message, std::string& result);
+    void handleTxExecuteReadPlan(const std::string& message, std::string& result);
+    void handleTxValidateAndCommit(const std::string& message, std::string& result);
     void handleTxWrite(const std::string& message, std::string& result);
     void handleTxDelete(const std::string& message, std::string& result);
 

--- a/test/pytest/oneshot_plan.py
+++ b/test/pytest/oneshot_plan.py
@@ -1,0 +1,342 @@
+import argparse
+import sys
+import time
+
+import mysql.connector
+
+from utils.connection import get_connection
+
+
+DBNAME = f"ha_lineairdb_oneshot_plan_{int(time.time())}"
+
+
+def reset(cursor, db):
+    cursor.execute(f"DROP DATABASE IF EXISTS {DBNAME}")
+    cursor.execute(f"CREATE DATABASE {DBNAME}")
+    cursor.execute(f"USE {DBNAME}")
+    db.commit()
+
+
+def expect_commit_error(cursor):
+    try:
+        cursor.execute("COMMIT")
+        return False
+    except mysql.connector.Error:
+        return True
+
+
+def test_prefetch_scope(cursor, db):
+    print("ONESHOT PLAN PREFETCH SCOPE TEST")
+    cursor.execute(
+        "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT NOT NULL) "
+        "ENGINE=LineairDB"
+    )
+    cursor.execute("INSERT INTO t VALUES (1,100),(2,200),(3,300)")
+    db.commit()
+
+    cursor.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
+    cursor.execute("SET @_ldb_plan='R:t:1;R:t:2;R:t:3'")
+    cursor.execute("START TRANSACTION")
+    cursor.execute("SELECT v FROM t WHERE id=1")
+    if cursor.fetchone()[0] != 100:
+        return 1
+    cursor.execute("UPDATE t SET v=v+10 WHERE id=3")
+    cursor.execute("COMMIT")
+
+    cursor.execute("UPDATE t SET v=777 WHERE id=1")
+    db.commit()
+
+    # A new transaction gets a fresh plan and must read the latest value.
+    cursor.execute("SET @_ldb_plan='R:t:1'")
+    cursor.execute("START TRANSACTION")
+    cursor.execute("SELECT v FROM t WHERE id=1")
+    if cursor.fetchone()[0] != 777:
+        return 1
+    cursor.execute("COMMIT")
+    print("\tPassed!")
+    return 0
+
+
+def test_conflict_abort():
+    print("ONESHOT PLAN CONFLICT TEST")
+    a = get_connection(user=args.user, password=args.password)
+    b = get_connection(user=args.user, password=args.password)
+    ca = a.cursor()
+    cb = b.cursor()
+    try:
+        ca.execute(f"USE {DBNAME}")
+        cb.execute(f"USE {DBNAME}")
+        ca.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
+        ca.execute("SET @_ldb_plan='R:t:1'")
+        ca.execute("START TRANSACTION")
+        ca.execute("SELECT v FROM t WHERE id=1")
+        ca.fetchone()
+
+        cb.execute("UPDATE t SET v=v+1 WHERE id=1")
+        b.commit()
+
+        ca.execute("UPDATE t SET v=v+100 WHERE id=1")
+        if not expect_commit_error(ca):
+            return 1
+
+        cb.execute("SELECT v FROM t WHERE id=1")
+        if cb.fetchone()[0] != 778:
+            return 1
+    finally:
+        try:
+            ca.close()
+            cb.close()
+            a.close()
+            b.close()
+        except Exception:
+            pass
+    print("\tPassed!")
+    return 0
+
+
+def test_unique_commit_check(cursor, db):
+    print("ONESHOT PLAN UNIQUE SECONDARY TEST")
+    cursor.execute(
+        "CREATE TABLE unique_c (id INT NOT NULL, c INT NOT NULL, "
+        "PRIMARY KEY(id), UNIQUE KEY u_c(c)) ENGINE=LineairDB"
+    )
+    cursor.execute("INSERT INTO unique_c VALUES (1,10)")
+    db.commit()
+
+    cursor.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
+    cursor.execute("SET @_ldb_plan='R:t:2'")
+    cursor.execute("START TRANSACTION")
+    cursor.execute("SELECT v FROM t WHERE id=2")
+    cursor.fetchone()
+    cursor.execute("INSERT INTO unique_c VALUES (2,10)")
+    if not expect_commit_error(cursor):
+        return 1
+
+    cursor.execute("SELECT COUNT(*) FROM unique_c")
+    if cursor.fetchone()[0] != 1:
+        return 1
+    print("\tPassed!")
+    return 0
+
+
+def test_range_clean_commit(cursor, db):
+    print("ONESHOT PLAN RANGE CLEAN COMMIT TEST")
+    cursor.execute(
+        "CREATE TABLE range_clean_t (id INT NOT NULL PRIMARY KEY, "
+        "v INT NOT NULL) ENGINE=LineairDB"
+    )
+    cursor.execute("INSERT INTO range_clean_t VALUES (1,1),(10,10),(20,20)")
+    db.commit()
+
+    cursor.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
+    cursor.execute("SET @_ldb_plan='S:range_clean_t:10:E:30'")
+    cursor.execute("START TRANSACTION")
+    cursor.execute(
+        "SELECT id FROM range_clean_t FORCE INDEX(PRIMARY) "
+        "WHERE id >= 10 AND id < 30 ORDER BY id"
+    )
+    if [row[0] for row in cursor.fetchall()] != [10, 20]:
+        return 1
+    cursor.execute("COMMIT")
+    print("\tPassed!")
+    return 0
+
+
+def test_range_phantom_abort():
+    print("ONESHOT PLAN RANGE PHANTOM TEST")
+    a = get_connection(user=args.user, password=args.password)
+    b = get_connection(user=args.user, password=args.password)
+    ca = a.cursor()
+    cb = b.cursor()
+    try:
+        ca.execute(f"USE {DBNAME}")
+        cb.execute(f"USE {DBNAME}")
+        ca.execute(
+            "CREATE TABLE range_t (id INT NOT NULL PRIMARY KEY, "
+            "v INT NOT NULL) ENGINE=LineairDB"
+        )
+        ca.execute("INSERT INTO range_t VALUES (1,1),(10,10),(20,20),(30,30)")
+        a.commit()
+
+        ca.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
+        ca.execute("SET @_ldb_plan='S:range_t:10:E:30'")
+        ca.execute("START TRANSACTION")
+        ca.execute(
+            "SELECT id FROM range_t FORCE INDEX(PRIMARY) "
+            "WHERE id >= 10 AND id < 30 ORDER BY id"
+        )
+        if [row[0] for row in ca.fetchall()] != [10, 20]:
+            return 1
+
+        cb.execute("INSERT INTO range_t VALUES (15,15)")
+        b.commit()
+
+        if not expect_commit_error(ca):
+            return 1
+    finally:
+        try:
+            ca.close()
+            cb.close()
+            a.close()
+            b.close()
+        except Exception:
+            pass
+    print("\tPassed!")
+    return 0
+
+
+def test_range_tombstone_reinsert_abort():
+    print("ONESHOT PLAN RANGE TOMBSTONE REINSERT TEST")
+    a = get_connection(user=args.user, password=args.password)
+    b = get_connection(user=args.user, password=args.password)
+    ca = a.cursor()
+    cb = b.cursor()
+    try:
+        ca.execute(f"USE {DBNAME}")
+        cb.execute(f"USE {DBNAME}")
+        ca.execute(
+            "CREATE TABLE tombstone_t (id INT NOT NULL PRIMARY KEY, "
+            "v INT NOT NULL) ENGINE=LineairDB"
+        )
+        ca.execute(
+            "INSERT INTO tombstone_t VALUES (10,10),(15,15),(20,20)"
+        )
+        ca.execute("DELETE FROM tombstone_t WHERE id=15")
+        a.commit()
+
+        ca.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
+        ca.execute("SET @_ldb_plan='S:tombstone_t:10:E:30'")
+        ca.execute("START TRANSACTION")
+        ca.execute(
+            "SELECT id FROM tombstone_t FORCE INDEX(PRIMARY) "
+            "WHERE id >= 10 AND id < 30 ORDER BY id"
+        )
+        if [row[0] for row in ca.fetchall()] != [10, 20]:
+            return 1
+
+        cb.execute("INSERT INTO tombstone_t VALUES (15,150)")
+        b.commit()
+
+        if not expect_commit_error(ca):
+            return 1
+    finally:
+        try:
+            ca.close()
+            cb.close()
+            a.close()
+            b.close()
+        except Exception:
+            pass
+    print("\tPassed!")
+    return 0
+
+
+def test_secondary_range_clean_commit(cursor, db):
+    print("ONESHOT PLAN SECONDARY RANGE CLEAN COMMIT TEST")
+    cursor.execute(
+        "CREATE TABLE si_range_clean_t ("
+        "id INT NOT NULL PRIMARY KEY, "
+        "c INT NOT NULL, "
+        "v INT NOT NULL, "
+        "KEY c_idx(c)) ENGINE=LineairDB"
+    )
+    cursor.execute(
+        "INSERT INTO si_range_clean_t VALUES "
+        "(1,10,1),(2,10,2),(3,20,3)"
+    )
+    db.commit()
+
+    cursor.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
+    cursor.execute("SET @_ldb_plan='SI:si_range_clean_t:c_idx:10'")
+    cursor.execute("START TRANSACTION")
+    cursor.execute(
+        "SELECT id FROM si_range_clean_t FORCE INDEX(c_idx) "
+        "WHERE c = 10 ORDER BY id"
+    )
+    if [row[0] for row in cursor.fetchall()] != [1, 2]:
+        return 1
+    cursor.execute("COMMIT")
+    print("\tPassed!")
+    return 0
+
+
+def test_secondary_range_phantom_abort():
+    print("ONESHOT PLAN SECONDARY RANGE PHANTOM TEST")
+    a = get_connection(user=args.user, password=args.password)
+    b = get_connection(user=args.user, password=args.password)
+    ca = a.cursor()
+    cb = b.cursor()
+    try:
+        ca.execute(f"USE {DBNAME}")
+        cb.execute(f"USE {DBNAME}")
+        ca.execute(
+            "CREATE TABLE si_range_t ("
+            "id INT NOT NULL PRIMARY KEY, "
+            "c INT NOT NULL, "
+            "v INT NOT NULL, "
+            "KEY c_idx(c)) ENGINE=LineairDB"
+        )
+        ca.execute(
+            "INSERT INTO si_range_t VALUES "
+            "(1,10,1),(2,10,2),(3,20,3)"
+        )
+        a.commit()
+
+        ca.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
+        ca.execute("SET @_ldb_plan='SI:si_range_t:c_idx:10'")
+        ca.execute("START TRANSACTION")
+        ca.execute(
+            "SELECT id FROM si_range_t FORCE INDEX(c_idx) "
+            "WHERE c = 10 ORDER BY id"
+        )
+        if [row[0] for row in ca.fetchall()] != [1, 2]:
+            return 1
+
+        cb.execute("INSERT INTO si_range_t VALUES (4,10,4)")
+        b.commit()
+
+        if not expect_commit_error(ca):
+            return 1
+    finally:
+        try:
+            ca.close()
+            cb.close()
+            a.close()
+            b.close()
+        except Exception:
+            pass
+    print("\tPassed!")
+    return 0
+
+
+def main():
+    db = get_connection(user=args.user, password=args.password)
+    cursor = db.cursor()
+    reset(cursor, db)
+
+    result = 0
+    result |= test_prefetch_scope(cursor, db)
+    result |= test_conflict_abort()
+    result |= test_unique_commit_check(cursor, db)
+    result |= test_range_clean_commit(cursor, db)
+    result |= test_range_phantom_abort()
+    result |= test_range_tombstone_reinsert_abort()
+    result |= test_secondary_range_clean_commit(cursor, db)
+    result |= test_secondary_range_phantom_abort()
+
+    cursor.close()
+    db.close()
+
+    if result == 0:
+        print("\nALL TESTS PASSED!")
+    else:
+        print("\nSOME TESTS FAILED!")
+    sys.exit(result)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Connect to MySQL")
+    parser.add_argument("--user", type=str, default="root")
+    parser.add_argument("--password", type=str, default="")
+    args = parser.parse_args()
+    main()


### PR DESCRIPTION
## Summary

- Add a single-round-trip Oneshot execution path so short read-heavy transactions can prefetch their entire read set, run the read plan in the proxy, and submit ValidateAndCommit in two RPCs instead of one RPC per primary-key / secondary-index touch.
- Introduce an `@_ldb_plan` session-variable DSL on the proxy and the `lineairdb_oneshot_execution` sysvar so eligible statements can opt into the path. Eligibility is checked per statement (SELECT / UPDATE / DELETE only, with a plan attached); any failure falls back to the existing transaction path.
- Add stateless read / range-scan / secondary-range-scan RPCs and a server-side read-plan executor so the oneshot transaction is built entirely from snapshot reads with deferred commit-time validation.
- Wire BenchBase TPC-C procedures to inject `@_ldb_plan` when `HELIOS_ONESHOT_PLAN=1`, and add a `--oneshot` flag to `benchrun.py` that toggles both the env var and the sysvar.
- Add a TPC-C-NP benchmark variant (`bench/config/tpcc-np.xml`) for the NewOrder + Payment subset used by DBx1000 (Yu et al., VLDB 2014) and Cicada to isolate write-intensive OLTP from deferred / read-only transactions.
- Overlay goodput as a dashed line on the throughput plot so abort-induced gaps are visible alongside the throughput curve.
- Add pytest covering oneshot-plan correctness for point prefetch, unique secondary-index checks, range scans, secondary-index range scans, and the corresponding phantom / tombstone abort cases.

## Why

The existing transaction path issues one RPC per primary-key or secondary-index touch, so per-transaction RPC count grows with the number of rows the SQL plan visits. For short OLTP transactions whose read set is statically describable, the proxy can describe the whole read set up front, prefetch it in a single RPC, replay the plan locally, and submit the resulting read / write / range entries to ValidateAndCommit. This collapses per-transaction RPC count to two and removes the per-transaction thread-pinning constraint, which is the prerequisite for distributing MySQL nodes behind a shared storage layer.

## Changes

### Wire protocol (`proto/lineairdb.proto`)
- Six new MessageTypes: stateless read / batch read / range scan / secondary-index range scan, read-plan execution, and validate-and-commit.

### Server (`server/rpc/lineairdb_rpc.{cc,hh}`)
- Stateless read and range-scan handlers return version-tagged snapshots without touching transaction state.
- Read-plan executor runs a sequence of point / range / secondary-index steps and returns aggregated read / write / range entries.
- ValidateAndCommit handler wraps `LineairDB::Database::ValidateAndCommit`.

### Proxy (`proxy/lineairdb_proxy.{cc,hh}`, `proxy/lineairdb_transaction.{cc,hh}`, `proxy/ha_lineairdb.cc`)
- RPC clients for the new stateless / plan / validate messages.
- Oneshot-mode local view caches prefetched rows and ranges and merges them into subsequent proxy-local reads / scans during plan replay.
- `@_ldb_plan` DSL parser gated by the sysvar, statement-type check, and plan presence; any mid-transaction precondition failure falls back to the existing path.

### Test (`test/pytest/oneshot_plan.py`)
- Eight correctness cases covering scope of point prefetch, conflict abort, unique-secondary-index check, range clean commit, range phantom / tombstone aborts, secondary-index range clean commit, and secondary-index range phantom abort.

### Bench tooling
- `bench/bin/benchrun.py`: `--oneshot` flag, dashed goodput line on the throughput plot, `tpcc-np` benchmark choice.
- `bench/config/tpcc-np.xml`: NewOrder + Payment-only mix with a comment explaining the rationale (88% workload coverage, removed transactions are read-only or deferred, prior art reference).