### PR TITLE
infra: enable the parallel TPC-H loader

### DIFF
--- a/bench/config/tpch.xml
+++ b/bench/config/tpch.xml
@@ -11,6 +11,9 @@
     <isolation>TRANSACTION_SERIALIZABLE</isolation>
     <batchsize>1024</batchsize>
 
+    <!-- Loader pool >= 3 + 5*tpch.load.shards; 128 covers up to 25 shards. -->
+    <loaderThreads>128</loaderThreads>
+
     <!-- Control scale factor to generate different amount of data -->
     <scalefactor>0.1</scalefactor>
 

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -265,7 +265,7 @@ private:
   std::string pushed_filter_;
 
   // Max number of buffered write/delete ops before an automatic flush
-  static constexpr size_t WRITE_BATCH_SIZE = 100;
+  static constexpr size_t WRITE_BATCH_SIZE = 1024;
   // Pending RPC flush queue for row and secondary-index ops in MySQL order
   std::vector<LineairDBProxy::BatchOp> write_buffer_ops_;
 


### PR DESCRIPTION
## Summary

- Bump the benchbase submodule to the sharded TPC-H loader on `research/helios`, which loads each big table on N parallel threads instead of one.
- Set `loaderThreads` to 128 in `bench/config/tpch.xml` to size the loader pool for shard counts up to 25.
- Raise the proxy `WRITE_BATCH_SIZE` from 100 to 1024 to match benchbase's JDBC batch.

## Why

The upstream loader loads each TPC-H table on a single thread, so a high-scale load is slow (lineitem is 6M rows at SF1) and most cores sit idle. The sharded loader fixes this, but two Helios-side settings have to match it: the benchbase loader pool must be large enough to run the shard threads, and the proxy must ship a bulk-load statement in one RPC instead of many small flushes.

## Details

- The benchbase bump shards each big table (part, customer, orders, partsupp, lineitem) into `N = availableProcessors()` threads over deterministic `(part, partCount)` chunks; tiny tables (region, nation, supplier) stay single-sharded. A per-table `CountDownLatch` keeps the FK parent-before-child order — a child table waits until all of its parent's shards finish. Override N with `-Dtpch.load.shards=N`.
- `loaderThreads = 128` covers the `3 + 5*N` threads the loader spawns for N up to 25; a smaller pool, or a larger N, stays correct but queues threads and serializes at the FK barriers.
- `WRITE_BATCH_SIZE = 1024` matches the JDBC batch, so a bulk-load statement ships in one `TxBatchWrite` RPC instead of ~10 mid-statement flushes (the load is RPC-round-trip bound).
- Measured at SF1: serial load (1 shard) 343s vs parallel (24 shards) 23s (~15x); table row counts and `lineitem` aggregates are identical to the serial load.