### PR TITLE
refactor: rename oneshot to prefetch

### DIFF
--- a/ansible/benchbase.yml
+++ b/ansible/benchbase.yml
@@ -69,10 +69,10 @@
       delegate_to: "{{ groups['benchbase'][0] }}"
 
     - name: "Refresh MySQL stats with ANALYZE TABLE on each MySQL ({{ bench_type | upper }})"
-      # Oneshot mode requires MySQL's chosen plan to match the @_ldb_plan DSL.
+      # Prefetch mode requires MySQL's chosen plan to match the @_prefetch_plan DSL.
       # Without fresh stats, MySQL can pick PRIMARY for queries the DSL expects
       # to take via a secondary index (e.g. OrderStatus customerByNameSQL),
-      # leading to plan/DSL mismatch and infinite oneshot retry.
+      # leading to plan/DSL mismatch and infinite prefetch retry.
       shell: |
         {{ _mysql_bin }} -u root --protocol=TCP \
           -h {{ hostvars[item].private_ip }} -P 3307 \

--- a/ansible/measure.yml
+++ b/ansible/measure.yml
@@ -23,10 +23,10 @@
     bench_type: ycsb
     bench_profile: b
     bench_serial: "{{ bench_type == 'tpch' }}"
-    # Run BenchBase in Helios oneshot mode: SET GLOBAL lineairdb_oneshot_execution=ON
+    # Run BenchBase in Helios prefetch mode: SET GLOBAL lineairdb_prefetch_execution=ON
     # on every MySQL once per sweep, then prefix the BenchBase java invocation with
-    # HELIOS_ONESHOT_PLAN=1 so the TPC-C procedures inject @_ldb_plan hints.
-    bench_oneshot: false
+    # HELIOS_PREFETCH_PLAN=1 so the TPC-C procedures inject @_prefetch_plan hints.
+    bench_prefetch: false
 
     # -- Execution parameters --
     bench_time: 60
@@ -70,12 +70,12 @@
       loop_control:
         label: "{{ item }}"
 
-    - name: "Toggle lineairdb_oneshot_execution on each MySQL (={{ 'ON' if bench_oneshot | bool else 'OFF' }})"
+    - name: "Toggle lineairdb_prefetch_execution on each MySQL (={{ 'ON' if bench_prefetch | bool else 'OFF' }})"
       shell: |
         ~/helios/build/runtime_output_directory/mysql \
           -u root --protocol=TCP \
           -h {{ hostvars[item].private_ip }} -P 3307 \
-          -e "SET GLOBAL lineairdb_oneshot_execution={{ 'ON' if bench_oneshot | bool else 'OFF' }};"
+          -e "SET GLOBAL lineairdb_prefetch_execution={{ 'ON' if bench_prefetch | bool else 'OFF' }};"
       args:
         executable: /bin/bash
       run_once: true

--- a/ansible/measure_term.yml
+++ b/ansible/measure_term.yml
@@ -50,8 +50,8 @@
     dest="$out_dir/execute_{{ bench_term }}"
     mkdir -p "$dest"
     java_status=0
-    {% if bench_oneshot | default(false) | bool %}
-    export HELIOS_ONESHOT_PLAN=1
+    {% if bench_prefetch | default(false) | bool %}
+    export HELIOS_PREFETCH_PLAN=1
     {% endif %}
     output=$(java -jar benchbase.jar -b {{ bench_type }} -c "$CFG" \
       --create=false --load=false --execute=true 2>&1) || java_status=$?

--- a/ansible/py/bench_aws.py
+++ b/ansible/py/bench_aws.py
@@ -344,8 +344,8 @@ def run_benchmarks(args, run_id):
         exec_vars += f" bench_serial={'true' if args.bench_serial else 'false'}"
     if args.bench_profile:
         exec_vars += f" bench_profile={args.bench_profile}"
-    if args.bench_oneshot:
-        exec_vars += " bench_oneshot=true"
+    if args.bench_prefetch:
+        exec_vars += " bench_prefetch=true"
     if args.perf:
         exec_vars += " enable_perf=true"
 
@@ -491,7 +491,7 @@ def main():
 Examples:
   python3 py/bench_aws.py --bench-type ycsb --bench-profile b
   python3 py/bench_aws.py --bench-type tpcc --bench-terms 1,16,64,128
-  python3 py/bench_aws.py --bench-type tpcc --bench-oneshot --bench-terms 1,16,64,128
+  python3 py/bench_aws.py --bench-type tpcc --bench-prefetch --bench-terms 1,16,64,128
   python3 py/bench_aws.py --bench-type tpch --bench-scalefactor 0.1
   python3 py/bench_aws.py --bench-type tpch --bench-serial false --bench-terms 1,2,4,8 --bench-scalefactor 0.01
   python3 py/bench_aws.py --cleanup-only
@@ -507,10 +507,10 @@ Examples:
     parser.add_argument("--bench-profile", default=None, help="YCSB profile: a,b,c,e,f")
     parser.add_argument("--bench-serial", default=None, type=lambda x: x.lower() == "true",
                         help="TPC-H serial mode (true/false)")
-    parser.add_argument("--bench-oneshot", action="store_true",
-                        help="Run BenchBase in Helios oneshot mode "
-                             "(SET GLOBAL lineairdb_oneshot_execution=ON on every MySQL "
-                             "and HELIOS_ONESHOT_PLAN=1 env for the executor)")
+    parser.add_argument("--bench-prefetch", action="store_true",
+                        help="Run BenchBase in Helios prefetch mode "
+                             "(SET GLOBAL lineairdb_prefetch_execution=ON on every MySQL "
+                             "and HELIOS_PREFETCH_PLAN=1 env for the executor)")
     parser.add_argument("--perf", action="store_true", help="Enable perf profiling on lineairdb + mysql nodes")
 
     # AWS options
@@ -556,8 +556,8 @@ Examples:
     # Setup log directory: result/<run_id>/<machine_spec>/logs/
     global LOG_FILE
     run_id = datetime.now().strftime("%Y%m%d-%H%M%S")
-    if args.bench_oneshot:
-        run_id += "-oneshot"
+    if args.bench_prefetch:
+        run_id += "-prefetch"
     log_dir = ANSIBLE_DIR / "result" / run_id / machine_spec / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     LOG_FILE = open(log_dir / "bench_aws.log", "w")

--- a/bench/bin/benchrun.py
+++ b/bench/bin/benchrun.py
@@ -202,7 +202,7 @@ def _benchbase_plugin(benchmark):
     return "tpcc" if benchmark == "tpcc-np" else benchmark
 
 
-def run_benchbase(benchmark, config_path, create=False, load=False, execute=False, oneshot=False):
+def run_benchbase(benchmark, config_path, create=False, load=False, execute=False, prefetch=False):
     """Run BenchBase with given phases."""
     jar = BENCHBASE_DIR / "benchbase.jar"
     if not jar.exists():
@@ -212,7 +212,7 @@ def run_benchbase(benchmark, config_path, create=False, load=False, execute=Fals
     flags = f"--create={'true' if create else 'false'} --load={'true' if load else 'false'} --execute={'true' if execute else 'false'}"
     cmd = f"java -jar {jar} -b {_benchbase_plugin(benchmark)} -c {config_path} {flags}"
 
-    env = {**os.environ, "HELIOS_ONESHOT_PLAN": "1"} if oneshot else None
+    env = {**os.environ, "HELIOS_PREFETCH_PLAN": "1"} if prefetch else None
     result = subprocess.run(
         cmd, shell=True, cwd=BENCHBASE_DIR,
         capture_output=True, text=True, env=env,
@@ -354,11 +354,11 @@ def setup_benchmark(benchmark, config_path, mysql_host, mysql_port):
     if load_time:
         print(f"  Load time: {load_time:.1f}s")
 
-    # Oneshot mode requires MySQL's chosen plan to match the @_ldb_plan DSL.
+    # Prefetch mode requires MySQL's chosen plan to match the @_prefetch_plan DSL.
     # Without fresh stats, MySQL can pick PRIMARY for queries the DSL expects
     # to take via a secondary index (e.g. OrderStatus customerByNameSQL),
-    # leading to plan/DSL mismatch and infinite oneshot retry. Refresh stats
-    # unconditionally so stateful and oneshot runs see the same optimizer
+    # leading to plan/DSL mismatch and infinite prefetch retry. Refresh stats
+    # unconditionally so stateful and prefetch runs see the same optimizer
     # decisions.
     analyze_sql = {
         "tpcc":   "ANALYZE TABLE customer, district, history, item, new_order, oorder, order_line, stock, warehouse;",
@@ -373,7 +373,7 @@ def setup_benchmark(benchmark, config_path, mysql_host, mysql_port):
     return load_time
 
 
-def run_execute(benchmark, config_path, terminals, result_base, oneshot=False):
+def run_execute(benchmark, config_path, terminals, result_base, prefetch=False):
     """Run execute phase with metrics collection. Returns result dict."""
     print(f"\n{'='*50}")
     print(f"  {benchmark.upper()} | Terminals: {terminals}")
@@ -398,7 +398,7 @@ def run_execute(benchmark, config_path, terminals, result_base, oneshot=False):
     jar = BENCHBASE_DIR / "benchbase.jar"
     bb_cmd = ["java", "-jar", str(jar), "-b", _benchbase_plugin(benchmark), "-c", str(config_path),
               "--create=false", "--load=false", "--execute=true"]
-    env = {**os.environ, "HELIOS_ONESHOT_PLAN": "1"} if oneshot else None
+    env = {**os.environ, "HELIOS_PREFETCH_PLAN": "1"} if prefetch else None
     bb_proc = subprocess.Popen(bb_cmd, cwd=BENCHBASE_DIR, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env)
     # bb_proc.pid IS the java process (no shell wrapper)
     f = open(metrics_dir / "pidstat-bench.log", "w")
@@ -694,9 +694,9 @@ def main():
                         help="Skip auto start/stop of lineairdb-server and mysqld (assume already running)")
     parser.add_argument("--keep-lineairdb-logs", action="store_true",
                         help="Keep lineairdb_logs after the benchmark")
-    parser.add_argument("--oneshot", action="store_true",
-                        help="Enable Oneshot path: SET GLOBAL lineairdb_oneshot_execution=ON and "
-                             "pass HELIOS_ONESHOT_PLAN=1 to BenchBase (TPC-C procedures inject @_ldb_plan)")
+    parser.add_argument("--prefetch", action="store_true",
+                        help="Enable Prefetch path: SET GLOBAL lineairdb_prefetch_execution=ON and "
+                             "pass HELIOS_PREFETCH_PLAN=1 to BenchBase (TPC-C procedures inject @_prefetch_plan)")
     args = parser.parse_args()
 
     # Validate
@@ -811,11 +811,11 @@ def main():
 
 def _run_bench(args, config_work, thread_list, result_base):
     """Setup + execute sweep + summary + plots. Extracted so main() can wrap it."""
-    # Toggle Oneshot sysvar explicitly to avoid stale state from prior runs.
-    oneshot_value = "ON" if args.oneshot else "OFF"
-    print(f"  Setting lineairdb_oneshot_execution={oneshot_value}")
+    # Toggle Prefetch sysvar explicitly to avoid stale state from prior runs.
+    prefetch_value = "ON" if args.prefetch else "OFF"
+    print(f"  Setting lineairdb_prefetch_execution={prefetch_value}")
     mysql_cmd(args.mysql_port, args.mysql_host,
-              f"SET GLOBAL lineairdb_oneshot_execution={oneshot_value};")
+              f"SET GLOBAL lineairdb_prefetch_execution={prefetch_value};")
 
     # Setup phase
     load_time = None
@@ -844,7 +844,7 @@ def _run_bench(args, config_work, thread_list, result_base):
     # Execute: sweep terminal counts (data is reused)
     all_results = []
     for terminals in thread_list:
-        result = run_execute(args.benchmark, config_work, terminals, result_base, oneshot=args.oneshot)
+        result = run_execute(args.benchmark, config_work, terminals, result_base, prefetch=args.prefetch)
         if result:
             result["load_time"] = load_time
             all_results.append(result)

--- a/bench/bin/fair_sweep.sh
+++ b/bench/bin/fair_sweep.sh
@@ -6,7 +6,7 @@
 # runs.
 #
 # Usage:
-#   fair_sweep.sh [--mode oneshot|stateful] [--sf N] [--time S] [--terms LIST]
+#   fair_sweep.sh [--mode prefetch|stateful] [--sf N] [--time S] [--terms LIST]
 #                 [--label TAG]
 #
 # Output:
@@ -18,7 +18,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPTS="$ROOT/scripts"
 
-MODE=oneshot          # oneshot | stateful
+MODE=prefetch          # prefetch | stateful
 SF=1
 TIME=30
 TERMS="1,4,16,32,64,128,256,384,512"
@@ -37,7 +37,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ "$MODE" =~ ^(oneshot|stateful)$ ]] || { echo "Invalid --mode" >&2; exit 2; }
+[[ "$MODE" =~ ^(prefetch|stateful)$ ]] || { echo "Invalid --mode" >&2; exit 2; }
 
 ts=$(date +%Y%m%d_%H%M%S)
 tag="${LABEL:+${LABEL}-}${MODE}-sf${SF}"
@@ -46,8 +46,8 @@ mkdir -p "$OUT_DIR/log"
 SUMMARY="$OUT_DIR/summary.csv"
 echo "terminals,throughput,goodput,retry,wall_s,drain_s,load_s" > "$SUMMARY"
 
-ONESHOT_FLAG=""
-[[ "$MODE" == "oneshot" ]] && ONESHOT_FLAG="--oneshot"
+PREFETCH_FLAG=""
+[[ "$MODE" == "prefetch" ]] && PREFETCH_FLAG="--prefetch"
 
 echo "fair_sweep: mode=$MODE sf=$SF time=${TIME}s terms=$TERMS"
 echo "output: $OUT_DIR"
@@ -93,7 +93,7 @@ for term in "${TERM_LIST[@]}"; do
   set +e
   python3 "$ROOT/bench/bin/benchrun.py" tpcc \
     --terminals "$term" --time "$TIME" --scalefactor "$SF" \
-    --external-server $ONESHOT_FLAG \
+    --external-server $PREFETCH_FLAG \
     >>"$log" 2>&1
   rc=$?
   set -e

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -46,7 +46,7 @@ enum OpCode {
     TX_BATCH_READ = 25;
     TX_BATCH_WRITE = 26;
 
-    // Experimental one-shot operations
+    // Experimental prefetch operations
     TX_STATELESS_READ = 27;
     TX_STATELESS_BATCH_READ = 28;
     TX_VALIDATE_AND_COMMIT = 29;

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -257,7 +257,7 @@ static RangeScanLimit range_scan_limit_for_order(
 // LineairDB server connection target (GLOBAL sysvars backing storage)
 static char *srv_server_host = nullptr;
 static ulong srv_server_port = 9999;
-static bool srv_oneshot_execution = false;
+static bool srv_prefetch_execution = false;
 
 // THD-scoped context
 struct LineairDBThdCtx {
@@ -609,7 +609,7 @@ int ha_lineairdb::write_row(uchar *buf) {
 
   // Write secondary index entries.
   // Normal transactions check UNIQUE indexes immediately.
-  // Oneshot sends UNIQUE index writes to validate-and-commit with row writes.
+  // Prefetch sends UNIQUE index writes to validate-and-commit with row writes.
   for (uint i = 0; i < table->s->keys; i++) {
     auto key_info = table->key_info[i];
     if (i == table->s->primary_key) continue;
@@ -617,7 +617,7 @@ int ha_lineairdb::write_row(uchar *buf) {
     std::string secondary_key = build_secondary_key_from_row(buf, key_info);
 
     if (key_info.flags & HA_NOSAME) {
-      if (tx->is_oneshot_mode()) {
+      if (tx->is_prefetch_mode()) {
         tx->buffer_write_secondary_index(db_table_name, key_info.name,
                                          secondary_key, key);
       } else {
@@ -1157,8 +1157,8 @@ static bool item_is_limit_safe_filter(const Item *item) {
          item_is_limit_safe_scalar(args[1]);
 }
 
-// Enable Oneshot only for DML; DDL must keep the normal transaction path
-static bool thd_can_use_oneshot(THD *thd) {
+// Enable Prefetch only for DML; DDL must keep the normal transaction path
+static bool thd_can_use_prefetch(THD *thd) {
   if (thd == nullptr) return false;                  // Missing session
   if (thd->lex == nullptr) return false;             // Missing SQL state
 
@@ -1235,9 +1235,9 @@ static bool try_parse_plan_int(const std::string& text, int64_t *value) {
   return end == text.c_str() + text.size();
 }
 
-static bool thd_has_ldb_plan(THD *thd) {
+static bool thd_has_prefetch_plan(THD *thd) {
   if (thd == nullptr) return false;
-  auto it = thd->user_vars.find("_ldb_plan");
+  auto it = thd->user_vars.find("_prefetch_plan");
   if (it == thd->user_vars.end()) return false;
 
   auto *entry = it->second.get();
@@ -1437,12 +1437,12 @@ static std::vector<LineairDBProxy::ReadPlanStep> parse_plan_steps(
   return steps;
 }
 
-// Read @_ldb_plan once and clear it so the next statement starts clean
-static std::string read_and_clear_ldb_plan(THD *thd) {
+// Read @_prefetch_plan once and clear it so the next statement starts clean
+static std::string read_and_clear_prefetch_plan(THD *thd) {
   std::string plan;
   if (thd == nullptr) return plan;
 
-  auto it = thd->user_vars.find("_ldb_plan");
+  auto it = thd->user_vars.find("_prefetch_plan");
   if (it == thd->user_vars.end()) return plan;
 
   auto *entry = it->second.get();
@@ -1457,11 +1457,11 @@ static std::string read_and_clear_ldb_plan(THD *thd) {
   return plan;
 }
 
-static void execute_oneshot_plan_if_present(THD *thd,
+static void execute_prefetch_plan_if_present(THD *thd,
                                             LineairDBTransaction *tx) {
-  if (tx == nullptr || !tx->is_oneshot_mode()) return;
+  if (tx == nullptr || !tx->is_prefetch_mode()) return;
 
-  const std::string plan_text = read_and_clear_ldb_plan(thd);
+  const std::string plan_text = read_and_clear_prefetch_plan(thd);
   if (plan_text.empty()) return;
 
   const auto steps = parse_plan_steps(thd, plan_text);
@@ -2093,14 +2093,14 @@ LineairDBTransaction *&ha_lineairdb::get_transaction(THD *thd) {
   if (ctx->tx == nullptr) {
     ctx->tx =
         new LineairDBTransaction(thd, ctx->proxy.get(), lineairdb_hton, FENCE);
-    const bool can_use_oneshot =
-        (srv_oneshot_execution && thd_can_use_oneshot(thd) &&
-         thd_has_ldb_plan(thd));
-    ctx->tx->set_oneshot_mode(can_use_oneshot);
+    const bool can_use_prefetch =
+        (srv_prefetch_execution && thd_can_use_prefetch(thd) &&
+         thd_has_prefetch_plan(thd));
+    ctx->tx->set_prefetch_mode(can_use_prefetch);
   }
   if (ctx->tx->is_not_started()) {
     ctx->tx->begin_transaction();
-    execute_oneshot_plan_if_present(thd, ctx->tx);
+    execute_prefetch_plan_if_present(thd, ctx->tx);
   }
   return ctx->tx;
 }
@@ -3955,15 +3955,15 @@ static MYSQL_SYSVAR_STR(server_host, srv_server_host,
 static MYSQL_SYSVAR_ULONG(server_port, srv_server_port, PLUGIN_VAR_RQCMDARG,
                           "LineairDB server TCP port.", nullptr, nullptr, 9999,
                           1, 65535, 0);
-static MYSQL_SYSVAR_BOOL(oneshot_execution, srv_oneshot_execution,
+static MYSQL_SYSVAR_BOOL(prefetch_execution, srv_prefetch_execution,
                          PLUGIN_VAR_OPCMDARG,
-                         "Enable experimental one-shot execution.", nullptr,
+                         "Enable experimental prefetch execution.", nullptr,
                          nullptr, false);
 
 static SYS_VAR *lineairdb_system_variables[] = {
     MYSQL_SYSVAR(server_host),
     MYSQL_SYSVAR(server_port),
-    MYSQL_SYSVAR(oneshot_execution),
+    MYSQL_SYSVAR(prefetch_execution),
     MYSQL_SYSVAR(enum_var),
     MYSQL_SYSVAR(ulong_var),
     MYSQL_SYSVAR(double_var),

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -75,7 +75,7 @@ enum class MessageType : uint32_t {
     TX_BATCH_READ = 25,
     TX_BATCH_WRITE = 26,
 
-    // Experimental one-shot operations
+    // Experimental prefetch operations
     TX_STATELESS_READ = 27,
     TX_STATELESS_BATCH_READ = 28,
     TX_VALIDATE_AND_COMMIT = 29,

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -106,10 +106,10 @@ LineairDBTransaction::read(std::string key) {
     return {reinterpret_cast<const std::byte*>(last_read_value_.data()), last_read_value_.size()};
   }
 
-  // Normal path misses go to the server; oneshot plans must prefetch them
+  // Normal path misses go to the server; prefetch plans must prefetch them
   rpc_trace_.record_local_view("read_miss");
-  if (oneshot_mode_) {
-    rpc_trace_.record_local_view("abort_oneshot_read_miss");
+  if (prefetch_mode_) {
+    rpc_trace_.record_local_view("abort_prefetch_read_miss");
     is_aborted_ = true;
     return std::pair<const std::byte *const, const size_t>{nullptr, 0};
   }
@@ -155,9 +155,9 @@ LineairDBTransaction::batch_read(const std::vector<std::string>& keys) {
     rpc_keys.push_back(keys[i]);
   }
 
-  // Oneshot plans must fetch every key up front; misses mean the plan is short
-  if (oneshot_mode_ && !rpc_keys.empty()) {
-    rpc_trace_.record_local_view("abort_oneshot_batch_miss");
+  // Prefetch plans must fetch every key up front; misses mean the plan is short
+  if (prefetch_mode_ && !rpc_keys.empty()) {
+    rpc_trace_.record_local_view("abort_prefetch_batch_miss");
     is_aborted_ = true;
     return pairs;
   }
@@ -184,7 +184,7 @@ LineairDBTransaction::batch_read(const std::vector<std::string>& keys) {
 
 void LineairDBTransaction::prefetch_stateless_reads(
     const std::vector<LineairDBProxy::StatelessReadKey>& reads) {
-  if (!oneshot_mode_ || reads.empty()) return;
+  if (!prefetch_mode_ || reads.empty()) return;
 
   std::vector<LineairDBProxy::StatelessReadKey> rpc_reads;
   rpc_reads.reserve(reads.size());
@@ -230,7 +230,7 @@ void LineairDBTransaction::prefetch_stateless_reads(
 
 void LineairDBTransaction::execute_read_plan(
     const std::vector<LineairDBProxy::ReadPlanStep>& steps) {
-  if (!oneshot_mode_ || steps.empty()) return;
+  if (!prefetch_mode_ || steps.empty()) return;
 
   rpc_trace_.record_local_view("plan_request:steps=" +
                                std::to_string(steps.size()));
@@ -315,7 +315,7 @@ void LineairDBTransaction::execute_read_plan(
 bool LineairDBTransaction::batch_write(
     const std::string& table_name,
     const std::vector<LineairDBProxy::BatchOp>& ops) {
-  if (oneshot_mode_) {
+  if (prefetch_mode_) {
     for (auto op : ops) {
       if (op.table_name.empty()) op.table_name = table_name;
       if (op.type == LineairDBProxy::BatchOp::Type::Write) {
@@ -368,7 +368,7 @@ LineairDBTransaction::get_matching_keys(std::string first_key_part) {
 
 bool LineairDBTransaction::write(std::string key, const std::string value) {
   if (table_is_not_chosen()) return false;
-  if (oneshot_mode_) {
+  if (prefetch_mode_) {
     buffer_write(db_table_key, key, value);
     return true;
   }
@@ -380,7 +380,7 @@ bool LineairDBTransaction::write(std::string key, const std::string value) {
 
 bool LineairDBTransaction::delete_value(std::string key) {
   if (table_is_not_chosen()) return false;
-  if (oneshot_mode_) {
+  if (prefetch_mode_) {
     buffer_delete(db_table_key, key);
     return true;
   }
@@ -396,7 +396,7 @@ std::vector<std::string>
 LineairDBTransaction::read_secondary_index(std::string index_name,
                                            std::string secondary_key) {
   if (table_is_not_chosen()) return {};
-  if (oneshot_mode_) {
+  if (prefetch_mode_) {
     const std::string end_key = next_lexicographic_key(secondary_key);
     if (end_key.empty()) {
       rpc_trace_.record_local_view("abort_secondary_key_end");
@@ -417,7 +417,7 @@ bool LineairDBTransaction::write_secondary_index(std::string index_name,
                                                  std::string secondary_key,
                                                  const std::string primary_key) {
   if (table_is_not_chosen()) return false;
-  if (oneshot_mode_) {
+  if (prefetch_mode_) {
     buffer_write_secondary_index(db_table_key, index_name, secondary_key,
                                  primary_key);
     return true;
@@ -430,7 +430,7 @@ bool LineairDBTransaction::delete_secondary_index(std::string index_name,
                                                   std::string secondary_key,
                                                   const std::string primary_key) {
   if (table_is_not_chosen()) return false;
-  if (oneshot_mode_) {
+  if (prefetch_mode_) {
     buffer_delete_secondary_index(db_table_key, index_name, secondary_key,
                                   primary_key);
     return true;
@@ -444,7 +444,7 @@ bool LineairDBTransaction::update_secondary_index(std::string index_name,
                                                   std::string new_secondary_key,
                                                   const std::string primary_key) {
   if (table_is_not_chosen()) return false;
-  if (oneshot_mode_) {
+  if (prefetch_mode_) {
     buffer_delete_secondary_index(db_table_key, index_name, old_secondary_key,
                                   primary_key);
     buffer_write_secondary_index(db_table_key, index_name, new_secondary_key,
@@ -461,7 +461,7 @@ std::vector<std::string>
 LineairDBTransaction::get_matching_keys_in_range(std::string start_key,
                                                  std::string end_key) {
   if (table_is_not_chosen()) return {};
-  if (oneshot_mode_) {
+  if (prefetch_mode_) {
     if (auto cached =
             lookup_local_range_scan(db_table_key, start_key, end_key, false, 0)) {
       std::vector<std::pair<std::string, std::string>> rows = cached->rows;
@@ -484,7 +484,7 @@ LineairDBTransaction::get_matching_keys_in_range(std::string start_key,
       return keys;
     }
 
-    rpc_trace_.record_local_view("abort_oneshot_pk_key_scan_miss");
+    rpc_trace_.record_local_view("abort_prefetch_pk_key_scan_miss");
     is_aborted_ = true;
     return {};
   }
@@ -501,7 +501,7 @@ LineairDBTransaction::get_matching_keys_and_values_in_range(std::string start_ke
                                                             uint64_t row_limit,
                                                             bool reverse_scan) {
   if (table_is_not_chosen()) return {};
-  if (oneshot_mode_) {
+  if (prefetch_mode_) {
     if (auto cached = lookup_local_range_scan(
             db_table_key, start_key, end_key, reverse_scan, row_limit)) {
       std::vector<std::pair<std::string, std::string>> pairs = cached->rows;
@@ -523,7 +523,7 @@ LineairDBTransaction::get_matching_keys_and_values_in_range(std::string start_ke
       return pairs;
     }
 
-    rpc_trace_.record_local_view("abort_oneshot_pk_value_scan_miss:" +
+    rpc_trace_.record_local_view("abort_prefetch_pk_value_scan_miss:" +
                                  std::to_string(start_key.size()) + ":" +
                                  std::to_string(end_key.size()));
     is_aborted_ = true;
@@ -554,7 +554,7 @@ LineairDBTransaction::get_matching_keys_and_values_in_range(std::string start_ke
 std::vector<std::pair<std::string, std::string>>
 LineairDBTransaction::get_matching_keys_and_values_from_prefix(std::string prefix) {
   if (table_is_not_chosen()) return {};
-  if (oneshot_mode_) {
+  if (prefetch_mode_) {
     const std::string prefix_end = next_lexicographic_key(prefix);
     if (prefix_end.empty()) {
       rpc_trace_.record_local_view("abort_pk_prefix_end");
@@ -621,7 +621,7 @@ LineairDBTransaction::get_matching_primary_keys_in_range(std::string index_name,
                                                          std::string start_key,
                                                          std::string end_key) {
   if (table_is_not_chosen()) return {};
-  if (oneshot_mode_) {
+  if (prefetch_mode_) {
     if (has_pending_secondary_ops_for_index(db_table_key, index_name)) {
       rpc_trace_.record_local_view("abort_secondary_scan_after_secondary_write:" +
                                    index_name);
@@ -638,7 +638,7 @@ LineairDBTransaction::get_matching_primary_keys_in_range(std::string index_name,
       return cached->primary_keys;
     }
 
-    rpc_trace_.record_local_view("abort_oneshot_secondary_scan_miss:" +
+    rpc_trace_.record_local_view("abort_prefetch_secondary_scan_miss:" +
                                  index_name + ":" +
                                  std::to_string(start_key.size()) + ":" +
                                  std::to_string(end_key.size()));
@@ -656,7 +656,7 @@ std::vector<std::string>
 LineairDBTransaction::get_matching_primary_keys_from_prefix(std::string index_name,
                                                             std::string prefix) {
   if (table_is_not_chosen()) return {};
-  if (oneshot_mode_) {
+  if (prefetch_mode_) {
     const std::string prefix_end = next_lexicographic_key(prefix);
     if (prefix_end.empty()) {
       rpc_trace_.record_local_view("abort_secondary_prefix_end");
@@ -734,7 +734,7 @@ void LineairDBTransaction::buffer_write(const std::string& table_name,
   write_buffer_ops_.push_back(std::move(op));
   record_local_write(table_name, key, true, value);
 
-  if (!oneshot_mode_ && write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
+  if (!prefetch_mode_ && write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
     flush_write_buffer();
   }
 }
@@ -752,7 +752,7 @@ void LineairDBTransaction::buffer_write_secondary_index(const std::string& table
   write_buffer_ops_.push_back(std::move(op));
   drop_local_secondary_scans(table_name, index_name);
 
-  if (!oneshot_mode_ && write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
+  if (!prefetch_mode_ && write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
     flush_write_buffer();
   }
 }
@@ -766,7 +766,7 @@ void LineairDBTransaction::buffer_delete(const std::string& table_name,
   write_buffer_ops_.push_back(std::move(op));
   record_local_write(table_name, key, false, ""); // value unused when not found
 
-  if (!oneshot_mode_ && write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
+  if (!prefetch_mode_ && write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
     flush_write_buffer();
   }
 }
@@ -785,14 +785,14 @@ void LineairDBTransaction::buffer_delete_secondary_index(
   write_buffer_ops_.push_back(std::move(op));
   drop_local_secondary_scans(table_name, index_name);
 
-  if (!oneshot_mode_ && write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
+  if (!prefetch_mode_ && write_buffer_ops_.size() >= WRITE_BATCH_SIZE) {
     flush_write_buffer();
   }
 }
 
 bool LineairDBTransaction::flush_write_buffer() {
   if (write_buffer_ops_.empty()) return true;
-  if (oneshot_mode_) return true;
+  if (prefetch_mode_) return true;
   if (is_aborted_) {
     write_buffer_ops_.clear();
     return false;
@@ -806,7 +806,7 @@ bool LineairDBTransaction::flush_write_buffer() {
 bool LineairDBTransaction::flush_write_buffer_for_table(
     const std::string& table_name) {
   if (write_buffer_ops_.empty()) return true;
-  if (oneshot_mode_) return true;
+  if (prefetch_mode_) return true;
   if (is_aborted_) {
     write_buffer_ops_.clear();
     return false;
@@ -1183,30 +1183,30 @@ LineairDBTransaction::lookup_local_secondary_scan(
 }
 
 bool LineairDBTransaction::fallback_to_normal_transaction(const char* reason) {
-  if (!oneshot_mode_) return true;
+  if (!prefetch_mode_) return true;
 
   // A clean transaction can still switch to the normal scan-capable path
-  const bool has_oneshot_state =
+  const bool has_prefetch_state =
       !stateless_read_set_.empty() || !write_buffer_ops_.empty() ||
       !rowcount_deltas_.empty() || !local_read_set_.empty() ||
       !local_write_set_.empty() || !range_validation_set_.empty() ||
       !index_validation_set_.empty() || !local_range_scans_.empty() ||
       !local_secondary_scans_.empty();
-  if (!has_oneshot_state) {
-    oneshot_mode_ = false;
-    oneshot_registered_ = false;
+  if (!has_prefetch_state) {
+    prefetch_mode_ = false;
+    prefetch_registered_ = false;
     begin_transaction();
     return !is_aborted_;
   }
 
   // Mixing stateless point reads with scans would need phantom tracking
-  LOG_WARNING("Oneshot fallback blocked by prior local state: %s", reason);
+  LOG_WARNING("Prefetch fallback blocked by prior local state: %s", reason);
   rpc_trace_.record_local_view(std::string("abort_fallback_") + reason);
   is_aborted_ = true;
   return false;
 }
 
-bool LineairDBTransaction::oneshot_validate_and_commit() {
+bool LineairDBTransaction::prefetch_validate_and_commit() {
   bool was_aborted = is_aborted_;
 
   std::vector<LineairDBProxy::StatelessReadKey> reads;
@@ -1276,8 +1276,8 @@ void LineairDBTransaction::begin_transaction() {
   rpc_trace_.start(-1, std::this_thread::get_id());
   lineairdb_proxy->set_current_trace(&rpc_trace_);
 
-  if (oneshot_mode_) {
-    oneshot_registered_ = true;
+  if (prefetch_mode_) {
+    prefetch_registered_ = true;
     is_aborted_ = false;
     if (thd_is_transaction()) {
       isTransaction = true;
@@ -1305,7 +1305,7 @@ void LineairDBTransaction::begin_transaction() {
 }
 
 void LineairDBTransaction::set_status_to_abort() {
-  if (oneshot_mode_ || tx_id == -1) {
+  if (prefetch_mode_ || tx_id == -1) {
     is_aborted_ = true;
     return;
   }
@@ -1317,8 +1317,8 @@ void LineairDBTransaction::set_status_to_abort() {
 }
 
 bool LineairDBTransaction::end_transaction() {
-  if (oneshot_mode_) {
-    return oneshot_validate_and_commit();
+  if (prefetch_mode_) {
+    return prefetch_validate_and_commit();
   }
 
   assert(tx_id != -1);

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -90,14 +90,14 @@ public:
   void set_status_to_abort();
   bool end_transaction();
   void fence() const;
-  void set_oneshot_mode(bool enabled) { oneshot_mode_ = enabled; }
-  bool is_oneshot_mode() const { return oneshot_mode_; }
+  void set_prefetch_mode(bool enabled) { prefetch_mode_ = enabled; }
+  bool is_prefetch_mode() const { return prefetch_mode_; }
   void prefetch_stateless_reads(
       const std::vector<LineairDBProxy::StatelessReadKey>& reads);
   void execute_read_plan(const std::vector<LineairDBProxy::ReadPlanStep>& steps);
 
   inline bool is_not_started() const {
-    if (oneshot_mode_) return !oneshot_registered_;
+    if (prefetch_mode_) return !prefetch_registered_;
     if (tx_id == -1) return true;
     return false;
   }
@@ -144,8 +144,8 @@ private:
   bool isTransaction;
   handlerton* hton;
   bool isFence;
-  bool oneshot_mode_{false};
-  bool oneshot_registered_{false};
+  bool prefetch_mode_{false};
+  bool prefetch_registered_{false};
 
   // stores the last RPC read result to maintain data pointer validity
   std::string last_read_value_;
@@ -283,7 +283,7 @@ private:
       const std::string& table_name, const std::string& index_name,
       const std::string& start_key, const std::string& end_key,
       bool reverse_scan, uint64_t row_limit) const;
-  bool oneshot_validate_and_commit();
+  bool prefetch_validate_and_commit();
   bool thd_is_transaction() const;
   void register_transaction_to_mysql();
   void register_single_statement_to_mysql();

--- a/server/protocol/message.hh
+++ b/server/protocol/message.hh
@@ -53,7 +53,7 @@ enum class MessageType : uint32_t {
     TX_BATCH_READ = 25,
     TX_BATCH_WRITE = 26,
 
-    // Experimental one-shot operations
+    // Experimental prefetch operations
     TX_STATELESS_READ = 27,
     TX_STATELESS_BATCH_READ = 28,
     TX_VALIDATE_AND_COMMIT = 29,

--- a/test/pytest/prefetch_plan.py
+++ b/test/pytest/prefetch_plan.py
@@ -7,7 +7,7 @@ import mysql.connector
 from utils.connection import get_connection
 
 
-DBNAME = f"ha_lineairdb_oneshot_plan_{int(time.time())}"
+DBNAME = f"ha_lineairdb_prefetch_plan_{int(time.time())}"
 
 
 def reset(cursor, db):
@@ -26,7 +26,7 @@ def expect_commit_error(cursor):
 
 
 def test_prefetch_scope(cursor, db):
-    print("ONESHOT PLAN PREFETCH SCOPE TEST")
+    print("PREFETCH PLAN PREFETCH SCOPE TEST")
     cursor.execute(
         "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT NOT NULL) "
         "ENGINE=LineairDB"
@@ -34,8 +34,8 @@ def test_prefetch_scope(cursor, db):
     cursor.execute("INSERT INTO t VALUES (1,100),(2,200),(3,300)")
     db.commit()
 
-    cursor.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
-    cursor.execute("SET @_ldb_plan='R:t:1;R:t:2;R:t:3'")
+    cursor.execute("SET GLOBAL lineairdb_prefetch_execution=ON")
+    cursor.execute("SET @_prefetch_plan='R:t:1;R:t:2;R:t:3'")
     cursor.execute("START TRANSACTION")
     cursor.execute("SELECT v FROM t WHERE id=1")
     if cursor.fetchone()[0] != 100:
@@ -47,7 +47,7 @@ def test_prefetch_scope(cursor, db):
     db.commit()
 
     # A new transaction gets a fresh plan and must read the latest value.
-    cursor.execute("SET @_ldb_plan='R:t:1'")
+    cursor.execute("SET @_prefetch_plan='R:t:1'")
     cursor.execute("START TRANSACTION")
     cursor.execute("SELECT v FROM t WHERE id=1")
     if cursor.fetchone()[0] != 777:
@@ -58,7 +58,7 @@ def test_prefetch_scope(cursor, db):
 
 
 def test_conflict_abort():
-    print("ONESHOT PLAN CONFLICT TEST")
+    print("PREFETCH PLAN CONFLICT TEST")
     a = get_connection(user=args.user, password=args.password)
     b = get_connection(user=args.user, password=args.password)
     ca = a.cursor()
@@ -66,8 +66,8 @@ def test_conflict_abort():
     try:
         ca.execute(f"USE {DBNAME}")
         cb.execute(f"USE {DBNAME}")
-        ca.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
-        ca.execute("SET @_ldb_plan='R:t:1'")
+        ca.execute("SET GLOBAL lineairdb_prefetch_execution=ON")
+        ca.execute("SET @_prefetch_plan='R:t:1'")
         ca.execute("START TRANSACTION")
         ca.execute("SELECT v FROM t WHERE id=1")
         ca.fetchone()
@@ -95,7 +95,7 @@ def test_conflict_abort():
 
 
 def test_unique_commit_check(cursor, db):
-    print("ONESHOT PLAN UNIQUE SECONDARY TEST")
+    print("PREFETCH PLAN UNIQUE SECONDARY TEST")
     cursor.execute(
         "CREATE TABLE unique_c (id INT NOT NULL, c INT NOT NULL, "
         "PRIMARY KEY(id), UNIQUE KEY u_c(c)) ENGINE=LineairDB"
@@ -103,8 +103,8 @@ def test_unique_commit_check(cursor, db):
     cursor.execute("INSERT INTO unique_c VALUES (1,10)")
     db.commit()
 
-    cursor.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
-    cursor.execute("SET @_ldb_plan='R:t:2'")
+    cursor.execute("SET GLOBAL lineairdb_prefetch_execution=ON")
+    cursor.execute("SET @_prefetch_plan='R:t:2'")
     cursor.execute("START TRANSACTION")
     cursor.execute("SELECT v FROM t WHERE id=2")
     cursor.fetchone()
@@ -120,7 +120,7 @@ def test_unique_commit_check(cursor, db):
 
 
 def test_range_clean_commit(cursor, db):
-    print("ONESHOT PLAN RANGE CLEAN COMMIT TEST")
+    print("PREFETCH PLAN RANGE CLEAN COMMIT TEST")
     cursor.execute(
         "CREATE TABLE range_clean_t (id INT NOT NULL PRIMARY KEY, "
         "v INT NOT NULL) ENGINE=LineairDB"
@@ -128,8 +128,8 @@ def test_range_clean_commit(cursor, db):
     cursor.execute("INSERT INTO range_clean_t VALUES (1,1),(10,10),(20,20)")
     db.commit()
 
-    cursor.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
-    cursor.execute("SET @_ldb_plan='S:range_clean_t:10:E:30'")
+    cursor.execute("SET GLOBAL lineairdb_prefetch_execution=ON")
+    cursor.execute("SET @_prefetch_plan='S:range_clean_t:10:E:30'")
     cursor.execute("START TRANSACTION")
     cursor.execute(
         "SELECT id FROM range_clean_t FORCE INDEX(PRIMARY) "
@@ -143,7 +143,7 @@ def test_range_clean_commit(cursor, db):
 
 
 def test_range_phantom_abort():
-    print("ONESHOT PLAN RANGE PHANTOM TEST")
+    print("PREFETCH PLAN RANGE PHANTOM TEST")
     a = get_connection(user=args.user, password=args.password)
     b = get_connection(user=args.user, password=args.password)
     ca = a.cursor()
@@ -158,8 +158,8 @@ def test_range_phantom_abort():
         ca.execute("INSERT INTO range_t VALUES (1,1),(10,10),(20,20),(30,30)")
         a.commit()
 
-        ca.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
-        ca.execute("SET @_ldb_plan='S:range_t:10:E:30'")
+        ca.execute("SET GLOBAL lineairdb_prefetch_execution=ON")
+        ca.execute("SET @_prefetch_plan='S:range_t:10:E:30'")
         ca.execute("START TRANSACTION")
         ca.execute(
             "SELECT id FROM range_t FORCE INDEX(PRIMARY) "
@@ -186,7 +186,7 @@ def test_range_phantom_abort():
 
 
 def test_range_tombstone_reinsert_abort():
-    print("ONESHOT PLAN RANGE TOMBSTONE REINSERT TEST")
+    print("PREFETCH PLAN RANGE TOMBSTONE REINSERT TEST")
     a = get_connection(user=args.user, password=args.password)
     b = get_connection(user=args.user, password=args.password)
     ca = a.cursor()
@@ -204,8 +204,8 @@ def test_range_tombstone_reinsert_abort():
         ca.execute("DELETE FROM tombstone_t WHERE id=15")
         a.commit()
 
-        ca.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
-        ca.execute("SET @_ldb_plan='S:tombstone_t:10:E:30'")
+        ca.execute("SET GLOBAL lineairdb_prefetch_execution=ON")
+        ca.execute("SET @_prefetch_plan='S:tombstone_t:10:E:30'")
         ca.execute("START TRANSACTION")
         ca.execute(
             "SELECT id FROM tombstone_t FORCE INDEX(PRIMARY) "
@@ -232,7 +232,7 @@ def test_range_tombstone_reinsert_abort():
 
 
 def test_secondary_range_clean_commit(cursor, db):
-    print("ONESHOT PLAN SECONDARY RANGE CLEAN COMMIT TEST")
+    print("PREFETCH PLAN SECONDARY RANGE CLEAN COMMIT TEST")
     cursor.execute(
         "CREATE TABLE si_range_clean_t ("
         "id INT NOT NULL PRIMARY KEY, "
@@ -246,8 +246,8 @@ def test_secondary_range_clean_commit(cursor, db):
     )
     db.commit()
 
-    cursor.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
-    cursor.execute("SET @_ldb_plan='SI:si_range_clean_t:c_idx:10'")
+    cursor.execute("SET GLOBAL lineairdb_prefetch_execution=ON")
+    cursor.execute("SET @_prefetch_plan='SI:si_range_clean_t:c_idx:10'")
     cursor.execute("START TRANSACTION")
     cursor.execute(
         "SELECT id FROM si_range_clean_t FORCE INDEX(c_idx) "
@@ -261,7 +261,7 @@ def test_secondary_range_clean_commit(cursor, db):
 
 
 def test_secondary_range_phantom_abort():
-    print("ONESHOT PLAN SECONDARY RANGE PHANTOM TEST")
+    print("PREFETCH PLAN SECONDARY RANGE PHANTOM TEST")
     a = get_connection(user=args.user, password=args.password)
     b = get_connection(user=args.user, password=args.password)
     ca = a.cursor()
@@ -282,8 +282,8 @@ def test_secondary_range_phantom_abort():
         )
         a.commit()
 
-        ca.execute("SET GLOBAL lineairdb_oneshot_execution=ON")
-        ca.execute("SET @_ldb_plan='SI:si_range_t:c_idx:10'")
+        ca.execute("SET GLOBAL lineairdb_prefetch_execution=ON")
+        ca.execute("SET @_prefetch_plan='SI:si_range_t:c_idx:10'")
         ca.execute("START TRANSACTION")
         ca.execute(
             "SELECT id FROM si_range_t FORCE INDEX(c_idx) "


### PR DESCRIPTION
## Summary

- Rename the `oneshot` identifiers throughout the storage engine and bench tooling to their `prefetch` equivalents.
- Rename the `lineairdb_oneshot_execution` sysvar to `lineairdb_prefetch_execution`.
- Rename the `HELIOS_ONESHOT_PLAN` environment variable to `HELIOS_PREFETCH_PLAN`.
- Rename the `@_ldb_plan` session-variable DSL to `@_prefetch_plan`.
- Rename the BenchBase plan-injection hook from the `Ordo` codename to `setPrefetchPlan`.

## Why

`oneshot` was the internal working name for the single-round-trip read path; `Prefetch` is the external term for it (ship the read set, execute it in one RPC). Aligning the code, sysvar, environment variable, session DSL, and bench hooks with the published term removes the internal codenames (`oneshot`, `Ordo`, `ldb`) that an outside reader would not recognize. No behavior change.

## Details

- The sysvar is declared `MYSQL_SYSVAR_BOOL(prefetch_execution, ...)`, so MySQL exposes it as `lineairdb_prefetch_execution`.
- `benchrun.py` and the Ansible bench pipeline (`benchbase.yml`, `measure*.yml`, `bench_aws.py`, `fair_sweep.sh`) follow the env-var / flag rename.
- The pytest suite is renamed `oneshot_plan.py` → `prefetch_plan.py`.
- The BenchBase submodule is bumped to pick up the renamed hook.
