### PR TITLE
feat: expand staged prefetch read-plan execution

### DIFF
--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -204,6 +204,7 @@ message TxExecuteReadPlan {
         repeated KeyBinding end_bindings = 8;
         bool for_each = 9;
         bool reverse_scan = 10;
+        PushedPredicate filter = 11; // Optional row filter for staged scans.
     }
     message StepResult {
         bool found = 1;

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -216,6 +216,11 @@ message TxExecuteReadPlan {
         repeated bytes secondary_keys = 8;
         bytes actual_start_key = 9;
         bytes actual_end_key = 10;
+        // for_each range probes return one group per deduplicated start key.
+        // group_sizes[i] rows belong to [group_start_keys[i], group_end_keys[i]).
+        repeated uint32 group_sizes = 11;
+        repeated bytes group_start_keys = 12;
+        repeated bytes group_end_keys = 13;
     }
     message Request {
         repeated PlanStep steps = 1;

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -680,7 +680,7 @@ int ha_lineairdb::index_read_map(uchar *buf, const uchar *key,
   }
 
   // The optimizer has run, so the SELECT/generic-DML QEP is available.
-  if (int err = maybe_prefetch_for_statement(ha_thd(), tx)) return err;
+  if (int err = maybe_prefetch_for_statement(ha_thd(), tx, table)) return err;
 
   build_search_plan(key, keypart_map, find_flag, key_info);
 
@@ -904,7 +904,7 @@ int ha_lineairdb::rnd_init(bool) {
   // The optimizer has run, so the QEP is available.
   // Statement-scoped autogen stages and executes the prefetch plan once per
   // statement; an unsupported QEP fails here.
-  if (int err = maybe_prefetch_for_statement(ha_thd(), tx)) {
+  if (int err = maybe_prefetch_for_statement(ha_thd(), tx, table)) {
     DBUG_RETURN(err);
   }
 
@@ -1963,7 +1963,7 @@ int ha_lineairdb::multi_range_read_init(RANGE_SEQ_IF *seq, void *seq_init_param,
     // Legacy single-table DML has no QEP plan. Default DS-MRR reaches
     // read_range_first()->index_read_map(), where the complete bounds exist.
     if (!legacy_dml) {
-      if (int err = maybe_prefetch_for_statement(ha_thd(), tx)) return err;
+      if (int err = maybe_prefetch_for_statement(ha_thd(), tx, table)) return err;
     }
     if (tx->is_aborted()) {
       return abort_errno(tx);

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -136,6 +136,8 @@ static constexpr uint LDB_INDEX_UNIQUE = 1u;
 static char *srv_server_host = nullptr;
 static ulong srv_server_port = 9999;
 static bool srv_prefetch_execution = false;
+// Non-static: read by LineairDBTransaction at begin (see lineairdb_transaction.cc)
+bool srv_prefetch_ro_novalidate = false;
 
 // THD-scoped context
 struct LineairDBThdCtx {
@@ -2219,11 +2221,18 @@ static MYSQL_SYSVAR_BOOL(prefetch_execution, srv_prefetch_execution,
                          PLUGIN_VAR_OPCMDARG,
                          "Enable experimental prefetch execution.", nullptr,
                          nullptr, false);
+static MYSQL_SYSVAR_BOOL(
+    prefetch_ro_novalidate, srv_prefetch_ro_novalidate, PLUGIN_VAR_OPCMDARG,
+    "Skip commit-time read validation for autocommit read-only SELECT under "
+    "prefetch execution. Sound only without concurrent writers (e.g. "
+    "analytical read-only workloads); the commit RPC is omitted entirely.",
+    nullptr, nullptr, false);
 
 static SYS_VAR *lineairdb_system_variables[] = {
     MYSQL_SYSVAR(server_host),
     MYSQL_SYSVAR(server_port),
     MYSQL_SYSVAR(prefetch_execution),
+    MYSQL_SYSVAR(prefetch_ro_novalidate),
     MYSQL_SYSVAR(enum_var),
     MYSQL_SYSVAR(ulong_var),
     MYSQL_SYSVAR(double_var),

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -403,6 +403,11 @@ public:
   /** Predicate pushdown: serialize WHERE conditions for server-side filtering */
   const Item *cond_push(const Item *cond) override;
 
+  /** Table-local filter from cond_push(), for autogen scan-step pushdown. */
+  const std::string &pushed_filter_for_autogen() const {
+    return pushed_filter_serialized_;
+  }
+
 private:
   // Serialized PushedPredicate protobuf from cond_push()
   std::string pushed_filter_serialized_;

--- a/proxy/lineairdb_autogen.cc
+++ b/proxy/lineairdb_autogen.cc
@@ -21,6 +21,7 @@
 #include "sql/sql_optimizer.h"
 #include "sql/sql_opt_exec_shared.h"
 #include "sql/table.h"
+#include "storage/lineairdb/ha_lineairdb.hh"
 
 namespace {
 
@@ -829,7 +830,7 @@ bool compile_index_search(TABLE *table, uint index,
 }  // namespace
 
 bool autogen_read_plan_from_qep(
-    THD *thd, AccessPath *root,
+    THD *thd, AccessPath *root, bool allow_filter_pushdown,
     std::vector<LineairDBProxy::ReadPlanStep> *out) {
   if (out == nullptr) {
     return raise_unsupported(thd, "NONE", "null output vector");
@@ -877,6 +878,14 @@ bool autogen_read_plan_from_qep(
     std::string reason;
     if (!compile_leaf(leaf, table_steps, &step, &reason)) {
       return raise_unsupported(thd, leaf->type, reason);
+    }
+
+    // Push cond_push() only for full primary scans here. Validated commits
+    // need the full scanned key set, so this is gated by ro_novalidate.
+    if (allow_filter_pushdown && step.is_scan && !step.for_each &&
+        step.index_name.empty() && table->file != nullptr) {
+      step.serialized_filter =
+          down_cast<ha_lineairdb *>(table->file)->pushed_filter_for_autogen();
     }
 
     table_steps[table] = static_cast<int>(steps.size());

--- a/proxy/lineairdb_autogen.cc
+++ b/proxy/lineairdb_autogen.cc
@@ -171,7 +171,7 @@ void collect_qep_leaves(AccessPath *p, std::vector<AccessPath *> *out,
     case AccessPath::MRR:
       // MRR is BKA's inner-table access: a ref-like (table, ref) leaf whose ref
       // keyparts bind to the outer table, so compile_ref_lookup turns it into a
-      // for_each point probe (FER/FES still rejected there).
+      // for_each point/range probe.
       out->push_back(p);
       return;
     case AccessPath::NESTED_LOOP_JOIN:
@@ -232,6 +232,21 @@ void collect_qep_leaves(AccessPath *p, std::vector<AccessPath *> *out,
       return;
     case AccessPath::UPDATE_ROWS:
       collect_qep_leaves(p->update_rows().child, out, ok, unsupported);
+      return;
+    case AccessPath::WEEDOUT:
+      // Semijoin duplicate weedout dedups locally via handler rowids;
+      // position()/rnd_pos() re-reads hit the staged row cache.
+      collect_qep_leaves(p->weedout().child, out, ok, unsupported);
+      return;
+    case AccessPath::NESTED_LOOP_SEMIJOIN_WITH_DUPLICATE_REMOVAL:
+      collect_qep_leaves(p->nested_loop_semijoin_with_duplicate_removal().outer,
+                         out, ok, unsupported);
+      collect_qep_leaves(p->nested_loop_semijoin_with_duplicate_removal().inner,
+                         out, ok, unsupported);
+      return;
+    case AccessPath::ZERO_ROWS:
+      // The optimizer proved this subtree returns nothing; no rows will be
+      // read at runtime, so no prefetch step is needed.
       return;
     default:
       set_unsupported(p, "unsupported QEP node", ok, unsupported);
@@ -509,6 +524,34 @@ bool compile_ref_lookup(
     }
     auto source = table_steps.find(source_field->table);
     if (source == table_steps.end()) {
+      TABLE *src_table = source_field->table;
+      if (src_table->s != nullptr && src_table->s->tmp_table != NO_TMP_TABLE) {
+        // The probe key comes from a MySQL temp table, so it is unavailable
+        // during staging. Cover the runtime probe by staging the probed index.
+        const THD *leaf_thd = table->in_use;
+        const bool plain_select =
+            leaf_thd != nullptr && leaf_thd->lex != nullptr &&
+            leaf_thd->lex->sql_command == SQLCOM_SELECT &&
+            table->reginfo.lock_type <= TL_READ;
+        if (!plain_select) {
+          if (reason != nullptr) {
+            *reason = "temp-table-driven probe outside plain SELECT";
+          }
+          return false;
+        }
+        step->bindings.clear();
+        step->end_bindings.clear();
+        step->for_each = false;
+        step->is_scan = true;
+        step->key_prefix.clear();
+        step->end_key_prefix = lineairdb_keyenc::scan_end_sentinel();
+        if (ref->key == static_cast<int>(table->s->primary_key)) {
+          step->index_name.clear();
+        } else {
+          step->index_name = key.name;
+        }
+        return !step->table_name.empty();
+      }
       if (reason != nullptr) *reason = "bound source is not an earlier step";
       return false;
     }
@@ -544,20 +587,17 @@ bool compile_ref_lookup(
 
   if (bound_parts > 0) {
     step->for_each = true;
-    // The server executes for_each as a per-source-row point StatelessRead only
-    // (lineairdb_rpc.cc); a per-row range probe (FER, primary partial key) or
-    // secondary probe (FES) is not implemented. Require a full-primary-key point
-    // probe and reject anything that would need a range scan per source row.
     if (child_primary && used_key_parts >= child_pk_parts) {
+      // Full-primary-key point probe per source row.
       step->is_scan = false;
       return !step->table_name.empty();
     }
-    if (reason != nullptr) {
-      *reason = child_primary
-                    ? "for_each primary range probe (FER) unsupported by server"
-                    : "for_each secondary probe (FES) unsupported by server";
-    }
-    return false;
+    // Otherwise each source row drives a bounded range probe: a primary-prefix
+    // scan for partial primary keys, or a secondary-index scan for secondary
+    // refs. The server groups rows by deduplicated probe key.
+    step->is_scan = true;
+    if (!child_primary) step->index_name = key.name;
+    return !step->table_name.empty();
   }
 
   step->key_prefix = lineairdb_keyenc::convert_key_to_ldbformat(
@@ -612,11 +652,7 @@ bool compile_leaf(AccessPath *leaf,
     const bool plain_select = leaf_thd != nullptr && leaf_thd->lex != nullptr &&
                               leaf_thd->lex->sql_command == SQLCOM_SELECT &&
                               table->reginfo.lock_type <= TL_READ;
-    const bool primary_order =
-        full_scan_index < 0 ||
-        (table->s->primary_key != MAX_KEY &&
-         full_scan_index == static_cast<int>(table->s->primary_key));
-    if (!plain_select || !primary_order) {
+    if (!plain_select) {
       if (reason != nullptr) *reason = "full table/index scan unsupported";
       return false;
     }
@@ -625,9 +661,18 @@ bool compile_leaf(AccessPath *leaf,
       if (reason != nullptr) *reason = "missing leaf table name";
       return false;
     }
+    const bool primary_order =
+        full_scan_index < 0 ||
+        (table->s->primary_key != MAX_KEY &&
+         full_scan_index == static_cast<int>(table->s->primary_key));
     step->is_scan = true;
     step->key_prefix.clear();
     step->end_key_prefix = lineairdb_keyenc::scan_end_sentinel();
+    if (!primary_order) {
+      // Full secondary INDEX_SCAN: stage the secondary range itself. Runtime
+      // index_first/index_next consumes it, then base rows come from row cache.
+      step->index_name = table->key_info[full_scan_index].name;
+    }
     return true;
   }
   if (ref == nullptr) {
@@ -743,12 +788,17 @@ bool autogen_read_plan_from_qep(
     return raise_unsupported(thd, "NONE", "missing THD/LEX query unit");
   }
 
-  Query_block *query_block = thd->lex->unit->first_query_block();
-  if (query_block == nullptr || query_block->join == nullptr) {
-    return raise_unsupported(thd, "NONE", "missing query block JOIN");
+  // Prefer the unit-level plan root: for statements whose top level is a
+  // materialized set operation / aggregated subquery the per-block JOIN root
+  // is empty and the executable plan hangs off the query expression.
+  AccessPath *root = thd->lex->unit->root_access_path();
+  if (root == nullptr) {
+    Query_block *query_block = thd->lex->unit->first_query_block();
+    if (query_block == nullptr || query_block->join == nullptr) {
+      return raise_unsupported(thd, "NONE", "missing query block JOIN");
+    }
+    root = query_block->join->root_access_path();
   }
-
-  AccessPath *root = query_block->join->root_access_path();
   if (root == nullptr) {
     return raise_unsupported(thd, "NONE", "missing JOIN root_access_path");
   }

--- a/proxy/lineairdb_autogen.cc
+++ b/proxy/lineairdb_autogen.cc
@@ -208,6 +208,25 @@ void collect_qep_leaves(AccessPath *p, std::vector<AccessPath *> *out,
     case AccessPath::STREAM:
       collect_qep_leaves(p->stream().child, out, ok, unsupported);
       return;
+    case AccessPath::TEMPTABLE_AGGREGATE:
+      // MySQL can run GROUP BY by filling an internal temp table and reading it
+      // back. Prefetch only needs the LineairDB reads that feed that temp table;
+      // the temp-table leaves themselves are skipped in the compile loop.
+      collect_qep_leaves(p->temptable_aggregate().subquery_path, out, ok,
+                         unsupported);
+      collect_qep_leaves(p->temptable_aggregate().table_path, out, ok,
+                         unsupported);
+      return;
+    case AccessPath::MATERIALIZE:
+      // Derived tables and materialized subqueries have the same shape: the
+      // source subqueries may read LineairDB, but the materialized table is
+      // local to MySQL.
+      for (const MaterializePathParameters::QueryBlock &qb :
+           p->materialize().param->query_blocks) {
+        collect_qep_leaves(qb.subquery_path, out, ok, unsupported);
+      }
+      collect_qep_leaves(p->materialize().table_path, out, ok, unsupported);
+      return;
     case AccessPath::DELETE_ROWS:
       collect_qep_leaves(p->delete_rows().child, out, ok, unsupported);
       return;
@@ -757,6 +776,11 @@ bool autogen_read_plan_from_qep(
     if (!qep_leaf_info(leaf, &table, &ref, &full_scan, &full_scan_index) ||
         table == nullptr) {
       return raise_unsupported(thd, leaf->type, "unsupported QEP leaf");
+    }
+    if (table->s != nullptr && table->s->tmp_table != NO_TMP_TABLE) {
+      // Local MySQL temp tables are not stored in LineairDB, so there is
+      // nothing to prefetch for this leaf.
+      continue;
     }
     if (table_steps.find(table) != table_steps.end()) {
       return raise_unsupported(thd, leaf->type, "duplicate QEP table leaf");

--- a/proxy/lineairdb_autogen.cc
+++ b/proxy/lineairdb_autogen.cc
@@ -880,10 +880,9 @@ bool autogen_read_plan_from_qep(
       return raise_unsupported(thd, leaf->type, reason);
     }
 
-    // Push cond_push() only for full primary scans here. Validated commits
-    // need the full scanned key set, so this is gated by ro_novalidate.
-    if (allow_filter_pushdown && step.is_scan && !step.for_each &&
-        step.index_name.empty() && table->file != nullptr) {
+    // Attach scan filters only when the caller allows filtered read-plan
+    // results. Callers that need a complete scanned key set pass false.
+    if (allow_filter_pushdown && step.is_scan && table->file != nullptr) {
       step.serialized_filter =
           down_cast<ha_lineairdb *>(table->file)->pushed_filter_for_autogen();
     }

--- a/proxy/lineairdb_autogen.cc
+++ b/proxy/lineairdb_autogen.cc
@@ -588,12 +588,28 @@ bool compile_leaf(AccessPath *leaf,
     return compile_index_range_scan(leaf, table, step, reason);
   }
   if (full_scan) {
-    // A full TABLE_SCAN / INDEX_SCAN has no key bound, so the prefetched row set
-    // cannot be matched against what rnd_next iterates (scan consumption is only
-    // validated for bounded ranges). Reject under no-fallback rather than risk
-    // serving a mismatched row set.
-    if (reason != nullptr) *reason = "full table/index scan unsupported";
-    return false;
+    // Plain SELECT primary scans consume the staged ["", sentinel) range.
+    const THD *leaf_thd = table->in_use;
+    const bool plain_select = leaf_thd != nullptr && leaf_thd->lex != nullptr &&
+                              leaf_thd->lex->sql_command == SQLCOM_SELECT &&
+                              table->reginfo.lock_type <= TL_READ;
+    const bool primary_order =
+        full_scan_index < 0 ||
+        (table->s->primary_key != MAX_KEY &&
+         full_scan_index == static_cast<int>(table->s->primary_key));
+    if (!plain_select || !primary_order) {
+      if (reason != nullptr) *reason = "full table/index scan unsupported";
+      return false;
+    }
+    step->table_name = physical_table_key(table);
+    if (step->table_name.empty()) {
+      if (reason != nullptr) *reason = "missing leaf table name";
+      return false;
+    }
+    step->is_scan = true;
+    step->key_prefix.clear();
+    step->end_key_prefix = lineairdb_keyenc::scan_end_sentinel();
+    return true;
   }
   if (ref == nullptr) {
     if (reason != nullptr) *reason = "table access without ref or range bound";

--- a/proxy/lineairdb_autogen.cc
+++ b/proxy/lineairdb_autogen.cc
@@ -491,6 +491,13 @@ bool compile_ref_lookup(
   bool saw_binding = false;
   uint bound_parts = 0;
 
+  // First pass: validate shape (constants strictly before bindings) and
+  // collect the bound keyparts so we can pick a single iterating source.
+  struct BoundPart {
+    uint kp;
+    Item_field *item;
+  };
+  std::vector<BoundPart> bound_items;
   for (uint kp = 0; kp < ref->key_parts; ++kp) {
     Item *item = ref->items[kp];
     if (item == nullptr) {
@@ -517,17 +524,26 @@ bool compile_ref_lookup(
     }
 
     saw_binding = true;
-    Field *source_field = down_cast<Item_field *>(item)->field;
-    if (source_field == nullptr || source_field->table == nullptr) {
+    Item_field *item_field = down_cast<Item_field *>(item);
+    if (item_field->field == nullptr || item_field->field->table == nullptr) {
       if (reason != nullptr) *reason = "missing bound source field";
       return false;
     }
-    auto source = table_steps.find(source_field->table);
+    bound_items.push_back({kp, item_field});
+  }
+
+  // Pick one iterator source; equality remap covers key parts bound through
+  // other earlier tables.
+  TABLE *iter_table = nullptr;
+  int iter_step = -1;
+  for (const BoundPart &bp : bound_items) {
+    auto source = table_steps.find(bp.item->field->table);
     if (source == table_steps.end()) {
-      TABLE *src_table = source_field->table;
+      TABLE *src_table = bp.item->field->table;
       if (src_table->s != nullptr && src_table->s->tmp_table != NO_TMP_TABLE) {
-        // The probe key comes from a MySQL temp table, so it is unavailable
-        // during staging. Cover the runtime probe by staging the probed index.
+        // The probe key comes from a MySQL temp table, so staging cannot
+        // enumerate its values. Cover the runtime probe by staging the probed
+        // table/index as a full range.
         const THD *leaf_thd = table->in_use;
         const bool plain_select =
             leaf_thd != nullptr && leaf_thd->lex != nullptr &&
@@ -555,7 +571,42 @@ bool compile_ref_lookup(
       if (reason != nullptr) *reason = "bound source is not an earlier step";
       return false;
     }
-    if (!append_bound_keypart(table, ref, kp, source_field, source->second,
+    // Use the latest bound source as the probe iterator.
+    if (source->second > iter_step) {
+      iter_step = source->second;
+      iter_table = bp.item->field->table;
+    }
+  }
+
+  // Append every bound key part against the chosen iterator source.
+  for (const BoundPart &bp : bound_items) {
+    Field *source_field = bp.item->field;
+    if (source_field->table != iter_table) {
+      // This key part came from another table; find its equal field on the
+      // iterator table.
+      Item_equal *eq = bp.item->item_equal_all_join_nests != nullptr
+                           ? bp.item->item_equal_all_join_nests
+                           : bp.item->item_equal;
+      Field *remapped = nullptr;
+      if (eq != nullptr) {
+        Item_equal::FieldProxy proxy(eq);
+        for (Item_field &candidate : proxy) {
+          if (candidate.field != nullptr &&
+              candidate.field->table == iter_table) {
+            remapped = candidate.field;
+            break;
+          }
+        }
+      }
+      if (remapped == nullptr) {
+        if (reason != nullptr) {
+          *reason = "for_each binding spans multiple source steps";
+        }
+        return false;
+      }
+      source_field = remapped;
+    }
+    if (!append_bound_keypart(table, ref, bp.kp, source_field, iter_step,
                               step, reason)) {
       return false;
     }
@@ -778,27 +829,13 @@ bool compile_index_search(TABLE *table, uint index,
 }  // namespace
 
 bool autogen_read_plan_from_qep(
-    THD *thd, std::vector<LineairDBProxy::ReadPlanStep> *out) {
+    THD *thd, AccessPath *root,
+    std::vector<LineairDBProxy::ReadPlanStep> *out) {
   if (out == nullptr) {
     return raise_unsupported(thd, "NONE", "null output vector");
   }
   out->clear();
 
-  if (thd == nullptr || thd->lex == nullptr || thd->lex->unit == nullptr) {
-    return raise_unsupported(thd, "NONE", "missing THD/LEX query unit");
-  }
-
-  // Prefer the unit-level plan root: for statements whose top level is a
-  // materialized set operation / aggregated subquery the per-block JOIN root
-  // is empty and the executable plan hangs off the query expression.
-  AccessPath *root = thd->lex->unit->root_access_path();
-  if (root == nullptr) {
-    Query_block *query_block = thd->lex->unit->first_query_block();
-    if (query_block == nullptr || query_block->join == nullptr) {
-      return raise_unsupported(thd, "NONE", "missing query block JOIN");
-    }
-    root = query_block->join->root_access_path();
-  }
   if (root == nullptr) {
     return raise_unsupported(thd, "NONE", "missing JOIN root_access_path");
   }

--- a/proxy/lineairdb_autogen.hh
+++ b/proxy/lineairdb_autogen.hh
@@ -9,16 +9,26 @@ struct TABLE;
 #include "lineairdb_index_search.hh"
 #include "lineairdb_proxy.hh"
 
-// Auto-generate a statement-scoped prefetch read plan from the current
-// statement's MySQL QEP (JOIN::root_access_path()). Returns true with steps on
-// full success. On ANY unsupported QEP shape it raises my_error(...) and
-// returns false (NO fallback, NO best-effort coverage). Caller must fail the
-// statement when false.
-bool autogen_read_plan_from_qep(
-    THD *thd, std::vector<LineairDBProxy::ReadPlanStep> *out);
+struct AccessPath;
 
-// Auto-generate one statement-scoped prefetch step from the handler access
-// selected for legacy single-table UPDATE/DELETE.
+/**
+ * @brief Build a statement-scoped prefetch read plan from a QEP root.
+ *
+ * @details `root` may be the whole statement root, or a subquery unit root
+ * when MySQL evaluates the subquery before the statement plan is finalized.
+ *
+ * @note Unsupported QEP shapes raise my_error() and return false. Callers must
+ * fail the statement; this path intentionally has no best-effort fallback.
+ */
+bool autogen_read_plan_from_qep(
+    THD *thd, AccessPath *root, std::vector<LineairDBProxy::ReadPlanStep> *out);
+
+/**
+ * @brief Build one statement-scoped prefetch step from handler index access.
+ *
+ * @details Used for legacy single-table UPDATE/DELETE, where the handler
+ * supplies the selected index/range instead of a normal QEP root.
+ */
 bool autogen_read_plan_from_index_search(
     THD *thd, TABLE *table, uint index, const IndexSearchPlan &search,
     std::vector<LineairDBProxy::ReadPlanStep> *out);

--- a/proxy/lineairdb_autogen.hh
+++ b/proxy/lineairdb_autogen.hh
@@ -16,7 +16,7 @@ struct AccessPath;
  *
  * @details `root` may be the whole statement root, or a subquery unit root
  * when MySQL evaluates the subquery before the statement plan is finalized.
- * If `allow_filter_pushdown` is true, eligible primary scans carry the
+ * If `allow_filter_pushdown` is true, eligible scan steps carry the
  * table-local cond_push() filter.
  *
  * @note Unsupported QEP shapes raise my_error() and return false. Callers must

--- a/proxy/lineairdb_autogen.hh
+++ b/proxy/lineairdb_autogen.hh
@@ -16,12 +16,15 @@ struct AccessPath;
  *
  * @details `root` may be the whole statement root, or a subquery unit root
  * when MySQL evaluates the subquery before the statement plan is finalized.
+ * If `allow_filter_pushdown` is true, eligible primary scans carry the
+ * table-local cond_push() filter.
  *
  * @note Unsupported QEP shapes raise my_error() and return false. Callers must
  * fail the statement; this path intentionally has no best-effort fallback.
  */
 bool autogen_read_plan_from_qep(
-    THD *thd, AccessPath *root, std::vector<LineairDBProxy::ReadPlanStep> *out);
+    THD *thd, AccessPath *root, bool allow_filter_pushdown,
+    std::vector<LineairDBProxy::ReadPlanStep> *out);
 
 /**
  * @brief Build one statement-scoped prefetch step from handler index access.

--- a/proxy/lineairdb_prefetch.cc
+++ b/proxy/lineairdb_prefetch.cc
@@ -355,7 +355,7 @@ void maybe_prefetch_for_transaction(THD *thd,
 static int autogen_and_execute_prefetch(THD *thd, AccessPath *root,
                                         LineairDBTransaction *tx) {
   std::vector<LineairDBProxy::ReadPlanStep> steps;
-  if (!autogen_read_plan_from_qep(thd, root, &steps)) {
+  if (!autogen_read_plan_from_qep(thd, root, tx->ro_novalidate(), &steps)) {
     // autogen has already raised a my_error describing the unsupported shape.
     tx->set_status_to_abort();
     thd_mark_transaction_to_rollback(thd, 1);

--- a/proxy/lineairdb_prefetch.cc
+++ b/proxy/lineairdb_prefetch.cc
@@ -351,10 +351,11 @@ void maybe_prefetch_for_transaction(THD *thd,
   tx->execute_read_plan(steps);
 }
 
-// Build the read plan from the statement's QEP and run it in one prefetch RPC.
-static int autogen_and_execute_prefetch(THD *thd, LineairDBTransaction *tx) {
+// Build the read plan from the given QEP root and run it in one prefetch RPC.
+static int autogen_and_execute_prefetch(THD *thd, AccessPath *root,
+                                        LineairDBTransaction *tx) {
   std::vector<LineairDBProxy::ReadPlanStep> steps;
-  if (!autogen_read_plan_from_qep(thd, &steps)) {
+  if (!autogen_read_plan_from_qep(thd, root, &steps)) {
     // autogen has already raised a my_error describing the unsupported shape.
     tx->set_status_to_abort();
     thd_mark_transaction_to_rollback(thd, 1);
@@ -365,6 +366,34 @@ static int autogen_and_execute_prefetch(THD *thd, LineairDBTransaction *tx) {
   // Loads the prefetched rows into the local cache and validation sets.
   tx->execute_read_plan(steps);
   return tx->is_aborted() ? HA_ERR_LOCK_DEADLOCK : 0;
+}
+
+// Plan root of the whole statement. This can still be null while MySQL is
+// evaluating an uncorrelated subquery before the outer plan exists.
+static AccessPath *statement_plan_root(THD *thd) {
+  if (thd == nullptr || thd->lex == nullptr || thd->lex->unit == nullptr) {
+    return nullptr;
+  }
+  if (AccessPath *root = thd->lex->unit->root_access_path()) return root;
+  Query_block *qb = thd->lex->unit->first_query_block();
+  if (qb == nullptr || qb->join == nullptr) return nullptr;
+  return qb->join->root_access_path();
+}
+
+// Plan root of the query expression that owns `table`: the subquery being
+// evaluated when the statement-level root is not available yet.
+static AccessPath *table_unit_plan_root(TABLE *table) {
+  if (table == nullptr || table->pos_in_table_list == nullptr) return nullptr;
+  Query_block *qb = table->pos_in_table_list->query_block;
+  if (qb == nullptr) return nullptr;
+  Query_expression *unit = qb->master_query_expression();
+  if (unit != nullptr) {
+    if (AccessPath *root = unit->root_access_path()) return root;
+  }
+  if (qb->join != nullptr) {
+    if (AccessPath *root = qb->join->root_access_path()) return root;
+  }
+  return nullptr;
 }
 
 static void sync_autogen_statement(THD *thd, LineairDBTransaction *tx) {
@@ -430,23 +459,48 @@ static const char *legacy_dml_shape_rejection(THD *thd, TABLE *table) {
   return nullptr;
 }
 
-int maybe_prefetch_for_statement(THD *thd, LineairDBTransaction *tx) {
+int maybe_prefetch_for_statement(THD *thd, LineairDBTransaction *tx,
+                                 TABLE *table) {
   if (tx == nullptr || !tx->is_prefetch_mode()) return 0;  // not prefetch protocol
   if (tx->tx_plan_used()) return 0;                        // tx-scoped plan covers it
 
   sync_autogen_statement(thd, tx);
-  if (tx->autogen_stmt_resolved()) return 0;  // already done this statement
-  tx->mark_autogen_stmt_resolved();
 
-  // A read is imminent (called from rnd_init / index_read_map / ...). A command
-  // whose read side cannot be prefetched (e.g. INSERT ... SELECT) would miss and
-  // abort silently in prefetch mode, so fail loudly instead.
+  AccessPath *stmt_root = statement_plan_root(thd);
+  if (stmt_root != nullptr) {
+    if (tx->autogen_stmt_resolved()) return 0;  // already done this statement
+    tx->mark_autogen_stmt_resolved();
+
+    // A read is imminent (called from rnd_init / index_read_map / ...). A
+    // command whose read side cannot be prefetched (e.g. INSERT ... SELECT)
+    // would miss and abort silently in prefetch mode, so fail loudly instead.
+    if (!thd_can_use_prefetch(thd)) {
+      return prefetch_reject_unsupported(
+          thd, tx, "read-bearing statement is not prefetch-eligible");
+    }
+
+    return autogen_and_execute_prefetch(thd, stmt_root, tx);
+  }
+
+  // No statement root yet: MySQL is evaluating a subquery before the outer
+  // plan is built. Stage that subquery's own plan once; the full statement is
+  // still staged later when outer execution starts.
+  AccessPath *unit_root = table_unit_plan_root(table);
+  if (unit_root == nullptr) {
+    if (tx->autogen_stmt_resolved()) return 0;
+    tx->mark_autogen_stmt_resolved();
+    return prefetch_reject_unsupported(thd, tx,
+                                       "missing JOIN root_access_path");
+  }
+  if (tx->autogen_root_staged(unit_root)) return 0;
+  tx->mark_autogen_root_staged(unit_root);
+
   if (!thd_can_use_prefetch(thd)) {
     return prefetch_reject_unsupported(
         thd, tx, "read-bearing statement is not prefetch-eligible");
   }
 
-  return autogen_and_execute_prefetch(thd, tx);
+  return autogen_and_execute_prefetch(thd, unit_root, tx);
 }
 
 // Gate for the handler entry points: true when autogen must defer to the

--- a/proxy/lineairdb_prefetch.hh
+++ b/proxy/lineairdb_prefetch.hh
@@ -44,7 +44,8 @@ void maybe_prefetch_for_transaction(THD *thd,
  *         (e.g. a read miss), with no my_error. Propagate any non-zero return to
  *         fail the statement.
  */
-int maybe_prefetch_for_statement(THD *thd, LineairDBTransaction *tx);
+int maybe_prefetch_for_statement(THD *thd, LineairDBTransaction *tx,
+                                 TABLE *table);
 
 /**
  * @brief True when this statement must defer autogen until index_read_map()

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -4,6 +4,7 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <errno.h>
+#include <algorithm>
 #include <chrono>
 #include <cstring>
 #include <iostream>
@@ -391,7 +392,6 @@ LineairDBProxy::ReadPlanResult LineairDBProxy::tx_execute_read_plan(
     }
 
     LineairDB::Protocol::TxExecuteReadPlan::Request request;
-    LineairDB::Protocol::TxExecuteReadPlan::Response response;
     for (const auto& step : steps) {
         auto* out = request.add_steps();
         out->set_table_name(step.table_name);
@@ -431,38 +431,110 @@ LineairDBProxy::ReadPlanResult LineairDBProxy::tx_execute_read_plan(
         }
     }
 
-    if (!send_protobuf_message(request, response,
-                               MessageType::TX_EXECUTE_READ_PLAN)) {
+    // TxExecuteReadPlan responses can exceed protobuf's ~2GB message limit, so
+    // the server returns this response as flat binary.
+    std::string raw;
+    if (!send_protobuf_recv_binary(request, raw,
+                                   MessageType::TX_EXECUTE_READ_PLAN)) {
         LOG_ERROR("RPC failed: Failed to send execute read plan message to server");
         return result;
     }
 
-    result.ok = response.ok();
-    if (!result.ok) return result;
-    result.steps.reserve(response.results_size());
-    for (const auto& step : response.results()) {
+    struct Reader {
+        const char* p;
+        const char* end;
+        bool ok = true;
+        Reader(const char* data, size_t n) : p(data), end(data + n) {}
+        uint8_t u8() {
+            if (end - p < 1) {
+                ok = false;
+                return 0;
+            }
+            return static_cast<uint8_t>(*p++);
+        }
+        uint64_t u64() {
+            if (end - p < 8) {
+                ok = false;
+                return 0;
+            }
+            uint64_t v;
+            std::memcpy(&v, p, 8);
+            p += 8;
+            return v;
+        }
+        std::string bytes() {
+            const uint64_t n = u64();
+            if (!ok || static_cast<uint64_t>(end - p) < n) {
+                ok = false;
+                return {};
+            }
+            std::string out(p, n);
+            p += n;
+            return out;
+        }
+    };
+
+    // Native-endian bytes spell "LDBFLATP" (LineairDB flat payload).
+    static constexpr uint64_t kFlatMagic = 0x5054414C4642444Cull;
+    Reader r(raw.data(), raw.size());
+    if (r.u64() != kFlatMagic || r.u8() != 1) {
+        LOG_ERROR("RPC failed: bad flat read-plan response header");
+        return result;
+    }
+    const bool resp_ok = r.u8() != 0;
+    const uint64_t count = r.u64();
+    if (!r.ok) return result;
+    result.ok = resp_ok;
+    if (!resp_ok) return result;
+
+    // Cap reserves by the wire size: every encoded element costs at least one
+    // byte, so a corrupt count cannot force a huge allocation.
+    const auto cap = [&raw](uint64_t n) {
+        return static_cast<size_t>(std::min<uint64_t>(n, raw.size()));
+    };
+    result.steps.reserve(cap(count));
+    for (uint64_t i = 0; i < count && r.ok; ++i) {
         ReadPlanStepResult out;
-        out.found = step.found();
-        out.value = step.value();
-        out.tid = step.tid();
-        out.actual_key = step.actual_key();
-        out.actual_start_key = step.actual_start_key();
-        out.actual_end_key = step.actual_end_key();
-        out.scan_keys.reserve(step.scan_keys_size());
-        for (const auto& key : step.scan_keys()) out.scan_keys.push_back(key);
-        out.scan_values.reserve(step.scan_values_size());
-        for (const auto& value : step.scan_values()) out.scan_values.push_back(value);
-        out.scan_tids.reserve(step.scan_tids_size());
-        for (const auto tid : step.scan_tids()) out.scan_tids.push_back(tid);
-        out.secondary_keys.reserve(step.secondary_keys_size());
-        for (const auto& key : step.secondary_keys()) out.secondary_keys.push_back(key);
-        out.group_sizes.reserve(step.group_sizes_size());
-        for (const auto sz : step.group_sizes()) out.group_sizes.push_back(sz);
-        out.group_start_keys.reserve(step.group_start_keys_size());
-        for (const auto& key : step.group_start_keys()) out.group_start_keys.push_back(key);
-        out.group_end_keys.reserve(step.group_end_keys_size());
-        for (const auto& key : step.group_end_keys()) out.group_end_keys.push_back(key);
+        out.found = r.u8() != 0;
+        out.tid = r.u64();
+        out.value = r.bytes();
+        out.actual_key = r.bytes();
+        out.actual_start_key = r.bytes();
+        out.actual_end_key = r.bytes();
+        uint64_t n = r.u64();
+        out.scan_keys.reserve(cap(n));
+        for (uint64_t j = 0; j < n && r.ok; ++j)
+            out.scan_keys.push_back(r.bytes());
+        n = r.u64();
+        out.scan_values.reserve(cap(n));
+        for (uint64_t j = 0; j < n && r.ok; ++j)
+            out.scan_values.push_back(r.bytes());
+        n = r.u64();
+        out.scan_tids.reserve(cap(n));
+        for (uint64_t j = 0; j < n && r.ok; ++j)
+            out.scan_tids.push_back(r.u64());
+        n = r.u64();
+        out.secondary_keys.reserve(cap(n));
+        for (uint64_t j = 0; j < n && r.ok; ++j)
+            out.secondary_keys.push_back(r.bytes());
+        n = r.u64();
+        out.group_sizes.reserve(cap(n));
+        for (uint64_t j = 0; j < n && r.ok; ++j)
+            out.group_sizes.push_back(static_cast<uint32_t>(r.u64()));
+        n = r.u64();
+        out.group_start_keys.reserve(cap(n));
+        for (uint64_t j = 0; j < n && r.ok; ++j)
+            out.group_start_keys.push_back(r.bytes());
+        n = r.u64();
+        out.group_end_keys.reserve(cap(n));
+        for (uint64_t j = 0; j < n && r.ok; ++j)
+            out.group_end_keys.push_back(r.bytes());
         result.steps.push_back(std::move(out));
+    }
+    if (!r.ok) {
+        LOG_ERROR("RPC failed: truncated flat read-plan response");
+        result.ok = false;
+        result.steps.clear();
     }
 
     return result;
@@ -1406,6 +1478,11 @@ bool LineairDBProxy::send_message_with_header(const std::string& serialized_requ
         LOG_ERROR("SEND_MESSAGE: Not connected!");
         return false;
     }
+    if (serialized_request.size() > UINT32_MAX) {
+        LOG_ERROR("SEND_MESSAGE: request %zu bytes exceeds the u32 frame limit",
+                  serialized_request.size());
+        return false;
+    }
 
     LOG_DEBUG("SEND_MESSAGE: Sending message of size %zu bytes with message_type %u", 
               serialized_request.size(), static_cast<uint32_t>(message_type));
@@ -1455,16 +1532,23 @@ bool LineairDBProxy::send_message_with_header(const std::string& serialized_requ
     LOG_DEBUG("SEND_MESSAGE: Received response header: sender_id=%lu, message_type=%u, payload_size=%u", 
               response_sender_id, response_message_type, response_payload_size);
 
-    // receive response payload
+    // Receive the response payload. recv(MSG_WAITALL) still caps one call near
+    // 2GB, so large read-plan responses must be drained in a loop.
     if (response_payload_size > 0) {
         serialized_response.resize(response_payload_size);
-        ssize_t payload_received = recv(socket_fd_, &serialized_response[0], response_payload_size, MSG_WAITALL);
-        if (payload_received != static_cast<ssize_t>(response_payload_size)) {
-            LOG_ERROR("SEND_MESSAGE: Failed to receive response payload, received %zd bytes instead of %u", 
-                      payload_received, response_payload_size);
-            return false;
+        size_t received_total = 0;
+        while (received_total < response_payload_size) {
+            const ssize_t chunk =
+                recv(socket_fd_, &serialized_response[received_total],
+                     response_payload_size - received_total, MSG_WAITALL);
+            if (chunk <= 0) {
+                LOG_ERROR("SEND_MESSAGE: Failed to receive response payload, received %zu/%u bytes",
+                          received_total, response_payload_size);
+                return false;
+            }
+            received_total += static_cast<size_t>(chunk);
         }
-        LOG_DEBUG("SEND_MESSAGE: Successfully received response payload (%zd bytes)", payload_received);
+        LOG_DEBUG("SEND_MESSAGE: Successfully received response payload (%zu bytes)", received_total);
     } else {
         LOG_DEBUG("SEND_MESSAGE: No response payload (empty response)");
         serialized_response.clear();

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -453,6 +453,12 @@ LineairDBProxy::ReadPlanResult LineairDBProxy::tx_execute_read_plan(
         for (const auto tid : step.scan_tids()) out.scan_tids.push_back(tid);
         out.secondary_keys.reserve(step.secondary_keys_size());
         for (const auto& key : step.secondary_keys()) out.secondary_keys.push_back(key);
+        out.group_sizes.reserve(step.group_sizes_size());
+        for (const auto sz : step.group_sizes()) out.group_sizes.push_back(sz);
+        out.group_start_keys.reserve(step.group_start_keys_size());
+        for (const auto& key : step.group_start_keys()) out.group_start_keys.push_back(key);
+        out.group_end_keys.reserve(step.group_end_keys_size());
+        for (const auto& key : step.group_end_keys()) out.group_end_keys.push_back(key);
         result.steps.push_back(std::move(out));
     }
 

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -402,6 +402,9 @@ LineairDBProxy::ReadPlanResult LineairDBProxy::tx_execute_read_plan(
         out->set_index_name(step.index_name);
         out->set_for_each(step.for_each);
         out->set_reverse_scan(step.reverse_scan);
+        if (!step.serialized_filter.empty()) {
+            out->mutable_filter()->ParseFromString(step.serialized_filter);
+        }
         for (const auto& binding : step.bindings) {
             auto* b = out->add_bindings();
             b->set_source_step(binding.source_step);

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -168,6 +168,10 @@ public:
         std::vector<std::string> secondary_keys;
         std::string actual_start_key;
         std::string actual_end_key;
+        // Per-probe groups for for_each range scans; sizes split scan arrays.
+        std::vector<uint32_t> group_sizes;
+        std::vector<std::string> group_start_keys;
+        std::vector<std::string> group_end_keys;
     };
     struct ReadPlanResult {
         bool ok = false;

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -156,6 +156,8 @@ public:
         std::vector<ReadPlanKeyBinding> end_bindings;
         bool for_each = false;
         bool reverse_scan = false;
+        // Serialized PushedPredicate; empty means no server-side filter.
+        std::string serialized_filter;
     };
     struct ReadPlanStepResult {
         bool found = false;

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -2,6 +2,8 @@
 #include "storage/lineairdb/ha_lineairdb.hh"
 #include "lineairdb_keyenc.hh"
 #include "../common/log.h"
+#include "sql/sql_lex.h"
+#include "sql/table.h"
 
 #include <thread>
 #include <unordered_set>
@@ -1011,6 +1013,7 @@ void LineairDBTransaction::append_base_row_read(
   // emplace_back-only, no dedup). Repeats carry the cached value's TID, so a
   // key read N times validates that same TID N times -- redundant but never
   // wrong. Commit aborts if any entry's TID no longer matches the server.
+  if (ro_novalidate_) return;  // read-only commit skips validation
   base_row_read_set_.push_back({table_name, key, tid, found});
 }
 
@@ -1020,6 +1023,7 @@ void LineairDBTransaction::append_range_read(
   // describe the replay and result_keys is the observed key list in scan
   // order. Append, like the point and Silo read sets; a scan consumed twice
   // is revalidated twice -- redundant but never wrong.
+  if (ro_novalidate_) return;  // read-only commit skips validation
   LineairDBProxy::RangeReadEntry entry;
   entry.table_name = cached.table_name;
   entry.start_key = cached.start_key;
@@ -1035,6 +1039,7 @@ void LineairDBTransaction::append_range_read(
 
 void LineairDBTransaction::append_secondary_range_read(
     const LocalSecondaryScanEntry& cached) {
+  if (ro_novalidate_) return;  // read-only commit skips validation
   LineairDBProxy::RangeReadEntry entry;
   entry.table_name = cached.table_name;
   entry.index_name = cached.index_name;
@@ -1142,6 +1147,19 @@ bool LineairDBTransaction::fallback_to_normal_transaction(const char* reason) {
 bool LineairDBTransaction::prefetch_validate_and_commit() {
   bool was_aborted = is_aborted_;
 
+  // Read-only fast path: no writes and no read validation to send.
+  // Finish locally so the SELECT uses only the read-plan RPC.
+  if (!was_aborted && ro_novalidate_ && write_buffer_ops_.empty() &&
+      rowcount_deltas_.empty()) {
+    if (rpc_trace_.active()) {
+      rpc_trace_.record_local_view("ro_novalidate_commit");
+      RpcTraceLogger::instance().log_line(rpc_trace_.finalize_jsonl(true));
+    }
+    lineairdb_proxy->set_current_trace(nullptr);
+    delete this;
+    return true;
+  }
+
   std::vector<LineairDBProxy::StatelessReadKey> reads;
   std::vector<uint64_t> read_tids;
   std::vector<bool> read_found;
@@ -1216,6 +1234,23 @@ void LineairDBTransaction::begin_transaction() {
       register_transaction_to_mysql();
     }
     else {
+      // Enable the no-validation fast path only for autocommit SELECTs whose
+      // tables use plain read locks. SELECT ... FOR UPDATE/SHARE and other
+      // stronger locks keep normal read-set validation.
+      extern bool srv_prefetch_ro_novalidate;
+      bool plain_read_only = srv_prefetch_ro_novalidate && thread != nullptr &&
+                             thd_sql_command(thread) == SQLCOM_SELECT &&
+                             thread->lex != nullptr;
+      if (plain_read_only) {
+        for (Table_ref *t = thread->lex->query_tables; t != nullptr;
+             t = t->next_global) {
+          if (t->lock_descriptor().type > TL_READ) {
+            plain_read_only = false;
+            break;
+          }
+        }
+      }
+      ro_novalidate_ = plain_read_only;
       register_single_statement_to_mysql();
     }
     return;

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -545,6 +545,9 @@ std::vector<std::pair<std::string, std::string>>
 LineairDBTransaction::get_matching_keys_and_values_from_prefix(std::string prefix) {
   if (table_is_not_chosen()) return {};
   if (prefetch_mode_) {
+    if (prefix.empty()) {
+      return get_matching_keys_and_values_in_range("", std::string());
+    }
     const std::string prefix_end = next_lexicographic_key(prefix);
     if (prefix_end.empty()) {
       abort_prefetch_cache_miss("primary prefix range end");

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -10,6 +10,20 @@
 
 namespace {
 
+// Composite key for the scan-cache exact-start lookup indexes.
+inline std::string scan_cache_index_key(const std::string& table,
+                                        const std::string& index,
+                                        const std::string& start) {
+  std::string k;
+  k.reserve(table.size() + index.size() + start.size() + 2);
+  k += table;
+  k.push_back('\x01');
+  k += index;
+  k.push_back('\x01');
+  k += start;
+  return k;
+}
+
 std::string next_lexicographic_key(std::string key) {
   for (size_t i = key.size(); i-- > 0;) {
     auto byte = static_cast<unsigned char>(key[i]);
@@ -278,10 +292,65 @@ void LineairDBTransaction::execute_read_plan(
       }
     }
 
+    if (step.for_each && step.is_scan) {
+      // Stage grouped for_each range results as ordinary scan-cache entries.
+      // Each group corresponds to one deduplicated probe key.
+      size_t flat = 0;  // Offset into the flat scan arrays across all groups.
+      for (size_t g = 0; g < step_result.group_sizes.size(); ++g) {
+        const size_t n = step_result.group_sizes[g];
+        const std::string& gstart = g < step_result.group_start_keys.size()
+                                        ? step_result.group_start_keys[g]
+                                        : std::string();
+        const std::string& gend = g < step_result.group_end_keys.size()
+                                      ? step_result.group_end_keys[g]
+                                      : std::string();
+        if (step.index_name.empty()) {
+          // Primary range group: cache row values by primary key.
+          LocalRangeScanEntry entry;
+          entry.table_name = step.table_name;
+          entry.start_key = gstart;
+          entry.end_key = gend;
+          entry.reverse_scan = step.reverse_scan;
+          entry.row_limit = step.scan_limit;
+          for (size_t j = flat; j < flat + n && j < step_result.scan_keys.size();
+               ++j) {
+            const std::string& key = step_result.scan_keys[j];
+            const std::string value = j < step_result.scan_values.size()
+                                          ? step_result.scan_values[j]
+                                          : "";
+            if (value.empty()) continue;
+            entry.rows.emplace_back(key, value);
+            entry.row_tids.push_back(
+                j < step_result.scan_tids.size() ? step_result.scan_tids[j] : 0);
+          }
+          push_range_scan_cache(std::move(entry));
+        } else {
+          // Secondary range group: cache secondary keys and their primary keys.
+          LocalSecondaryScanEntry entry;
+          entry.table_name = step.table_name;
+          entry.index_name = step.index_name;
+          entry.start_key = gstart;
+          entry.end_key = gend;
+          entry.reverse_scan = step.reverse_scan;
+          entry.row_limit = step.scan_limit;
+          for (size_t j = flat; j < flat + n && j < step_result.scan_keys.size();
+               ++j) {
+            entry.primary_keys.push_back(step_result.scan_keys[j]);
+            if (j < step_result.secondary_keys.size()) {
+              entry.secondary_keys.push_back(step_result.secondary_keys[j]);
+            }
+          }
+          push_secondary_scan_cache(std::move(entry));
+        }
+        flat += n;
+      }
+      continue;
+    }
+
     if (step.for_each) continue;
 
     if (step.index_name.empty()) {
-      range_scan_cache_.push_back(
+      push_range_scan_cache(
           {step.table_name, step_result.actual_start_key,
            step_result.actual_end_key, step.reverse_scan, step.scan_limit,
            std::move(rows), std::move(row_tids)});
@@ -301,7 +370,7 @@ void LineairDBTransaction::execute_read_plan(
       for (const auto& key : step_result.scan_keys) {
         cached.primary_keys.push_back(key);
       }
-      secondary_scan_cache_.push_back(std::move(cached));
+      push_secondary_scan_cache(std::move(cached));
     }
   }
 }
@@ -975,6 +1044,15 @@ void LineairDBTransaction::drop_secondary_scan_cache(
     kept.push_back(entry);
   }
   secondary_scan_cache_.swap(kept);
+  // Vector indices shifted: rebuild the exact-start lookup index.
+  secondary_scan_start_index_.clear();
+  for (size_t i = 0; i < secondary_scan_cache_.size(); ++i) {
+    const auto& e = secondary_scan_cache_[i];
+    secondary_scan_start_index_[scan_cache_index_key(e.table_name,
+                                                     e.index_name,
+                                                     e.start_key)]
+        .push_back(i);
+  }
 }
 
 void LineairDBTransaction::record_write(const std::string& table_name,
@@ -1062,10 +1140,60 @@ void LineairDBTransaction::abort_prefetch_cache_miss(
   thd_mark_transaction_to_rollback(thread, 1);
 }
 
+void LineairDBTransaction::push_range_scan_cache(LocalRangeScanEntry entry) {
+  range_scan_start_index_[scan_cache_index_key(entry.table_name, "",
+                                               entry.start_key)]
+      .push_back(range_scan_cache_.size());
+  range_scan_cache_.push_back(std::move(entry));
+}
+
+void LineairDBTransaction::push_secondary_scan_cache(
+    LocalSecondaryScanEntry entry) {
+  secondary_scan_start_index_[scan_cache_index_key(
+                                  entry.table_name, entry.index_name,
+                                  entry.start_key)]
+      .push_back(secondary_scan_cache_.size());
+  secondary_scan_cache_.push_back(std::move(entry));
+}
+
 std::optional<LineairDBTransaction::LocalRangeScanEntry>
 LineairDBTransaction::lookup_range_scan_cache(
     const std::string& table_name, const std::string& start_key,
     const std::string& end_key, bool reverse_scan, uint64_t row_limit) const {
+  // Grouped for_each range probes are staged by exact start key. Try that
+  // index before falling back to the wider range-cache scan below.
+  auto idx_it = range_scan_start_index_.find(
+      scan_cache_index_key(table_name, "", start_key));
+  if (idx_it != range_scan_start_index_.end()) {
+    for (auto rit = idx_it->second.rbegin(); rit != idx_it->second.rend();
+         ++rit) {
+      const auto& e = range_scan_cache_[*rit];
+      if (e.reverse_scan == reverse_scan && e.row_limit == row_limit &&
+          end_key <= e.end_key) {
+        // Copy and trim because the staged group may cover a wider range.
+        LocalRangeScanEntry cached = e;
+        cached.start_key = start_key;
+        cached.end_key = end_key;
+        cached.row_limit = row_limit;
+        std::vector<std::pair<std::string, std::string>> rows;
+        std::vector<uint64_t> row_tids;
+        rows.reserve(cached.rows.size());
+        row_tids.reserve(cached.row_tids.size());
+        for (size_t i = 0; i < cached.rows.size(); ++i) {
+          const auto& row = cached.rows[i];
+          if (row.first >= start_key && row.first < end_key) {
+            rows.push_back(row);
+            if (i < cached.row_tids.size())
+              row_tids.push_back(cached.row_tids[i]);
+          }
+        }
+        cached.rows = std::move(rows);
+        cached.row_tids = std::move(row_tids);
+        return cached;
+      }
+    }
+  }
+
   for (auto it = range_scan_cache_.rbegin();
        it != range_scan_cache_.rend(); ++it) {
     const bool same_table = it->table_name == table_name;
@@ -1103,6 +1231,40 @@ LineairDBTransaction::lookup_secondary_scan_cache(
     const std::string& start_key, const std::string& end_key,
     bool reverse_scan, uint64_t row_limit) const {
   (void)reverse_scan; // SI cache keeps the query-specific order from the plan
+
+  // Grouped for_each secondary probes are staged by exact start key. Try that
+  // index before falling back to the wider secondary-cache scan below.
+  auto idx_it = secondary_scan_start_index_.find(
+      scan_cache_index_key(table_name, index_name, start_key));
+  if (idx_it != secondary_scan_start_index_.end()) {
+    for (auto rit = idx_it->second.rbegin(); rit != idx_it->second.rend();
+         ++rit) {
+      const auto& e = secondary_scan_cache_[*rit];
+      if (e.row_limit == row_limit && end_key <= e.end_key) {
+        // Copy and trim paired secondary/primary keys to the requested range.
+        LocalSecondaryScanEntry cached = e;
+        cached.start_key = start_key;
+        cached.end_key = end_key;
+        cached.row_limit = row_limit;
+        if (cached.secondary_keys.size() == cached.primary_keys.size()) {
+          std::vector<std::string> secondary_keys;
+          std::vector<std::string> primary_keys;
+          secondary_keys.reserve(cached.secondary_keys.size());
+          primary_keys.reserve(cached.primary_keys.size());
+          for (size_t i = 0; i < cached.secondary_keys.size(); ++i) {
+            if (cached.secondary_keys[i] >= start_key &&
+                cached.secondary_keys[i] < end_key) {
+              secondary_keys.push_back(cached.secondary_keys[i]);
+              primary_keys.push_back(cached.primary_keys[i]);
+            }
+          }
+          cached.secondary_keys = std::move(secondary_keys);
+          cached.primary_keys = std::move(primary_keys);
+        }
+        return cached;
+      }
+    }
+  }
 
   for (auto it = secondary_scan_cache_.rbegin();
        it != secondary_scan_cache_.rend(); ++it) {

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -252,9 +252,11 @@ void LineairDBTransaction::execute_read_plan(
     return;
   }
 
+  // Consume each decoded step destructively: move strings into local caches,
+  // then release the step before staging the next one.
   for (size_t i = 0; i < result.steps.size() && i < steps.size(); ++i) {
     const auto& step = steps[i];
-    const auto& step_result = result.steps[i];
+    auto& step_result = result.steps[i];
 
     if (!step.is_scan && !step.for_each) {
       rpc_trace_.record_local_view(trace_count_event(
@@ -267,30 +269,13 @@ void LineairDBTransaction::execute_read_plan(
         record_row_cache(step.table_name, step_result.actual_key, false, "",
                           step_result.tid, true);
       }
+      step_result = LineairDBProxy::ReadPlanStepResult{};
       continue;
     }
 
     rpc_trace_.record_local_view(trace_plan_scan_event(
         step.table_name, step.index_name, step_result.scan_keys.size(),
         step_result.scan_values.size(), step.scan_limit, step.for_each));
-
-    std::vector<std::pair<std::string, std::string>> rows;
-    std::vector<uint64_t> row_tids;
-    rows.reserve(step_result.scan_keys.size());
-    row_tids.reserve(step_result.scan_keys.size());
-    for (size_t j = 0; j < step_result.scan_keys.size(); ++j) {
-      const std::string& key = step_result.scan_keys[j];
-      const std::string value =
-          j < step_result.scan_values.size() ? step_result.scan_values[j] : "";
-      const uint64_t tid =
-          j < step_result.scan_tids.size() ? step_result.scan_tids[j] : 0;
-      const bool found = !value.empty();
-      record_row_cache(step.table_name, key, found, value, tid, true);
-      if (found) {
-        rows.emplace_back(key, value);
-        row_tids.push_back(tid);
-      }
-    }
 
     if (step.for_each && step.is_scan) {
       // Stage grouped for_each range results as ordinary scan-cache entries.
@@ -314,14 +299,18 @@ void LineairDBTransaction::execute_read_plan(
           entry.row_limit = step.scan_limit;
           for (size_t j = flat; j < flat + n && j < step_result.scan_keys.size();
                ++j) {
-            const std::string& key = step_result.scan_keys[j];
-            const std::string value = j < step_result.scan_values.size()
-                                          ? step_result.scan_values[j]
-                                          : "";
-            if (value.empty()) continue;
-            entry.rows.emplace_back(key, value);
-            entry.row_tids.push_back(
-                j < step_result.scan_tids.size() ? step_result.scan_tids[j] : 0);
+            std::string key = std::move(step_result.scan_keys[j]);
+            std::string value = j < step_result.scan_values.size()
+                                    ? std::move(step_result.scan_values[j])
+                                    : std::string();
+            const uint64_t tid =
+                j < step_result.scan_tids.size() ? step_result.scan_tids[j] : 0;
+            const bool found = !value.empty();
+            record_row_cache(step.table_name, key, found, value, tid, true);
+            if (found) {
+              entry.rows.emplace_back(std::move(key), std::move(value));
+              entry.row_tids.push_back(tid);
+            }
           }
           push_range_scan_cache(std::move(entry));
         } else {
@@ -335,26 +324,70 @@ void LineairDBTransaction::execute_read_plan(
           entry.row_limit = step.scan_limit;
           for (size_t j = flat; j < flat + n && j < step_result.scan_keys.size();
                ++j) {
-            entry.primary_keys.push_back(step_result.scan_keys[j]);
+            std::string key = std::move(step_result.scan_keys[j]);
+            std::string value = j < step_result.scan_values.size()
+                                    ? std::move(step_result.scan_values[j])
+                                    : std::string();
+            const uint64_t tid =
+                j < step_result.scan_tids.size() ? step_result.scan_tids[j] : 0;
+            record_row_cache(step.table_name, key, !value.empty(), value, tid,
+                             true);
             if (j < step_result.secondary_keys.size()) {
-              entry.secondary_keys.push_back(step_result.secondary_keys[j]);
+              entry.secondary_keys.push_back(
+                  std::move(step_result.secondary_keys[j]));
             }
+            entry.primary_keys.push_back(std::move(key));
           }
           push_secondary_scan_cache(std::move(entry));
         }
         flat += n;
       }
+      step_result = LineairDBProxy::ReadPlanStepResult{};
       continue;
     }
 
-    if (step.for_each) continue;
+    if (step.for_each) {
+      // Point probes only populate the row cache.
+      for (size_t j = 0; j < step_result.scan_keys.size(); ++j) {
+        std::string key = std::move(step_result.scan_keys[j]);
+        std::string value = j < step_result.scan_values.size()
+                                ? std::move(step_result.scan_values[j])
+                                : std::string();
+        const uint64_t tid =
+            j < step_result.scan_tids.size() ? step_result.scan_tids[j] : 0;
+        record_row_cache(step.table_name, key, !value.empty(), value, tid,
+                         true);
+      }
+      step_result = LineairDBProxy::ReadPlanStepResult{};
+      continue;
+    }
 
     if (step.index_name.empty()) {
+      // Primary scan: cache row values and stage one primary range entry.
+      std::vector<std::pair<std::string, std::string>> rows;
+      std::vector<uint64_t> row_tids;
+      rows.reserve(step_result.scan_keys.size());
+      row_tids.reserve(step_result.scan_keys.size());
+      for (size_t j = 0; j < step_result.scan_keys.size(); ++j) {
+        std::string key = std::move(step_result.scan_keys[j]);
+        std::string value = j < step_result.scan_values.size()
+                                ? std::move(step_result.scan_values[j])
+                                : std::string();
+        const uint64_t tid =
+            j < step_result.scan_tids.size() ? step_result.scan_tids[j] : 0;
+        const bool found = !value.empty();
+        record_row_cache(step.table_name, key, found, value, tid, true);
+        if (found) {
+          rows.emplace_back(std::move(key), std::move(value));
+          row_tids.push_back(tid);
+        }
+      }
       push_range_scan_cache(
           {step.table_name, step_result.actual_start_key,
            step_result.actual_end_key, step.reverse_scan, step.scan_limit,
            std::move(rows), std::move(row_tids)});
     } else {
+      // Keep secondary_keys and primary_keys aligned; lookup walks the pairs.
       LocalSecondaryScanEntry cached;
       cached.table_name = step.table_name;
       cached.index_name = step.index_name;
@@ -363,15 +396,24 @@ void LineairDBTransaction::execute_read_plan(
       cached.reverse_scan = step.reverse_scan;
       cached.row_limit = step.scan_limit;
       cached.secondary_keys.reserve(step_result.secondary_keys.size());
-      cached.primary_keys.reserve(step_result.scan_keys.size());
-      for (const auto& key : step_result.secondary_keys) {
-        cached.secondary_keys.push_back(key);
+      for (auto& key : step_result.secondary_keys) {
+        cached.secondary_keys.push_back(std::move(key));
       }
-      for (const auto& key : step_result.scan_keys) {
-        cached.primary_keys.push_back(key);
+      cached.primary_keys.reserve(step_result.scan_keys.size());
+      for (size_t j = 0; j < step_result.scan_keys.size(); ++j) {
+        std::string key = std::move(step_result.scan_keys[j]);
+        std::string value = j < step_result.scan_values.size()
+                                ? std::move(step_result.scan_values[j])
+                                : std::string();
+        const uint64_t tid =
+            j < step_result.scan_tids.size() ? step_result.scan_tids[j] : 0;
+        record_row_cache(step.table_name, key, !value.empty(), value, tid,
+                         true);
+        cached.primary_keys.push_back(std::move(key));
       }
       push_secondary_scan_cache(std::move(cached));
     }
+    step_result = LineairDBProxy::ReadPlanStepResult{};
   }
 }
 

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -115,6 +115,8 @@ public:
   }
   bool autogen_stmt_resolved() const { return autogen_stmt_resolved_; }
   void mark_autogen_stmt_resolved() { autogen_stmt_resolved_ = true; }
+  // True for the read-only no-validation path; staged filters use the same gate.
+  bool ro_novalidate() const { return ro_novalidate_; }
   // Subqueries may be staged before the statement root exists. Remember each
   // root so the same subquery plan is not prefetched twice in one statement.
   bool autogen_root_staged(const void *root) const {

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -3,6 +3,7 @@
 
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "sql/handler.h" /* handler */
 #include "mysql/plugin.h"
@@ -110,9 +111,18 @@ public:
     autogen_query_id_ = query_id;
     autogen_stmt_resolved_ = false;
     autogen_stmt_handler_deferred_ = false;
+    autogen_staged_roots_.clear();
   }
   bool autogen_stmt_resolved() const { return autogen_stmt_resolved_; }
   void mark_autogen_stmt_resolved() { autogen_stmt_resolved_ = true; }
+  // Subqueries may be staged before the statement root exists. Remember each
+  // root so the same subquery plan is not prefetched twice in one statement.
+  bool autogen_root_staged(const void *root) const {
+    return autogen_staged_roots_.count(root) != 0;
+  }
+  void mark_autogen_root_staged(const void *root) {
+    autogen_staged_roots_.insert(root);
+  }
   bool is_autogen_stmt_handler_deferred() const {
     return autogen_stmt_handler_deferred_;
   }
@@ -178,6 +188,7 @@ private:
   bool tx_plan_used_{false};
   uint64_t autogen_query_id_{0};
   bool autogen_stmt_resolved_{false};
+  std::unordered_set<const void*> autogen_staged_roots_;
   // Set when this statement's plan is built from the handler index access
   // (deferred legacy-DML path) instead of the QEP; a second handler access
   // then means an index merge the single staged range cannot serve.

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -172,6 +172,9 @@ private:
   bool isFence;
   bool prefetch_mode_{false};
   bool prefetch_registered_{false};
+  // Autocommit single-statement SELECT with lineairdb_prefetch_ro_novalidate=ON:
+  // read sets are not accumulated and commit skips the validation RPC.
+  bool ro_novalidate_{false};
   bool tx_plan_used_{false};
   uint64_t autogen_query_id_{0};
   bool autogen_stmt_resolved_{false};

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -263,6 +263,12 @@ private:
   };
   std::vector<LocalRangeScanEntry> range_scan_cache_;
   std::vector<LocalSecondaryScanEntry> secondary_scan_cache_;
+  // Exact-start indexes for grouped range scans. Without these, each runtime
+  // probe would scan the whole cache vector. Keyed table\x01index\x01start_key.
+  std::unordered_map<std::string, std::vector<size_t>> range_scan_start_index_;
+  std::unordered_map<std::string, std::vector<size_t>> secondary_scan_start_index_;
+  void push_range_scan_cache(LocalRangeScanEntry entry);
+  void push_secondary_scan_cache(LocalSecondaryScanEntry entry);
 
   // Predicate pushdown: serialized PushedPredicate for scan filtering
   std::string pushed_filter_;

--- a/server/network/message_handler.cc
+++ b/server/network/message_handler.cc
@@ -49,10 +49,16 @@ bool MessageHandler::receive_message(int socket, uint64_t& sender_id,
     return true;
 }
 
-bool MessageHandler::send_response(int socket, uint64_t sender_id, 
+bool MessageHandler::send_response(int socket, uint64_t sender_id,
                                   MessageType message_type, const std::string& payload) {
     LOG_DEBUG("Sending response (%zu bytes)", payload.size());
-    
+
+    if (payload.size() > UINT32_MAX) {
+        LOG_ERROR("Response payload %zu bytes exceeds the u32 frame limit; dropping",
+                  payload.size());
+        return false;
+    }
+
     // Prepare response header
     MessageHeader response_header;
     response_header.sender_id = htobe64(sender_id);
@@ -84,6 +90,12 @@ bool MessageHandler::send_response(int socket, uint64_t sender_id,
 bool MessageHandler::send_response_writev(int socket, uint64_t sender_id,
                                           MessageType message_type, const std::string& payload) {
     LOG_DEBUG("Sending response via writev (%zu bytes)", payload.size());
+
+    if (payload.size() > UINT32_MAX) {
+        LOG_ERROR("Response payload %zu bytes exceeds the u32 frame limit; dropping",
+                  payload.size());
+        return false;
+    }
 
     MessageHeader response_header;
     response_header.sender_id = htobe64(sender_id);

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -644,6 +644,24 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             end_key = next_lexicographic_key(start_key);
         }
 
+        // Step-level row filter: parseable non-matches are dropped; rows the
+        // evaluator cannot parse are returned for MySQL to re-check.
+        const bool step_has_filter =
+            step.has_filter() && step.filter().has_expr();
+        const auto* step_filter =
+            step_has_filter ? &step.filter().expr() : nullptr;
+        const uint32_t step_filter_cols =
+            step_has_filter ? step.filter().num_columns() : 0;
+        PredicateEvaluator step_eval;
+        auto row_passes = [&](const std::string& value) {
+            if (step_filter == nullptr) return true;
+            if (!step_eval.parse_row(value.data(), value.size(),
+                                     step_filter_cols)) {
+                return true;
+            }
+            return step_eval.evaluate(*step_filter);
+        };
+
         if (step.for_each()) {
             int source_step = -1;
             if (step.bindings_size() > 0) {
@@ -685,6 +703,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                             return;
                         }
                         for (auto& r : scan_result.rows) {
+                            if (!row_passes(r.value)) continue;
                             step_result->add_scan_keys(std::move(r.key));
                             step_result->add_scan_values(std::move(r.value));
                             step_result->add_scan_tids(r.tid);
@@ -703,6 +722,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                             return;
                         }
                         for (auto& r : scan_result.rows) {
+                            if (!row_passes(r.value)) continue;
                             step_result->add_secondary_keys(
                                 std::move(r.secondary_key));
                             step_result->add_scan_keys(std::move(r.primary_key));
@@ -759,22 +779,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                 flat_plan::encode_to_string(response, result);
                 return;
             }
-            const bool has_filter =
-                step.has_filter() && step.filter().has_expr();
-            const auto* filter_expr =
-                has_filter ? &step.filter().expr() : nullptr;
-            const uint32_t filter_num_cols =
-                has_filter ? step.filter().num_columns() : 0;
-            PredicateEvaluator evaluator;
             for (auto& row : scan_result.rows) {
-                // Drop rows only when the server can parse and reject them.
-                // Parse failures are returned for MySQL to evaluate.
-                if (filter_expr != nullptr &&
-                    evaluator.parse_row(row.value.data(), row.value.size(),
-                                        filter_num_cols) &&
-                    !evaluator.evaluate(*filter_expr)) {
-                    continue;
-                }
+                if (!row_passes(row.value)) continue;
                 step_result->add_scan_keys(std::move(row.key));
                 step_result->add_scan_values(std::move(row.value));
                 step_result->add_scan_tids(row.tid);
@@ -792,6 +798,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                 return;
             }
             for (auto& row : scan_result.rows) {
+                if (!row_passes(row.value)) continue;
                 step_result->add_secondary_keys(std::move(row.secondary_key));
                 step_result->add_scan_keys(std::move(row.primary_key));
                 step_result->add_scan_values(std::move(row.value));

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -541,6 +541,81 @@ void LineairDBRpc::handleTxStatelessBatchRead(const std::string& message,
     result = response.SerializeAsString();
 }
 
+namespace flat_plan {
+// Native-endian bytes spell "LDBFLATP" (LineairDB flat payload).
+static constexpr uint64_t kMagic = 0x5054414C4642444Cull;
+static constexpr uint8_t kVersion = 1;
+
+template <class Sink>
+void w_u8(Sink& out, uint8_t v) {
+    const char c = static_cast<char>(v);
+    out.append(&c, 1);
+}
+
+template <class Sink>
+void w_u64(Sink& out, uint64_t v) {
+    char bytes[8];
+    std::memcpy(bytes, &v, 8);
+    out.append(bytes, 8);
+}
+
+template <class Sink>
+void w_bytes(Sink& out, const std::string& s) {
+    w_u64(out, static_cast<uint64_t>(s.size()));
+    out.append(s.data(), s.size());
+}
+
+struct CountSink {
+    uint64_t n = 0;
+    void append(const char*, size_t k) { n += k; }
+};
+
+template <class Sink>
+void encode_step(
+    const LineairDB::Protocol::TxExecuteReadPlan::StepResult& s, Sink& out) {
+    w_u8(out, s.found() ? 1 : 0);
+    w_u64(out, s.tid());
+    w_bytes(out, s.value());
+    w_bytes(out, s.actual_key());
+    w_bytes(out, s.actual_start_key());
+    w_bytes(out, s.actual_end_key());
+    w_u64(out, static_cast<uint64_t>(s.scan_keys_size()));
+    for (const auto& k : s.scan_keys()) w_bytes(out, k);
+    w_u64(out, static_cast<uint64_t>(s.scan_values_size()));
+    for (const auto& v : s.scan_values()) w_bytes(out, v);
+    w_u64(out, static_cast<uint64_t>(s.scan_tids_size()));
+    for (const auto t : s.scan_tids()) w_u64(out, t);
+    w_u64(out, static_cast<uint64_t>(s.secondary_keys_size()));
+    for (const auto& k : s.secondary_keys()) w_bytes(out, k);
+    w_u64(out, static_cast<uint64_t>(s.group_sizes_size()));
+    for (const auto g : s.group_sizes()) w_u64(out, g);
+    w_u64(out, static_cast<uint64_t>(s.group_start_keys_size()));
+    for (const auto& k : s.group_start_keys()) w_bytes(out, k);
+    w_u64(out, static_cast<uint64_t>(s.group_end_keys_size()));
+    for (const auto& k : s.group_end_keys()) w_bytes(out, k);
+}
+
+// Destructive: release each StepResult after encoding it so large read-plan
+// responses do not keep both protobuf rows and the flat payload alive.
+void encode_to_string(LineairDB::Protocol::TxExecuteReadPlan::Response& r,
+                      std::string& out) {
+    CountSink count;
+    count.n = 8 + 1 + 1 + 8;  // magic + version + ok + result count
+    for (const auto& s : r.results()) encode_step(s, count);
+
+    out.clear();
+    out.reserve(count.n);
+    w_u64(out, kMagic);
+    w_u8(out, kVersion);
+    w_u8(out, r.ok() ? 1 : 0);
+    w_u64(out, static_cast<uint64_t>(r.results_size()));
+    for (int i = 0; i < r.results_size(); ++i) {
+        encode_step(r.results(i), out);
+        r.mutable_results(i)->Clear();
+    }
+}
+}  // namespace flat_plan
+
 void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                                            std::string& result) {
     LineairDB::Protocol::TxExecuteReadPlan::Request request;
@@ -606,7 +681,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                                 step.scan_limit(), step.reverse_scan());
                         if (!scan_result.ok) {
                             response.set_ok(false);
-                            result = response.SerializeAsString();
+                            flat_plan::encode_to_string(response, result);
                             return;
                         }
                         for (auto& r : scan_result.rows) {
@@ -624,7 +699,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                                     step.reverse_scan());
                         if (!scan_result.ok) {
                             response.set_ok(false);
-                            result = response.SerializeAsString();
+                            flat_plan::encode_to_string(response, result);
                             return;
                         }
                         for (auto& r : scan_result.rows) {
@@ -681,7 +756,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                     step.scan_limit(), step.reverse_scan());
             if (!scan_result.ok) {
                 response.set_ok(false);
-                result = response.SerializeAsString();
+                flat_plan::encode_to_string(response, result);
                 return;
             }
             const bool has_filter =
@@ -713,7 +788,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                     step.scan_limit(), step.reverse_scan());
             if (!scan_result.ok) {
                 response.set_ok(false);
-                result = response.SerializeAsString();
+                flat_plan::encode_to_string(response, result);
                 return;
             }
             for (auto& row : scan_result.rows) {
@@ -725,7 +800,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
         }
     }
 
-    result = response.SerializeAsString();
+    flat_plan::encode_to_string(response, result);
 }
 
 void LineairDBRpc::handleTxValidateAndCommit(const std::string& message,

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -684,7 +684,22 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                 result = response.SerializeAsString();
                 return;
             }
+            const bool has_filter =
+                step.has_filter() && step.filter().has_expr();
+            const auto* filter_expr =
+                has_filter ? &step.filter().expr() : nullptr;
+            const uint32_t filter_num_cols =
+                has_filter ? step.filter().num_columns() : 0;
+            PredicateEvaluator evaluator;
             for (auto& row : scan_result.rows) {
+                // Drop rows only when the server can parse and reject them.
+                // Parse failures are returned for MySQL to evaluate.
+                if (filter_expr != nullptr &&
+                    evaluator.parse_row(row.value.data(), row.value.size(),
+                                        filter_num_cols) &&
+                    !evaluator.evaluate(*filter_expr)) {
+                    continue;
+                }
                 step_result->add_scan_keys(std::move(row.key));
                 step_result->add_scan_values(std::move(row.value));
                 step_result->add_scan_tids(row.tid);

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <algorithm>
 #include <cstdlib>
+#include <unordered_set>
 
 #include "lineairdb.pb.h"
 
@@ -581,12 +582,67 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             const auto* source = previous_results[source_step];
             const int row_count =
                 std::max(source->scan_keys_size(), source->scan_values_size());
+            // Dedup probes: many source rows share a join key, and the proxy
+            // serves every runtime probe of one key from the single staged
+            // result, so re-executing the probe only inflates the response.
+            std::unordered_set<std::string> seen_probe_keys;
+            seen_probe_keys.reserve(static_cast<size_t>(row_count));
             for (int row = 0; row < row_count; ++row) {
                 bool row_complete = true;
                 const std::string row_key =
                     build_plan_key(step.key_prefix(), step.bindings(),
                                    previous_results, row, &row_complete);
                 if (!row_complete) continue;
+                if (!seen_probe_keys.insert(row_key).second) continue;
+
+                if (step.is_scan()) {
+                    // Per-probe range scan: [row_key, next(row_key)).
+                    const std::string row_end = next_lexicographic_key(row_key);
+                    int group_rows = 0;
+                    if (step.index_name().empty()) {
+                        auto scan_result =
+                            db_manager_->get_database()->StatelessRangeScan(
+                                step.table_name(), row_key, row_end,
+                                step.scan_limit(), step.reverse_scan());
+                        if (!scan_result.ok) {
+                            response.set_ok(false);
+                            result = response.SerializeAsString();
+                            return;
+                        }
+                        for (auto& r : scan_result.rows) {
+                            step_result->add_scan_keys(std::move(r.key));
+                            step_result->add_scan_values(std::move(r.value));
+                            step_result->add_scan_tids(r.tid);
+                            ++group_rows;
+                        }
+                    } else {
+                        auto scan_result =
+                            db_manager_->get_database()
+                                ->StatelessSecondaryRangeScan(
+                                    step.table_name(), step.index_name(),
+                                    row_key, row_end, step.scan_limit(),
+                                    step.reverse_scan());
+                        if (!scan_result.ok) {
+                            response.set_ok(false);
+                            result = response.SerializeAsString();
+                            return;
+                        }
+                        for (auto& r : scan_result.rows) {
+                            step_result->add_secondary_keys(
+                                std::move(r.secondary_key));
+                            step_result->add_scan_keys(std::move(r.primary_key));
+                            step_result->add_scan_values(std::move(r.value));
+                            step_result->add_scan_tids(r.tid);
+                            ++group_rows;
+                        }
+                    }
+                    step_result->add_group_sizes(
+                        static_cast<uint32_t>(group_rows));
+                    step_result->add_group_start_keys(row_key);
+                    step_result->add_group_end_keys(row_end);
+                    continue;
+                }
+
                 auto read_result =
                     db_manager_->get_database()->StatelessRead(
                         step.table_name(), row_key);

--- a/server/rpc/predicate_evaluator.cc
+++ b/server/rpc/predicate_evaluator.cc
@@ -67,7 +67,9 @@ bool PredicateEvaluator::parse_row(const char* data, size_t length,
     field_index++;
   }
 
-  return true;
+  // If the row ended before all filter columns were present, keep it in the
+  // response so MySQL can evaluate the condition.
+  return field_index == total_fields;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Teach autogen prefetch to stage full primary scans, temp-table-backed base reads, grouped range probes, and more SELECT plan shapes.
- Add a read-only no-validation path for autocommit plain SELECTs, gated by `lineairdb_prefetch_ro_novalidate`.
- Push `cond_push()` filters into staged scans when filtered read-plan results are allowed.
- Encode `TxExecuteReadPlan` responses with a flat binary payload and drain large responses with a receive loop.
- Move decoded read-plan rows into local caches step by step to reduce peak memory during large staged scans.

## Why

The existing autogen prefetch path handled only a narrow set of read shapes. Many analytic SELECTs were rejected before execution, and larger read-plan responses could hit protobuf or single-recv limits. This branch makes staged prefetch usable for full scans, secondary scans, grouped probes, temp-table-backed plans, and larger result sets while keeping validation-sensitive paths conservative.

## Details

- Full table scans and primary index scans can now be staged for plain read-only SELECTs.
- MySQL-local temp-table leaves are skipped, while the LineairDB base reads feeding those temp tables are still staged.
- Grouped for-each range probes stage one bounded scan entry per deduplicated probe.
- Additional SELECT plan shapes are covered, including multi-source equality remapping and per-unit subquery staging.
- `lineairdb_prefetch_ro_novalidate` skips read-set accumulation and the commit validation RPC only for autocommit plain SELECTs; locking reads and writes keep full validation.
- Staged scan filters are attached only when the caller allows filtered read-plan results, so validated paths still keep the complete scanned key set.
- Read-plan responses use a flat payload for `TxExecuteReadPlan`; normal scan RPCs keep their existing paths.
- Oversized request/response frames fail loudly instead of risking truncation or stream desync.