### PR TITLE
feat: expand prefetch coverage for subqueries and bounded scans

### DIFF
--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -702,6 +702,10 @@ int ha_lineairdb::index_next(uchar *buf) {
   // materialize mode
   if (secondary_index_results_.empty() ||
       current_position_in_index_ >= secondary_index_results_.size()) {
+    if (materialized_scan_truncated_ && !secondary_index_results_.empty()) {
+      tx->fallback_to_normal_transaction("read past limit-staged scan");
+      return abort_errno(tx);
+    }
     return HA_ERR_END_OF_FILE;
   }
 
@@ -721,6 +725,10 @@ int ha_lineairdb::index_next_same(uchar *buf, const uchar *key [[maybe_unused]],
   // materialize mode
   if (secondary_index_results_.empty() ||
       current_position_in_index_ >= secondary_index_results_.size()) {
+    if (materialized_scan_truncated_ && !secondary_index_results_.empty()) {
+      tx->fallback_to_normal_transaction("read past limit-staged scan");
+      return abort_errno(tx);
+    }
     return HA_ERR_END_OF_FILE;
   }
 
@@ -983,6 +991,7 @@ void ha_lineairdb::reset_index_search_buffers() {
   secondary_index_results_.clear();
   secondary_index_payloads_.clear();
   current_position_in_index_ = 0;
+  materialized_scan_truncated_ = false;
 }
 
 /**

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -86,6 +86,20 @@ public:
   std::atomic<uint64_t> stats_base_records{0};
 };
 
+// LIMIT and direction that a handler range scan may push to LineairDB.
+// row_limit=0 means keep the scan unbounded and let MySQL apply LIMIT.
+struct RangeScanLimit {
+  ha_rows row_limit{0};
+  bool reverse_scan{false};
+};
+
+// Returns LIMIT and scan direction to push, or row_limit=0 to keep it local.
+// Safe only when the server scan sees every WHERE predicate that can affect
+// which rows belong before the LIMIT.
+RangeScanLimit range_scan_limit_for_order(THD *thd, const KEY *key,
+                                          uint matched_prefix,
+                                          bool has_mysql_only_filter);
+
 /** @brief
   Class definition for the storage engine
 */
@@ -122,6 +136,10 @@ private:
   std::unordered_map<std::string, size_t> scan_cache_;  // primary key -> index in scanned_values_
   std::vector<std::string> secondary_index_results_;
   std::vector<std::string> secondary_index_payloads_;
+  // Set by get_matching_keys_and_values_in_range() when these materialized
+  // rows are only a LIMIT-staged window. index_next()/index_next_same() consume
+  // it and abort on over-read instead of returning a false EOF.
+  bool materialized_scan_truncated_{false};
   std::string last_fetched_primary_key_;
   std::string end_range_exclusive_key_; // For HA_READ_BEFORE_KEY: exclude this key from results
   my_off_t

--- a/proxy/lineairdb_autogen.cc
+++ b/proxy/lineairdb_autogen.cc
@@ -832,13 +832,16 @@ bool compile_index_search(TABLE *table, uint index,
  *
  * @details The main statement tree and optional inner subquery trees share
  * `table_steps`, so correlated inner probes can bind to earlier outer steps.
+ * `allow_limit_pushdown` is kept off for optional inner roots because LIMIT
+ * metadata is read from the current statement context.
  *
  * @note Failures are returned through `unsupported` instead of raising
  * immediately; `added_tables` lets optional callers roll back only this tree's
  * additions.
  */
 bool compile_tree_leaves(
-    AccessPath *root, bool allow_filter_pushdown,
+    THD *thd, AccessPath *root, bool allow_filter_pushdown,
+    bool allow_limit_pushdown,
     std::unordered_map<TABLE *, int> *table_steps,
     std::vector<LineairDBProxy::ReadPlanStep> *steps,
     std::vector<TABLE *> *added_tables, UnsupportedQep *unsupported) {
@@ -882,6 +885,27 @@ bool compile_tree_leaves(
       unsupported->type = leaf->type;
       unsupported->reason = reason;
       return false;
+    }
+
+    // Push LIMIT into a single ASC REF scan only when LIMIT sits directly
+    // above this leaf. count_all_rows and reject_multiple_rows both read past
+    // LIMIT, so they cannot use a truncated staged entry.
+    if (allow_limit_pushdown && root->type == AccessPath::LIMIT_OFFSET &&
+        root->limit_offset().offset == 0 &&
+        !root->limit_offset().count_all_rows &&
+        !root->limit_offset().reject_multiple_rows &&
+        root->limit_offset().child == leaf && leaves.size() == 1 &&
+        leaf->type == AccessPath::REF && ref != nullptr && ref->key >= 0 &&
+        table->s != nullptr && ref->key < static_cast<int>(table->s->keys) &&
+        step.is_scan && !step.for_each && step.index_name.empty() &&
+        step.scan_limit == 0) {
+      const RangeScanLimit limit = range_scan_limit_for_order(
+          thd, &table->key_info[ref->key], ref->key_parts,
+          /*has_mysql_only_filter=*/false);
+      if (limit.row_limit > 0 && !limit.reverse_scan) {
+        step.scan_limit = static_cast<uint64_t>(limit.row_limit);
+        step.reverse_scan = false;
+      }
     }
 
     // Attach scan filters only when the caller allows filtered read-plan
@@ -946,7 +970,8 @@ bool autogen_read_plan_from_qep(
   std::vector<TABLE *> added_tables;
   UnsupportedQep unsupported;
 
-  if (!compile_tree_leaves(root, allow_filter_pushdown, &table_steps, &steps,
+  if (!compile_tree_leaves(thd, root, allow_filter_pushdown,
+                           /*allow_limit_pushdown=*/true, &table_steps, &steps,
                            &added_tables, &unsupported)) {
     return raise_unsupported(thd, unsupported.type, unsupported.reason);
   }
@@ -962,7 +987,8 @@ bool autogen_read_plan_from_qep(
       const size_t step_mark = steps.size();
       const size_t table_mark = added_tables.size();
       UnsupportedQep inner_unsupported;
-      if (!compile_tree_leaves(inner_root, allow_filter_pushdown, &table_steps,
+      if (!compile_tree_leaves(thd, inner_root, allow_filter_pushdown,
+                               /*allow_limit_pushdown=*/false, &table_steps,
                                &steps, &added_tables,
                                &inner_unsupported)) {
         steps.resize(step_mark);

--- a/proxy/lineairdb_autogen.cc
+++ b/proxy/lineairdb_autogen.cc
@@ -827,34 +827,32 @@ bool compile_index_search(TABLE *table, uint index,
   return false;
 }
 
-}  // namespace
-
-bool autogen_read_plan_from_qep(
-    THD *thd, AccessPath *root, bool allow_filter_pushdown,
-    std::vector<LineairDBProxy::ReadPlanStep> *out) {
-  if (out == nullptr) {
-    return raise_unsupported(thd, "NONE", "null output vector");
-  }
-  out->clear();
-
-  if (root == nullptr) {
-    return raise_unsupported(thd, "NONE", "missing JOIN root_access_path");
-  }
-
+/**
+ * @brief Compile one AccessPath tree into staged read-plan steps.
+ *
+ * @details The main statement tree and optional inner subquery trees share
+ * `table_steps`, so correlated inner probes can bind to earlier outer steps.
+ *
+ * @note Failures are returned through `unsupported` instead of raising
+ * immediately; `added_tables` lets optional callers roll back only this tree's
+ * additions.
+ */
+bool compile_tree_leaves(
+    AccessPath *root, bool allow_filter_pushdown,
+    std::unordered_map<TABLE *, int> *table_steps,
+    std::vector<LineairDBProxy::ReadPlanStep> *steps,
+    std::vector<TABLE *> *added_tables, UnsupportedQep *unsupported) {
   std::vector<AccessPath *> leaves;
   bool ok = true;
-  UnsupportedQep unsupported;
-  collect_qep_leaves(root, &leaves, &ok, &unsupported);
+  collect_qep_leaves(root, &leaves, &ok, unsupported);
   if (!ok) {
-    return raise_unsupported(thd, unsupported.type, unsupported.reason);
+    return false;
   }
   if (leaves.empty()) {
-    return raise_unsupported(thd, root->type, "QEP has no table leaves");
+    unsupported->type = root->type;
+    unsupported->reason = "QEP has no table leaves";
+    return false;
   }
-
-  std::unordered_map<TABLE *, int> table_steps;
-  std::vector<LineairDBProxy::ReadPlanStep> steps;
-  steps.reserve(leaves.size());
 
   for (AccessPath *leaf : leaves) {
     TABLE *table = nullptr;
@@ -863,21 +861,27 @@ bool autogen_read_plan_from_qep(
     int full_scan_index = -1;
     if (!qep_leaf_info(leaf, &table, &ref, &full_scan, &full_scan_index) ||
         table == nullptr) {
-      return raise_unsupported(thd, leaf->type, "unsupported QEP leaf");
+      unsupported->type = leaf->type;
+      unsupported->reason = "unsupported QEP leaf";
+      return false;
     }
     if (table->s != nullptr && table->s->tmp_table != NO_TMP_TABLE) {
       // Local MySQL temp tables are not stored in LineairDB, so there is
       // nothing to prefetch for this leaf.
       continue;
     }
-    if (table_steps.find(table) != table_steps.end()) {
-      return raise_unsupported(thd, leaf->type, "duplicate QEP table leaf");
+    if (table_steps->find(table) != table_steps->end()) {
+      unsupported->type = leaf->type;
+      unsupported->reason = "duplicate QEP table leaf";
+      return false;
     }
 
     LineairDBProxy::ReadPlanStep step;
     std::string reason;
-    if (!compile_leaf(leaf, table_steps, &step, &reason)) {
-      return raise_unsupported(thd, leaf->type, reason);
+    if (!compile_leaf(leaf, *table_steps, &step, &reason)) {
+      unsupported->type = leaf->type;
+      unsupported->reason = reason;
+      return false;
     }
 
     // Attach scan filters only when the caller allows filtered read-plan
@@ -887,8 +891,91 @@ bool autogen_read_plan_from_qep(
           down_cast<ha_lineairdb *>(table->file)->pushed_filter_for_autogen();
     }
 
-    table_steps[table] = static_cast<int>(steps.size());
-    steps.push_back(std::move(step));
+    (*table_steps)[table] = static_cast<int>(steps->size());
+    added_tables->push_back(table);
+    steps->push_back(std::move(step));
+  }
+
+  return true;
+}
+
+/**
+ * @brief Collect plan roots that hang off Item-held subqueries.
+ *
+ * @details The main AccessPath tree does not cover every read MySQL may run.
+ * IN and correlated subqueries can live as separate Query_expressions under
+ * Item conditions, so collect those roots and stage them separately.
+ */
+void collect_inner_unit_roots(Query_expression *unit,
+                              std::vector<AccessPath *> *roots) {
+  if (unit == nullptr) return;
+  for (Query_block *qb = unit->first_query_block(); qb != nullptr;
+       qb = qb->next_query_block()) {
+    for (Query_expression *inner = qb->first_inner_query_expression();
+         inner != nullptr; inner = inner->next_query_expression()) {
+      AccessPath *root = inner->root_access_path();
+      if (root == nullptr) {
+        Query_block *inner_block = inner->first_query_block();
+        if (inner_block != nullptr && inner_block->join != nullptr) {
+          root = inner_block->join->root_access_path();
+        }
+      }
+      if (root != nullptr) roots->push_back(root);
+      collect_inner_unit_roots(inner, roots);
+    }
+  }
+}
+
+}  // namespace
+
+bool autogen_read_plan_from_qep(
+    THD *thd, AccessPath *root, bool allow_filter_pushdown,
+    std::vector<LineairDBProxy::ReadPlanStep> *out,
+    bool include_inner_units) {
+  if (out == nullptr) {
+    return raise_unsupported(thd, "NONE", "null output vector");
+  }
+  out->clear();
+
+  if (root == nullptr) {
+    return raise_unsupported(thd, "NONE", "missing JOIN root_access_path");
+  }
+
+  std::unordered_map<TABLE *, int> table_steps;
+  std::vector<LineairDBProxy::ReadPlanStep> steps;
+  std::vector<TABLE *> added_tables;
+  UnsupportedQep unsupported;
+
+  if (!compile_tree_leaves(root, allow_filter_pushdown, &table_steps, &steps,
+                           &added_tables, &unsupported)) {
+    return raise_unsupported(thd, unsupported.type, unsupported.reason);
+  }
+
+  if (include_inner_units && thd != nullptr && thd->lex != nullptr) {
+    std::vector<AccessPath *> inner_roots;
+    collect_inner_unit_roots(thd->lex->unit, &inner_roots);
+    for (AccessPath *inner_root : inner_roots) {
+      if (inner_root == root) continue;
+
+      // Optional inner tree: keep the outer plan if this subquery shape is not
+      // stageable, but remove any partial steps from the failed attempt.
+      const size_t step_mark = steps.size();
+      const size_t table_mark = added_tables.size();
+      UnsupportedQep inner_unsupported;
+      if (!compile_tree_leaves(inner_root, allow_filter_pushdown, &table_steps,
+                               &steps, &added_tables,
+                               &inner_unsupported)) {
+        steps.resize(step_mark);
+        for (size_t i = table_mark; i < added_tables.size(); ++i) {
+          table_steps.erase(added_tables[i]);
+        }
+        added_tables.resize(table_mark);
+      }
+    }
+  }
+
+  if (steps.empty()) {
+    return raise_unsupported(thd, root->type, "QEP has no stageable leaves");
   }
 
   *out = std::move(steps);

--- a/proxy/lineairdb_autogen.hh
+++ b/proxy/lineairdb_autogen.hh
@@ -18,13 +18,17 @@ struct AccessPath;
  * when MySQL evaluates the subquery before the statement plan is finalized.
  * If `allow_filter_pushdown` is true, eligible scan steps carry the
  * table-local cond_push() filter.
+ * If `include_inner_units` is true, Item-held subquery plans are compiled into
+ * the same step list so correlated probes can bind to earlier outer steps.
  *
  * @note Unsupported QEP shapes raise my_error() and return false. Callers must
- * fail the statement; this path intentionally has no best-effort fallback.
+ * fail the statement. Inner-unit failures are ignored only when
+ * `include_inner_units` is true; the outer plan remains unchanged.
  */
 bool autogen_read_plan_from_qep(
     THD *thd, AccessPath *root, bool allow_filter_pushdown,
-    std::vector<LineairDBProxy::ReadPlanStep> *out);
+    std::vector<LineairDBProxy::ReadPlanStep> *out,
+    bool include_inner_units = false);
 
 /**
  * @brief Build one statement-scoped prefetch step from handler index access.

--- a/proxy/lineairdb_index_search.cc
+++ b/proxy/lineairdb_index_search.cc
@@ -678,9 +678,24 @@ int ha_lineairdb::execute_prefix_last(uchar *buf, LineairDBTransaction *tx) {
       secondary_index_payloads_.push_back(std::move(kv.second));
     }
   } else {
+    // A prefix-last probe may hit a staged reverse LIMIT 1 secondary scan.
+    // Normal stateful execution keeps the full prefix range.
+    const KEY *key = &table->key_info[active_index];
+    const bool filter_ready = prepare_select_filter_for_tx(
+        ha_thd(), table, tx, &pushed_filter_serialized_);
+    RangeScanLimit scan_limit = range_scan_limit_for_order(
+        ha_thd(), key, current_plan_.used_key_parts,
+        has_unpushed_filter_ || !filter_ready);
+    if (tx->is_prefetch_mode() && !tx->tx_plan_used()) {
+      scan_limit = RangeScanLimit{};
+    }
+    const bool push_desc_limit =
+        (scan_limit.row_limit == 1 && scan_limit.reverse_scan);
+
     secondary_index_results_ = tx->get_matching_primary_keys_in_range(
         current_index_name, current_plan_.same_group_prefix_serialized,
-        current_plan_.same_group_end_serialized);
+        current_plan_.same_group_end_serialized, push_desc_limit ? 1 : 0,
+        push_desc_limit);
     batch_fetch_secondary_payloads(tx);
   }
 

--- a/proxy/lineairdb_index_search.cc
+++ b/proxy/lineairdb_index_search.cc
@@ -33,12 +33,6 @@
 #include "sql/table.h"
 #include "typelib.h"
 
-// LIMIT and direction to pass to a range scan
-struct RangeScanLimit {
-  ha_rows row_limit{0};
-  bool reverse_scan{false};
-};
-
 // True when one ORDER BY item is exactly the requested keypart and direction
 static bool order_item_matches_key_part(ORDER *order, const KEY *key,
                                         uint key_part_idx,
@@ -96,8 +90,7 @@ static bool order_by_matches_key_suffix(Query_block *qb, const KEY *key,
   return true;
 }
 
-// Returns LIMIT and scan direction to push, or row_limit=0 to keep it local
-static RangeScanLimit range_scan_limit_for_order(
+RangeScanLimit range_scan_limit_for_order(
     THD *thd, const KEY *key, uint matched_prefix, bool has_mysql_only_filter) {
   RangeScanLimit scan_limit;
 
@@ -419,7 +412,7 @@ int ha_lineairdb::execute_same_key_materialize(uchar *buf,
     // Same-key scans can use ASC or DESC LIMIT when ORDER BY matches the key.
     auto key_values = tx->get_matching_keys_and_values_in_range(
         prefix, prefix_end, static_cast<uint64_t>(scan_limit.row_limit),
-        scan_limit.reverse_scan);
+        scan_limit.reverse_scan, &materialized_scan_truncated_);
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
       secondary_index_payloads_.push_back(std::move(kv.second));
@@ -461,9 +454,9 @@ int ha_lineairdb::execute_prefix_first(uchar *buf, LineairDBTransaction *tx) {
 
   if (current_plan_.is_primary) {
     // Restrict to [prefix, prefix_end) so index_next never leaks non-prefix
-    // rows.
+    // rows. A limit-staged hit must abort if index_next reads past it.
     auto key_values = tx->get_matching_keys_and_values_in_range(
-        prefix, prefix_end);
+        prefix, prefix_end, 0, false, &materialized_scan_truncated_);
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
       secondary_index_payloads_.push_back(std::move(kv.second));
@@ -530,7 +523,8 @@ int ha_lineairdb::execute_range_materialize(uchar *buf,
     // Range scans can use ASC or DESC LIMIT when ORDER BY matches the key.
     auto key_values = tx->get_matching_keys_and_values_in_range(
         effective_start, effective_end,
-        static_cast<uint64_t>(scan_limit.row_limit), scan_limit.reverse_scan);
+        static_cast<uint64_t>(scan_limit.row_limit), scan_limit.reverse_scan,
+        &materialized_scan_truncated_);
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
       secondary_index_payloads_.push_back(std::move(kv.second));

--- a/proxy/lineairdb_prefetch.cc
+++ b/proxy/lineairdb_prefetch.cc
@@ -353,9 +353,11 @@ void maybe_prefetch_for_transaction(THD *thd,
 
 // Build the read plan from the given QEP root and run it in one prefetch RPC.
 static int autogen_and_execute_prefetch(THD *thd, AccessPath *root,
-                                        LineairDBTransaction *tx) {
+                                        LineairDBTransaction *tx,
+                                        bool include_inner_units = false) {
   std::vector<LineairDBProxy::ReadPlanStep> steps;
-  if (!autogen_read_plan_from_qep(thd, root, tx->ro_novalidate(), &steps)) {
+  if (!autogen_read_plan_from_qep(thd, root, tx->ro_novalidate(), &steps,
+                                  include_inner_units)) {
     // autogen has already raised a my_error describing the unsupported shape.
     tx->set_status_to_abort();
     thd_mark_transaction_to_rollback(thd, 1);
@@ -479,7 +481,9 @@ int maybe_prefetch_for_statement(THD *thd, LineairDBTransaction *tx,
           thd, tx, "read-bearing statement is not prefetch-eligible");
     }
 
-    return autogen_and_execute_prefetch(thd, stmt_root, tx);
+    // Some subqueries live under Item conditions instead of the main plan tree.
+    return autogen_and_execute_prefetch(thd, stmt_root, tx,
+                                        /*include_inner_units=*/true);
   }
 
   // No statement root yet: MySQL is evaluating a subquery before the outer

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -240,8 +240,25 @@ void LineairDBTransaction::prefetch_stateless_reads(
 }
 
 void LineairDBTransaction::execute_read_plan(
-    const std::vector<LineairDBProxy::ReadPlanStep>& steps) {
-  if (!prefetch_mode_ || steps.empty()) return;
+    const std::vector<LineairDBProxy::ReadPlanStep>& full_steps) {
+  if (!prefetch_mode_ || full_steps.empty()) return;
+
+  // Exact point reads already covered by the local view need no staging RPC.
+  std::vector<LineairDBProxy::ReadPlanStep> steps;
+  steps.reserve(full_steps.size());
+  for (const auto& step : full_steps) {
+    const bool constant_point_read = !step.is_scan && !step.for_each &&
+                                     step.bindings.empty() &&
+                                     step.end_bindings.empty() &&
+                                     !step.key_prefix.empty();
+    if (constant_point_read &&
+        (lookup_write_set(step.table_name, step.key_prefix) ||
+         lookup_row_cache(step.table_name, step.key_prefix))) {
+      continue;
+    }
+    steps.push_back(step);
+  }
+  if (steps.empty()) return;
 
   rpc_trace_.record_local_view("plan_request:steps=" +
                                std::to_string(steps.size()));

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -619,14 +619,18 @@ std::vector<std::pair<std::string, std::string>>
 LineairDBTransaction::get_matching_keys_and_values_in_range(std::string start_key,
                                                             std::string end_key,
                                                             uint64_t row_limit,
-                                                            bool reverse_scan) {
+                                                            bool reverse_scan,
+                                                            bool *served_truncated) {
+  if (served_truncated != nullptr) *served_truncated = false;
   if (table_is_not_chosen()) return {};
   if (prefetch_mode_) {
     // Unbounded-upper: map an empty end to the sentinel the scan was staged with
     // so the [start, sentinel) slice keeps every row (see scan_end_sentinel).
     if (end_key.empty()) end_key = lineairdb_keyenc::scan_end_sentinel();
     if (auto cached = lookup_range_scan_cache(
-            db_table_key, start_key, end_key, reverse_scan, row_limit)) {
+            db_table_key, start_key, end_key, reverse_scan, row_limit,
+            /*allow_truncated=*/served_truncated != nullptr)) {
+      if (served_truncated != nullptr) *served_truncated = cached->truncated;
       std::vector<std::pair<std::string, std::string>> pairs = cached->rows;
       for (size_t i = 0; i < cached->rows.size() && i < cached->row_tids.size();
            ++i) {
@@ -1073,6 +1077,20 @@ bool LineairDBTransaction::has_pending_ops_for_table(
   return false;
 }
 
+bool LineairDBTransaction::has_pending_row_ops_in_range(
+    const std::string& table_name, const std::string& start_key,
+    const std::string& end_key) const {
+  for (const auto& op : write_buffer_ops_) {
+    if (op.table_name != table_name) continue;
+    if (op.type != LineairDBProxy::BatchOp::Type::Write &&
+        op.type != LineairDBProxy::BatchOp::Type::Delete) {
+      continue;
+    }
+    if (op.key >= start_key && op.key < end_key) return true;
+  }
+  return false;
+}
+
 bool LineairDBTransaction::has_pending_secondary_ops_for_index(
     const std::string& table_name,
     const std::string& index_name) const {
@@ -1218,7 +1236,11 @@ void LineairDBTransaction::push_secondary_scan_cache(
 std::optional<LineairDBTransaction::LocalRangeScanEntry>
 LineairDBTransaction::lookup_range_scan_cache(
     const std::string& table_name, const std::string& start_key,
-    const std::string& end_key, bool reverse_scan, uint64_t row_limit) const {
+    const std::string& end_key, bool reverse_scan, uint64_t row_limit,
+    bool allow_truncated) const {
+  const bool pending_in_range =
+      has_pending_row_ops_in_range(table_name, start_key, end_key);
+
   // Grouped for_each range probes are staged by exact start key. Try that
   // index before falling back to the wider range-cache scan below.
   auto idx_it = range_scan_start_index_.find(
@@ -1227,6 +1249,7 @@ LineairDBTransaction::lookup_range_scan_cache(
     for (auto rit = idx_it->second.rbegin(); rit != idx_it->second.rend();
          ++rit) {
       const auto& e = range_scan_cache_[*rit];
+      if (e.row_limit != 0 && pending_in_range) continue;
       if (e.reverse_scan == reverse_scan && e.row_limit == row_limit &&
           end_key <= e.end_key) {
         // Copy and trim because the staged group may cover a wider range.
@@ -1255,6 +1278,7 @@ LineairDBTransaction::lookup_range_scan_cache(
 
   for (auto it = range_scan_cache_.rbegin();
        it != range_scan_cache_.rend(); ++it) {
+    if (it->row_limit != 0 && pending_in_range) continue;
     const bool same_table = it->table_name == table_name;
     const bool same_direction = it->reverse_scan == reverse_scan;
     const bool same_limit = it->row_limit == row_limit;
@@ -1279,6 +1303,27 @@ LineairDBTransaction::lookup_range_scan_cache(
       cached.rows = std::move(rows);
       cached.row_tids = std::move(row_tids);
       return cached;
+    }
+  }
+
+  // Serve an unbounded handler request from a LIMIT-staged entry only when
+  // the caller opted in to over-read aborts and no own row op can change the
+  // first-N window. `truncated` flows out through served_truncated.
+  if (allow_truncated && row_limit == 0 && !reverse_scan &&
+      !pending_in_range) {
+    auto idx_it = range_scan_start_index_.find(
+        scan_cache_index_key(table_name, "", start_key));
+    if (idx_it != range_scan_start_index_.end()) {
+      for (auto rit = idx_it->second.rbegin(); rit != idx_it->second.rend();
+           ++rit) {
+        const auto& e = range_scan_cache_[*rit];
+        if (e.row_limit > 0 && !e.reverse_scan && e.start_key == start_key &&
+            e.end_key == end_key) {
+          LocalRangeScanEntry cached = e;
+          cached.truncated = (e.rows.size() >= e.row_limit);
+          return cached;
+        }
+      }
     }
   }
   return std::nullopt;

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -745,7 +745,9 @@ LineairDBTransaction::fetch_next_key_with_prefix(const std::string &last_key,
 std::vector<std::string>
 LineairDBTransaction::get_matching_primary_keys_in_range(std::string index_name,
                                                          std::string start_key,
-                                                         std::string end_key) {
+                                                         std::string end_key,
+                                                         uint64_t row_limit,
+                                                         bool reverse_scan) {
   if (table_is_not_chosen()) return {};
   if (prefetch_mode_) {
     if (has_pending_secondary_ops_for_index(db_table_key, index_name)) {
@@ -754,8 +756,15 @@ LineairDBTransaction::get_matching_primary_keys_in_range(std::string index_name,
     }
 
     if (end_key.empty()) end_key = lineairdb_keyenc::scan_end_sentinel();
-    if (auto cached = lookup_secondary_scan_cache(
-            db_table_key, index_name, start_key, end_key, false, 0)) {
+    auto cached = lookup_secondary_scan_cache(
+        db_table_key, index_name, start_key, end_key, reverse_scan, row_limit);
+    if (!cached && row_limit != 0) {
+      // A full staged scan of the same range covers a limited request; the
+      // caller positions on the requested end of the materialized result.
+      cached = lookup_secondary_scan_cache(db_table_key, index_name, start_key,
+                                           end_key, false, 0);
+    }
+    if (cached) {
       rpc_trace_.record_local_view("use_si_scan:" + db_table_key + ":" +
                                    index_name + ":n=" +
                                    std::to_string(cached->primary_keys.size()));
@@ -1334,7 +1343,11 @@ LineairDBTransaction::lookup_secondary_scan_cache(
     const std::string& table_name, const std::string& index_name,
     const std::string& start_key, const std::string& end_key,
     bool reverse_scan, uint64_t row_limit) const {
-  (void)reverse_scan; // SI cache keeps the query-specific order from the plan
+  // Direction only matters for limited scans: an unlimited entry holds the
+  // whole range, but a LIMIT entry holds the first rows in its own direction.
+  const auto direction_compatible = [&](const LocalSecondaryScanEntry& e) {
+    return e.row_limit == 0 || e.reverse_scan == reverse_scan;
+  };
 
   // Grouped for_each secondary probes are staged by exact start key. Try that
   // index before falling back to the wider secondary-cache scan below.
@@ -1344,7 +1357,8 @@ LineairDBTransaction::lookup_secondary_scan_cache(
     for (auto rit = idx_it->second.rbegin(); rit != idx_it->second.rend();
          ++rit) {
       const auto& e = secondary_scan_cache_[*rit];
-      if (e.row_limit == row_limit && end_key <= e.end_key) {
+      if (e.row_limit == row_limit && end_key <= e.end_key &&
+          direction_compatible(e)) {
         // Copy and trim paired secondary/primary keys to the requested range.
         LocalSecondaryScanEntry cached = e;
         cached.start_key = start_key;
@@ -1377,7 +1391,8 @@ LineairDBTransaction::lookup_secondary_scan_cache(
     const bool same_limit = it->row_limit == row_limit;
     const bool covers_range =
         it->start_key <= start_key && end_key <= it->end_key;
-    if (same_index && same_limit && covers_range) {
+    if (same_index && same_limit && covers_range &&
+        direction_compatible(*it)) {
       LocalSecondaryScanEntry cached = *it;
       cached.start_key = start_key;
       cached.end_key = end_key;

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -50,7 +50,8 @@ public:
   bool write_secondary_index(std::string index_name, std::string secondary_key, const std::string primary_key);
   std::vector<std::string> read_secondary_index(std::string index_name, std::string secondary_key);
   std::vector<std::string> get_matching_primary_keys_in_range(
-      std::string index_name, std::string start_key, std::string end_key);
+      std::string index_name, std::string start_key, std::string end_key,
+      uint64_t row_limit = 0, bool reverse_scan = false);
   std::vector<std::string> get_matching_primary_keys_from_prefix(
       std::string index_name, std::string prefix);
   std::optional<std::string> fetch_last_key_in_range(

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -37,9 +37,13 @@ public:
   std::vector<std::string> get_all_keys();
   std::vector<std::string> get_matching_keys(std::string key);
   std::vector<std::string> get_matching_keys_in_range(std::string start_key, std::string end_key);
+  // Optional out: set when this call is served from a LIMIT-staged cache
+  // entry. The handler must not treat exhausting the returned rows as EOF.
+  // TODO: replace this out-param with a small result struct when scan-cache
+  // serving is split out of LineairDBTransaction.
   std::vector<std::pair<std::string, std::string>> get_matching_keys_and_values_in_range(
       std::string start_key, std::string end_key, uint64_t row_limit = 0,
-      bool reverse_scan = false);
+      bool reverse_scan = false, bool *served_truncated = nullptr);
   std::vector<std::pair<std::string, std::string>> get_matching_keys_and_values_from_prefix(
       std::string prefix);
   bool write(std::string key, const std::string value);
@@ -263,6 +267,9 @@ private:
     uint64_t row_limit = 0;
     std::vector<std::pair<std::string, std::string>> rows;
     std::vector<uint64_t> row_tids;
+    // Set only on lookup return copies: this entry came from a LIMIT-staged
+    // window, so the handler must abort if MySQL asks past these rows.
+    bool truncated = false;
   };
   struct LocalSecondaryScanEntry {
     std::string table_name;
@@ -318,6 +325,9 @@ private:
       std::vector<std::pair<std::string, std::string>>& rows,
       const std::string& prefix) const;
   bool has_pending_ops_for_table(const std::string& table_name) const;
+  bool has_pending_row_ops_in_range(const std::string& table_name,
+                                    const std::string& start_key,
+                                    const std::string& end_key) const;
   bool has_pending_secondary_ops_for_index(
       const std::string& table_name,
       const std::string& index_name) const;
@@ -338,7 +348,8 @@ private:
   void abort_prefetch_cache_miss(const std::string& reason);
   std::optional<LocalRangeScanEntry> lookup_range_scan_cache(
       const std::string& table_name, const std::string& start_key,
-      const std::string& end_key, bool reverse_scan, uint64_t row_limit) const;
+      const std::string& end_key, bool reverse_scan, uint64_t row_limit,
+      bool allow_truncated = false) const;
   std::optional<LocalSecondaryScanEntry> lookup_secondary_scan_cache(
       const std::string& table_name, const std::string& index_name,
       const std::string& start_key, const std::string& end_key,


### PR DESCRIPTION
## Summary

- Stage read-plan leaves from inner subquery plan trees, so reads inside supported `IN (...)` and correlated subquery shapes can participate in statement-scoped prefetch.
- Skip point read-plan steps that are already covered by the transaction's local view or row cache.
- Stage eligible LIMIT-bounded primary scans and guard against reading past the staged LIMIT window.
- Serve secondary `ORDER BY key DESC LIMIT 1` probes from staged reverse LIMIT 1 secondary scans.

## Why

The staged prefetch path can miss reads that are not direct leaves of the main statement plan tree, and it can also spend work on reads that are already available locally. Some ordered LIMIT queries also need only the first row in the chosen scan direction, but previously had to consume a broader range or miss the staged cache.

This branch extends the same prefetch machinery to those cases while keeping unsupported or validation-sensitive paths conservative.

## Details

- `autogen_read_plan_from_qep` can include inner `Query_expression` roots found under statement conditions. Those inner plan trees are compiled into the same statement read plan, allowing correlated probes to bind to earlier outer steps.
- Covered constant point reads are removed before executing a read plan; if every step is already covered, the read-plan RPC is skipped.
- Eligible primary scans carry `RangeScanLimit` metadata when the MySQL plan has a direct `LIMIT 0, N` shape over a single supported range read.
- LIMIT-staged scan cache entries report when the staged window is exhausted, so execution can fail loudly instead of silently returning an incomplete range.
- Secondary range cache lookup now receives the requested scan direction and row limit. Limited cache entries only answer matching directions, so an ASC LIMIT entry cannot satisfy a DESC LIMIT probe.