### PR TITLE
feat: reduce staged prefetch read-plan payload

### DIFF
--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -234,6 +234,9 @@ message TxExecuteReadPlan {
         RowProjection projection = 12;
         // Optional membership reduction for high-fanout join probes.
         repeated SemijoinFilter semijoins = 14;
+        // Drop filtered_keys when no later same-table probe can need negative
+        // coverage for rows rejected by the pushed filter.
+        bool suppress_filtered_keys = 15;
     }
     // Drop probe rows whose join key is absent from an earlier step's result.
     // Columns are 0-based TABLE::field[] ordinals.

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -246,6 +246,9 @@ message TxExecuteReadPlan {
         repeated uint32 group_sizes = 11;
         repeated bytes group_start_keys = 12;
         repeated bytes group_end_keys = 13;
+        // Primary keys rejected by the pushed scan filter. The proxy records
+        // them as negative row-cache entries for later point probes.
+        repeated bytes filtered_keys = 14;
     }
     message Request {
         repeated PlanStep steps = 1;

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -232,6 +232,17 @@ message TxExecuteReadPlan {
         // Optional column subset for staged rows. The server keeps full null
         // flags, sends only listed column values, and filters before trimming.
         RowProjection projection = 12;
+        // Optional membership reduction for high-fanout join probes.
+        repeated SemijoinFilter semijoins = 14;
+    }
+    // Drop probe rows whose join key is absent from an earlier step's result.
+    // Columns are 0-based TABLE::field[] ordinals.
+    message SemijoinFilter {
+        uint32 source_step = 1;
+        uint32 source_column = 2;
+        uint32 probe_column = 3;
+        // Optional filter applied while building the source membership set.
+        PushedPredicate source_filter = 4;
     }
     message RowProjection {
         uint32 num_columns = 1; // table->s->fields

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -229,6 +229,13 @@ message TxExecuteReadPlan {
         bool for_each = 9;
         bool reverse_scan = 10;
         PushedPredicate filter = 11; // Optional row filter for staged scans.
+        // Optional column subset for staged rows. The server keeps full null
+        // flags, sends only listed column values, and filters before trimming.
+        RowProjection projection = 12;
+    }
+    message RowProjection {
+        uint32 num_columns = 1; // table->s->fields
+        repeated uint32 field_indexes = 2 [packed = true]; // 0-based, sorted.
     }
     message StepResult {
         bool found = 1;

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -2305,12 +2305,81 @@ int ha_lineairdb::set_fields_from_lineairdb(uchar *buf,
   /* Avoid asserts in ::store() for columns that are not going to be updated
    */
   my_bitmap_map *org_bitmap = dbug_tmp_use_all_columns(table, table->write_set);
-  /**
-   * store each column value to corresponding field
-   */
+
+  THD *const thd_for_serve = ha_thd();
+  const uint64_t serve_query_id =
+      thd_for_serve != nullptr
+          ? static_cast<uint64_t>(thd_for_serve->query_id)
+          : 0;
+
+  // Refresh once per statement, and again if statement-root staging registers
+  // projection after an earlier unit serve populated the memo.
+  const uint64_t proj_epoch =
+      LineairDBTransaction::load_projection_global_epoch();
+  if (serve_memo_query_id_ != serve_query_id ||
+      serve_memo_proj_epoch_ != proj_epoch) {
+    serve_memo_query_id_ = serve_query_id;
+    serve_memo_proj_epoch_ = proj_epoch;
+    auto tx = get_transaction(thd_for_serve);
+    serve_memo_projection_ =
+        tx != nullptr ? tx->load_table_projection(db_table_name) : nullptr;
+
+    // DML may rebuild rows and secondary keys from this buffer, so only a
+    // plain SELECT can leave unread fields untouched.
+    serve_memo_can_skip_unread_fields_ =
+        thd_for_serve != nullptr && thd_for_serve->lex != nullptr &&
+        thd_for_serve->lex->sql_command == SQLCOM_SELECT;
+  }
+
+  const bool can_skip_unread_fields = serve_memo_can_skip_unread_fields_;
+
+  {
+    // Projected rows contain kept columns only; null flags remain full-width.
+    const std::vector<uint32_t> *kept = serve_memo_projection_;
+
+    // Unit-only prefetch can still serve full rows for a projected table.
+    if (kept != nullptr && ldbField.get_row_size() != kept->size()) {
+      kept = nullptr;
+    }
+
+    if (kept != nullptr) {
+      for (size_t projected_col = 0; projected_col < kept->size();
+           ++projected_col) {
+        const uint32_t field_index = (*kept)[projected_col];
+        if (field_index >= table->s->fields) break;
+        if (can_skip_unread_fields &&
+            !bitmap_is_set(table->read_set, field_index)) {
+          continue;
+        }
+        Field *f = table->field[field_index];
+        const auto mysqlFieldValue =
+            ldbField.get_column_of_row(projected_col);
+        if (f->is_nullable() && f->is_null_in_record(buf)) {
+          f->set_null();
+        } else {
+          f->store(mysqlFieldValue.data(), mysqlFieldValue.size(),
+                   &my_charset_bin, CHECK_FIELD_WARN);
+          Field *arr[2] = {f, nullptr};
+          if (store_blob_to_field(arr)) {
+            dbug_tmp_restore_column_map(table->write_set, org_bitmap);
+            return HA_ERR_OUT_OF_MEM;
+          }
+        }
+      }
+      dbug_tmp_restore_column_map(table->write_set, org_bitmap);
+      return 0;
+    }
+  }
+
+  // Full rows map parsed column index directly to TABLE::field[].
   size_t columnIndex = 0;
   for (Field **field = table->field; *field; field++) {
+    if (columnIndex >= ldbField.get_row_size()) break;  // short/trimmed value
     const auto mysqlFieldValue = ldbField.get_column_of_row(columnIndex++);
+    if (can_skip_unread_fields &&
+        !bitmap_is_set(table->read_set, (*field)->field_index())) {
+      continue;  // pure SELECT: column not read this statement
+    }
     if ((*field)->is_nullable() && (*field)->is_null_in_record(buf)) {
       (*field)->set_null();
     } else {

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -153,6 +153,18 @@ private:
   // rows are only a LIMIT-staged window. index_next()/index_next_same() consume
   // it and abort on over-read instead of returning a false EOF.
   bool materialized_scan_truncated_{false};
+  // Per-statement memo for set_fields_from_lineairdb.
+  // Refreshed when query_id or projection registration epoch changes.
+  uint64_t serve_memo_query_id_{0};
+  uint64_t serve_memo_proj_epoch_{0};
+
+  // Projection layout for the table currently being decoded; nullptr means
+  // rows are full-width.
+  const std::vector<uint32_t> *serve_memo_projection_{nullptr};
+
+  // True when this statement can skip Field::store outside read_set.
+  bool serve_memo_can_skip_unread_fields_{false};
+
   std::string last_fetched_primary_key_;
   std::string end_range_exclusive_key_; // For HA_READ_BEFORE_KEY: exclude this key from results
   my_off_t

--- a/proxy/lineairdb_autogen.cc
+++ b/proxy/lineairdb_autogen.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <string>
 #include <unordered_map>
@@ -834,8 +835,8 @@ bool compile_index_search(TABLE *table, uint index,
  *
  * @details The main statement tree and optional inner subquery trees share
  * `table_steps`, so correlated inner probes can bind to earlier outer steps.
- * `allow_limit_pushdown` is kept off for optional inner roots because LIMIT
- * metadata is read from the current statement context.
+ * `allow_limit_pushdown` is kept off for optional inner roots. `eq_edges`
+ * collects FIELD-to-keypart edges used by semijoin planning.
  *
  * @note Failures are returned through `unsupported` instead of raising
  * immediately; `added_tables` lets optional callers roll back only this tree's
@@ -845,7 +846,9 @@ bool compile_tree_leaves(
     THD *thd, AccessPath *root, bool allow_limit_pushdown,
     std::unordered_map<TABLE *, int> *table_steps,
     std::vector<LineairDBProxy::ReadPlanStep> *steps,
-    std::vector<TABLE *> *added_tables, UnsupportedQep *unsupported) {
+    std::vector<TABLE *> *added_tables,
+    std::vector<std::pair<Field *, Field *>> *eq_edges,
+    UnsupportedQep *unsupported) {
   std::vector<AccessPath *> leaves;
   bool ok = true;
   collect_qep_leaves(root, &leaves, &ok, unsupported);
@@ -868,6 +871,22 @@ bool compile_tree_leaves(
       unsupported->type = leaf->type;
       unsupported->reason = "unsupported QEP leaf";
       return false;
+    }
+    // Join edge for semijoin planning: source field -> probed keypart field.
+    if (eq_edges != nullptr && ref != nullptr && ref->items != nullptr &&
+        table->s != nullptr && ref->key >= 0 &&
+        ref->key < static_cast<int>(table->s->keys)) {
+      for (uint kp = 0; kp < ref->key_parts; ++kp) {
+        Item *val = ref->items[kp];
+        if (val == nullptr) continue;
+        val = val->real_item();
+        if (val->type() != Item::FIELD_ITEM) continue;
+        Field *sf = down_cast<Item_field *>(val)->field;
+        Field *tf = (kp < table->key_info[ref->key].user_defined_key_parts)
+                        ? table->key_info[ref->key].key_part[kp].field
+                        : nullptr;
+        if (sf != nullptr && tf != nullptr) eq_edges->emplace_back(sf, tf);
+      }
     }
     if (table->s != nullptr && table->s->tmp_table != NO_TMP_TABLE) {
       // Local MySQL temp tables are not stored in LineairDB, so there is
@@ -918,6 +937,44 @@ bool compile_tree_leaves(
 }
 
 /**
+ * @brief Return true when semijoin membership reduction is result-preserving.
+ *
+ * @details The reduction is limited to plain inner joins in the top-level
+ * query block. Outer joins, semi/anti nests, and nested query blocks can need
+ * rows that fail the membership test.
+ */
+bool semijoin_safe_leaf(const TABLE *table) {
+  if (table == nullptr) return false;
+  const Table_ref *ref = table->pos_in_table_list;
+  if (ref == nullptr) return false;
+  if (ref->is_inner_table_of_outer_join()) return false;
+  for (const Table_ref *embedding = ref->embedding; embedding != nullptr;
+       embedding = embedding->embedding) {
+    if (embedding->is_sj_or_aj_nest()) return false;
+  }
+  const Query_block *query_block = ref->query_block;
+  if (query_block == nullptr || query_block->outer_query_block() != nullptr) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @brief Check whether two join key fields can be compared as stored bytes.
+ */
+bool semijoin_keys_compatible(const Field *source, const Field *probe) {
+  if (source == nullptr || probe == nullptr) return false;
+  if (source->is_nullable() || probe->is_nullable()) return false;
+  if (source->type() != probe->type()) return false;
+  if (source->pack_length() != probe->pack_length()) return false;
+  if (source->result_type() == STRING_RESULT &&
+      source->charset() != probe->charset()) {
+    return false;
+  }
+  return true;
+}
+
+/**
  * @brief Collect plan roots that hang off Item-held subqueries.
  *
  * @details The main AccessPath tree does not cover every read MySQL may run.
@@ -964,9 +1021,10 @@ bool autogen_read_plan_from_qep(
   std::vector<TABLE *> added_tables;
   UnsupportedQep unsupported;
 
+  std::vector<std::pair<Field *, Field *>> eq_edges;
   if (!compile_tree_leaves(thd, root, /*allow_limit_pushdown=*/true,
                            &table_steps, &steps,
-                           &added_tables, &unsupported)) {
+                           &added_tables, &eq_edges, &unsupported)) {
     return raise_unsupported(thd, unsupported.type, unsupported.reason);
   }
 
@@ -981,10 +1039,13 @@ bool autogen_read_plan_from_qep(
       const size_t step_mark = steps.size();
       const size_t table_mark = added_tables.size();
       UnsupportedQep inner_unsupported;
+      const size_t edge_mark = eq_edges.size();
       if (!compile_tree_leaves(thd, inner_root,
                                /*allow_limit_pushdown=*/false, &table_steps,
-                               &steps, &added_tables, &inner_unsupported)) {
+                               &steps, &added_tables, &eq_edges,
+                               &inner_unsupported)) {
         steps.resize(step_mark);
+        eq_edges.resize(edge_mark);
         for (size_t i = table_mark; i < added_tables.size(); ++i) {
           table_steps.erase(added_tables[i]);
         }
@@ -1013,6 +1074,92 @@ bool autogen_read_plan_from_qep(
       std::string table_filter;
       if (build_single_table_filter(thd, t, &table_filter)) {
         s.serialized_filter = std::move(table_filter);
+      }
+    }
+  }
+
+  // Semijoin reduction: for high-fanout probes, use an earlier filtered
+  // source step as a membership set and skip probe rows that cannot join.
+  if (allow_filter_pushdown && !eq_edges.empty()) {
+    // Build join-key equivalence classes from FIELD=keypart edges.
+    std::unordered_map<Field *, Field *> uf;
+    std::function<Field *(Field *)> find_root = [&](Field *x) -> Field * {
+      auto it = uf.find(x);
+      if (it == uf.end()) { uf[x] = x; return x; }
+      if (it->second == x) return x;
+      Field *r = find_root(it->second);
+      uf[x] = r;
+      return r;
+    };
+    for (auto &e : eq_edges) uf[find_root(e.first)] = find_root(e.second);
+
+    // Probe candidates are grouped range scans driven by earlier rows.
+    for (auto &kvp : table_steps) {
+      TABLE *probe_t = kvp.first;
+      const int probe_step = kvp.second;
+      if (probe_step < 0 || probe_step >= static_cast<int>(steps.size()))
+        continue;
+      auto &ps = steps[probe_step];
+      if (!(ps.for_each && ps.is_scan)) continue;  // FER/FES high-fanout only
+      if (!semijoin_safe_leaf(probe_t)) continue;
+      if (probe_t->s == nullptr) continue;
+
+      // Find the field whose value each probe row will join on.
+      Field *probe_field = nullptr;
+      if (!ps.index_name.empty()) {
+        for (uint k = 0; k < probe_t->s->keys; ++k) {
+          if (ps.index_name == probe_t->key_info[k].name) {
+            probe_field = probe_t->key_info[k].key_part[0].field;
+            break;
+          }
+        }
+      } else if (probe_t->s->primary_key != MAX_KEY) {
+        probe_field =
+            probe_t->key_info[probe_t->s->primary_key].key_part[0].field;
+      }
+      if (probe_field == nullptr || uf.find(probe_field) == uf.end()) continue;
+      Field *cls = find_root(probe_field);
+
+      // Source candidates must be earlier steps in the same query block.
+      for (auto &kvp2 : table_steps) {
+        TABLE *src_t = kvp2.first;
+        const int src_step = kvp2.second;
+        if (src_step >= probe_step || src_step < 0 ||
+            src_step >= static_cast<int>(steps.size()))
+          continue;
+        if (!semijoin_safe_leaf(src_t)) continue;
+        if (src_t->pos_in_table_list->query_block !=
+            probe_t->pos_in_table_list->query_block)
+          continue;
+        if (!steps[src_step].is_scan) continue;
+
+        // Source membership must come from rows already filtered, or from a
+        // source_filter carried by the semijoin.
+        std::string sf_filter;
+        const bool src_prefiltered =
+            steps[src_step].is_scan && !steps[src_step].for_each &&
+            !steps[src_step].serialized_filter.empty();
+        if (!src_prefiltered &&
+            (!build_single_table_filter(thd, src_t, &sf_filter) ||
+             sf_filter.empty()))
+          continue;  // no selective predicate -> not a useful source
+        if (src_t->s == nullptr || src_t->s->primary_key == MAX_KEY) continue;
+        Field *src_pk =
+            src_t->key_info[src_t->s->primary_key].key_part[0].field;
+        if (uf.find(src_pk) == uf.end() || find_root(src_pk) != cls) continue;
+        if (!semijoin_keys_compatible(src_pk, probe_field)) continue;
+
+        // Attach one source membership test to this probe step.
+        const int sc = qep_table_field_index(src_t, src_pk);
+        const int pc = qep_table_field_index(probe_t, probe_field);
+        if (sc < 0 || pc < 0) continue;
+        LineairDBProxy::ReadPlanStep::Semijoin sj;
+        sj.source_step = static_cast<uint32_t>(src_step);
+        sj.source_column = static_cast<uint32_t>(sc);
+        sj.probe_column = static_cast<uint32_t>(pc);
+        if (!src_prefiltered) sj.source_filter = std::move(sf_filter);
+        ps.semijoins.push_back(std::move(sj));
+        break;  // one semijoin source per probe step
       }
     }
   }
@@ -1078,6 +1225,24 @@ void plan_projection_pushdown(
     for (const auto &b : s.end_bindings) force_binding_col(b);
   }
 
+  // Semijoin source rows must keep the column used for membership. A
+  // source_filter uses full-row ordinals, so that source ships full rows.
+  for (const auto &s : *steps) {
+    for (const auto &sj : s.semijoins) {
+      if (sj.source_step >= steps->size()) continue;
+      const std::string &src = (*steps)[sj.source_step].table_name;
+      auto fo = fields_of.find(src);
+      if (fo == fields_of.end()) continue;
+      if (!sj.source_filter.empty()) {
+        unsafe_src.insert(src);  // full-row filter indices -> ship full
+      } else if (sj.source_column < fo->second) {
+        auto &u = union_rs[src];
+        if (u.size() < fo->second) u.resize(fo->second, false);
+        u[sj.source_column] = true;
+      }
+    }
+  }
+
   // Pick projected tables and build full ordinal -> projected position maps.
   // Positions are 1-based because source_column==0 means byte-slice binding.
   std::unordered_map<std::string, std::vector<uint32_t>> full_to_proj;
@@ -1110,6 +1275,20 @@ void plan_projection_pushdown(
   for (auto &s : *steps) {
     for (auto &b : s.bindings) remap_binding(b);
     for (auto &b : s.end_bindings) remap_binding(b);
+  }
+
+  // Remap each semijoin's source_column to its projected position when the
+  // source step is projected (pre-filtered branch; force-kept above, so the
+  // packed position is nonzero). Full-shipped sources keep full ordinals.
+  for (auto &s : *steps) {
+    for (auto &sj : s.semijoins) {
+      if (sj.source_step >= steps->size()) continue;
+      auto it = full_to_proj.find((*steps)[sj.source_step].table_name);
+      if (it == full_to_proj.end()) continue;
+      const uint32_t fi = sj.source_column;
+      const uint32_t pos = (fi < it->second.size()) ? it->second[fi] : 0;
+      if (pos > 0) sj.source_column = pos - 1;  // 1-based f2p -> 0-based packed
+    }
   }
 
   for (auto &s : *steps) {

--- a/proxy/lineairdb_autogen.cc
+++ b/proxy/lineairdb_autogen.cc
@@ -5,6 +5,7 @@
 #include <limits>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -1018,6 +1019,105 @@ bool autogen_read_plan_from_qep(
 
   *out = std::move(steps);
   return true;
+}
+
+void plan_projection_pushdown(
+    THD *thd, std::vector<LineairDBProxy::ReadPlanStep> *steps,
+    std::unordered_map<std::string, std::vector<uint32_t>> *kept_out) {
+  kept_out->clear();
+  if (thd == nullptr || thd->lex == nullptr || steps == nullptr) return;
+
+  std::unordered_map<std::string, std::vector<bool>> union_rs;
+  std::unordered_map<std::string, uint32_t> fields_of;
+  std::unordered_set<std::string> gcol_tables;
+
+  // Merge read_set by physical table; one projection layout is shared by all
+  // aliases that read the same LineairDB table.
+  for (auto *tl = thd->lex->query_tables; tl != nullptr; tl = tl->next_global) {
+    if (tl->table == nullptr || tl->table->s == nullptr) continue;
+    TABLE *t = tl->table;
+    const std::string n = physical_table_key(t);
+    const uint32_t nf = t->s->fields;
+    fields_of[n] = nf;
+    auto &u = union_rs[n];
+    if (u.size() < nf) u.resize(nf, false);
+    for (uint f = 0; f < nf; ++f) {
+      if (t->field[f]->is_gcol()) gcol_tables.insert(n);
+      if (bitmap_is_set(t->read_set, f)) u[f] = true;
+    }
+  }
+
+  // Keep columns needed by value bindings. Column-form bindings can be
+  // remapped to the trimmed layout; byte-slice bindings need the source row
+  // to stay full because their offsets are not column-aware.
+  std::unordered_set<std::string> unsafe_src;
+  const auto force_binding_col =
+      [&](const LineairDBProxy::ReadPlanKeyBinding &b) {
+        if (b.from_key || b.source_step >= steps->size()) return;
+        const std::string &src = (*steps)[b.source_step].table_name;
+        auto fo = fields_of.find(src);
+        if (fo == fields_of.end()) {
+          unsafe_src.insert(src);
+          return;
+        }
+        if (b.source_column > 0) {
+          const uint32_t fi = static_cast<uint32_t>(b.source_column - 1);
+          if (fi >= fo->second) {
+            unsafe_src.insert(src);
+            return;
+          }
+          auto &u = union_rs[src];
+          if (u.size() < fo->second) u.resize(fo->second, false);
+          u[fi] = true;  // keep the binding's source column through the trim
+        } else {
+          unsafe_src.insert(src);  // byte-slice form: not remappable
+        }
+      };
+  for (const auto &s : *steps) {
+    for (const auto &b : s.bindings) force_binding_col(b);
+    for (const auto &b : s.end_bindings) force_binding_col(b);
+  }
+
+  // Pick projected tables and build full ordinal -> projected position maps.
+  // Positions are 1-based because source_column==0 means byte-slice binding.
+  std::unordered_map<std::string, std::vector<uint32_t>> full_to_proj;
+  for (auto &kv : union_rs) {
+    const std::string &n = kv.first;
+    if (gcol_tables.count(n) != 0 || unsafe_src.count(n) != 0) continue;
+    const uint32_t nf = fields_of[n];
+    std::vector<uint32_t> kept;
+    for (uint32_t f = 0; f < nf; ++f) {
+      if (kv.second[f]) kept.push_back(f);
+    }
+    if (kept.empty() || kept.size() == nf) continue;  // no benefit
+    std::vector<uint32_t> f2p(nf, 0);
+    for (uint32_t k = 0; k < kept.size(); ++k) f2p[kept[k]] = k + 1;
+    full_to_proj.emplace(n, std::move(f2p));
+    kept_out->emplace(n, std::move(kept));
+  }
+
+  // Remap column-form bindings from original column ordinal to projected
+  // ordinal, matching the row layout the server will actually ship.
+  const auto remap_binding = [&](LineairDBProxy::ReadPlanKeyBinding &b) {
+    if (b.from_key || b.source_column <= 0 || b.source_step >= steps->size())
+      return;
+    auto it = full_to_proj.find((*steps)[b.source_step].table_name);
+    if (it == full_to_proj.end()) return;  // source ships full rows
+    const uint32_t fi = static_cast<uint32_t>(b.source_column - 1);
+    const uint32_t pos = (fi < it->second.size()) ? it->second[fi] : 0;
+    if (pos > 0) b.source_column = static_cast<int32_t>(pos);
+  };
+  for (auto &s : *steps) {
+    for (auto &b : s.bindings) remap_binding(b);
+    for (auto &b : s.end_bindings) remap_binding(b);
+  }
+
+  for (auto &s : *steps) {
+    auto it = kept_out->find(s.table_name);
+    if (it == kept_out->end()) continue;
+    s.projection = it->second;
+    s.projection_num_columns = fields_of[s.table_name];
+  }
 }
 
 // Produce a one-step prefetch plan from the handler access, raising

--- a/proxy/lineairdb_autogen.cc
+++ b/proxy/lineairdb_autogen.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "lineairdb_keyenc.hh"
+#include "lineairdb_pushdown.hh"
 #include "my_base.h"
 #include "my_sys.h"
 #include "mysqld_error.h"
@@ -840,8 +841,7 @@ bool compile_index_search(TABLE *table, uint index,
  * additions.
  */
 bool compile_tree_leaves(
-    THD *thd, AccessPath *root, bool allow_filter_pushdown,
-    bool allow_limit_pushdown,
+    THD *thd, AccessPath *root, bool allow_limit_pushdown,
     std::unordered_map<TABLE *, int> *table_steps,
     std::vector<LineairDBProxy::ReadPlanStep> *steps,
     std::vector<TABLE *> *added_tables, UnsupportedQep *unsupported) {
@@ -908,13 +908,6 @@ bool compile_tree_leaves(
       }
     }
 
-    // Attach scan filters only when the caller allows filtered read-plan
-    // results. Callers that need a complete scanned key set pass false.
-    if (allow_filter_pushdown && step.is_scan && table->file != nullptr) {
-      step.serialized_filter =
-          down_cast<ha_lineairdb *>(table->file)->pushed_filter_for_autogen();
-    }
-
     (*table_steps)[table] = static_cast<int>(steps->size());
     added_tables->push_back(table);
     steps->push_back(std::move(step));
@@ -970,8 +963,8 @@ bool autogen_read_plan_from_qep(
   std::vector<TABLE *> added_tables;
   UnsupportedQep unsupported;
 
-  if (!compile_tree_leaves(thd, root, allow_filter_pushdown,
-                           /*allow_limit_pushdown=*/true, &table_steps, &steps,
+  if (!compile_tree_leaves(thd, root, /*allow_limit_pushdown=*/true,
+                           &table_steps, &steps,
                            &added_tables, &unsupported)) {
     return raise_unsupported(thd, unsupported.type, unsupported.reason);
   }
@@ -987,10 +980,9 @@ bool autogen_read_plan_from_qep(
       const size_t step_mark = steps.size();
       const size_t table_mark = added_tables.size();
       UnsupportedQep inner_unsupported;
-      if (!compile_tree_leaves(thd, inner_root, allow_filter_pushdown,
+      if (!compile_tree_leaves(thd, inner_root,
                                /*allow_limit_pushdown=*/false, &table_steps,
-                               &steps, &added_tables,
-                               &inner_unsupported)) {
+                               &steps, &added_tables, &inner_unsupported)) {
         steps.resize(step_mark);
         for (size_t i = table_mark; i < added_tables.size(); ++i) {
           table_steps.erase(added_tables[i]);
@@ -1002,6 +994,26 @@ bool autogen_read_plan_from_qep(
 
   if (steps.empty()) {
     return raise_unsupported(thd, root->type, "QEP has no stageable leaves");
+  }
+
+  // Attach scan filters after the full plan is known.
+  if (allow_filter_pushdown) {
+    std::unordered_map<std::string, int> table_step_count;
+    for (const auto &s : steps) table_step_count[s.table_name]++;
+    for (size_t i = 0; i < steps.size(); ++i) {
+      auto &s = steps[i];
+      if (!s.is_scan) continue;
+      // Rejected keys become table-level not-found cache entries. If the same
+      // physical table appears more than once, aliases may have different
+      // predicates, so skip filter pushdown for that table.
+      if (table_step_count[s.table_name] != 1) continue;
+      TABLE *t = i < added_tables.size() ? added_tables[i] : nullptr;
+      if (t == nullptr) continue;
+      std::string table_filter;
+      if (build_single_table_filter(thd, t, &table_filter)) {
+        s.serialized_filter = std::move(table_filter);
+      }
+    }
   }
 
   *out = std::move(steps);

--- a/proxy/lineairdb_autogen.hh
+++ b/proxy/lineairdb_autogen.hh
@@ -1,6 +1,9 @@
 #ifndef LINEAIRDB_AUTOGEN_HH
 #define LINEAIRDB_AUTOGEN_HH
 
+#include <cstdint>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 class THD;
@@ -39,5 +42,18 @@ bool autogen_read_plan_from_qep(
 bool autogen_read_plan_from_index_search(
     THD *thd, TABLE *table, uint index, const IndexSearchPlan &search,
     std::vector<LineairDBProxy::ReadPlanStep> *out);
+
+/**
+ * @brief Plan column projection for staged read-plan rows.
+ *
+ * @details For each physical table, union read_set across aliases and annotate
+ * eligible steps with the kept column ordinals. Column-form value bindings
+ * force their source column to stay in the projection and are remapped to the
+ * trimmed layout. Byte-slice bindings and generated-column tables ship full
+ * rows.
+ */
+void plan_projection_pushdown(
+    THD *thd, std::vector<LineairDBProxy::ReadPlanStep> *steps,
+    std::unordered_map<std::string, std::vector<uint32_t>> *kept_out);
 
 #endif

--- a/proxy/lineairdb_field.hh
+++ b/proxy/lineairdb_field.hh
@@ -55,6 +55,9 @@ class LineairDBField {
                             const size_t length);
   std::string_view get_null_flags() const { return nullFlagView; }
   std::string_view get_column_of_row(const size_t i) const { return row[i]; }
+  // Parsed column count: a projection-trimmed value holds only the kept
+  // columns, so decoders must size their mapping by this, not s->fields.
+  size_t get_row_size() const { return row.size(); }
 
   LineairDBField() = default;
 

--- a/proxy/lineairdb_prefetch.cc
+++ b/proxy/lineairdb_prefetch.cc
@@ -4,8 +4,6 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
-#include <cstdlib>
-#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -354,7 +352,8 @@ void maybe_prefetch_for_transaction(THD *thd,
 // Build the read plan from the given QEP root and run it in one prefetch RPC.
 static int autogen_and_execute_prefetch(THD *thd, AccessPath *root,
                                         LineairDBTransaction *tx,
-                                        bool include_inner_units = false) {
+                                        bool include_inner_units = false,
+                                        bool allow_projection = false) {
   std::vector<LineairDBProxy::ReadPlanStep> steps;
   if (!autogen_read_plan_from_qep(thd, root, tx->ro_novalidate(), &steps,
                                   include_inner_units)) {
@@ -364,6 +363,16 @@ static int autogen_and_execute_prefetch(THD *thd, AccessPath *root,
     return HA_ERR_UNSUPPORTED;
   }
   if (steps.empty()) return 0;
+
+  // Trim rows only for statement-root read-only prefetch; unit episodes can
+  // run before read_set is final and must ship full rows.
+  if (allow_projection && tx->ro_novalidate()) {
+    std::unordered_map<std::string, std::vector<uint32_t>> kept_of;
+    plan_projection_pushdown(thd, &steps, &kept_of);
+    for (auto &kv : kept_of) {
+      tx->set_table_projection(kv.first, std::move(kv.second));
+    }
+  }
 
   // Loads the prefetched rows into the local cache and validation sets.
   tx->execute_read_plan(steps);
@@ -481,9 +490,12 @@ int maybe_prefetch_for_statement(THD *thd, LineairDBTransaction *tx,
           thd, tx, "read-bearing statement is not prefetch-eligible");
     }
 
-    // Some subqueries live under Item conditions instead of the main plan tree.
+    // Statement-level staging also sweeps Item-embedded subquery plan trees
+    // that are invisible to the main-tree leaf walk. This is the only episode
+    // allowed to trim rows, so each table has one projection layout per tx.
     return autogen_and_execute_prefetch(thd, stmt_root, tx,
-                                        /*include_inner_units=*/true);
+                                        /*include_inner_units=*/true,
+                                        /*allow_projection=*/true);
   }
 
   // No statement root yet: MySQL is evaluating a subquery before the outer

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -442,6 +442,11 @@ LineairDBProxy::ReadPlanResult LineairDBProxy::tx_execute_read_plan(
         if (!step.serialized_filter.empty()) {
             out->mutable_filter()->ParseFromString(step.serialized_filter);
         }
+        if (!step.projection.empty() && step.projection_num_columns > 0) {
+            auto* p = out->mutable_projection();
+            p->set_num_columns(step.projection_num_columns);
+            for (uint32_t f : step.projection) p->add_field_indexes(f);
+        }
         for (const auto& binding : step.bindings) {
             auto* b = out->add_bindings();
             b->set_source_step(binding.source_step);

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -447,6 +447,15 @@ LineairDBProxy::ReadPlanResult LineairDBProxy::tx_execute_read_plan(
             p->set_num_columns(step.projection_num_columns);
             for (uint32_t f : step.projection) p->add_field_indexes(f);
         }
+        for (const auto& sj : step.semijoins) {
+            auto* o = out->add_semijoins();
+            o->set_source_step(sj.source_step);
+            o->set_source_column(sj.source_column);
+            o->set_probe_column(sj.probe_column);
+            if (!sj.source_filter.empty()) {
+                o->mutable_source_filter()->ParseFromString(sj.source_filter);
+            }
+        }
         for (const auto& binding : step.bindings) {
             auto* b = out->add_bindings();
             b->set_source_step(binding.source_step);

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -439,6 +439,7 @@ LineairDBProxy::ReadPlanResult LineairDBProxy::tx_execute_read_plan(
         out->set_index_name(step.index_name);
         out->set_for_each(step.for_each);
         out->set_reverse_scan(step.reverse_scan);
+        out->set_suppress_filtered_keys(step.suppress_filtered_keys);
         if (!step.serialized_filter.empty()) {
             out->mutable_filter()->ParseFromString(step.serialized_filter);
         }

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -513,8 +513,9 @@ LineairDBProxy::ReadPlanResult LineairDBProxy::tx_execute_read_plan(
 
     // Native-endian bytes spell "LDBFLATP" (LineairDB flat payload).
     static constexpr uint64_t kFlatMagic = 0x5054414C4642444Cull;
+    static constexpr uint8_t kFlatVersion = 2;
     Reader r(raw.data(), raw.size());
-    if (r.u64() != kFlatMagic || r.u8() != 1) {
+    if (r.u64() != kFlatMagic || r.u8() != kFlatVersion) {
         LOG_ERROR("RPC failed: bad flat read-plan response header");
         return result;
     }
@@ -566,6 +567,10 @@ LineairDBProxy::ReadPlanResult LineairDBProxy::tx_execute_read_plan(
         out.group_end_keys.reserve(cap(n));
         for (uint64_t j = 0; j < n && r.ok; ++j)
             out.group_end_keys.push_back(r.bytes());
+        n = r.u64();
+        out.filtered_keys.reserve(cap(n));
+        for (uint64_t j = 0; j < n && r.ok; ++j)
+            out.filtered_keys.push_back(r.bytes());
         result.steps.push_back(std::move(out));
     }
     if (!r.ok) {

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -188,6 +188,8 @@ public:
         std::vector<uint32_t> group_sizes;
         std::vector<std::string> group_start_keys;
         std::vector<std::string> group_end_keys;
+        // Keys the step filter rejected (plain scans): negative coverage.
+        std::vector<std::string> filtered_keys;
     };
     struct ReadPlanResult {
         bool ok = false;

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -172,6 +172,10 @@ public:
         bool reverse_scan = false;
         // Serialized PushedPredicate; empty means no server-side filter.
         std::string serialized_filter;
+        // Projection pushdown: kept 0-based TABLE::field[] ordinals (ascending,
+        // unique). Empty = ship full rows. num_columns = table->s->fields.
+        std::vector<uint32_t> projection;
+        uint32_t projection_num_columns = 0;
     };
     struct ReadPlanStepResult {
         bool found = false;

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -185,6 +185,8 @@ public:
             std::string source_filter;
         };
         std::vector<Semijoin> semijoins;
+        // Drop filtered_keys when no later same-table probe can need them.
+        bool suppress_filtered_keys = false;
     };
     struct ReadPlanStepResult {
         bool found = false;

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -176,6 +176,15 @@ public:
         // unique). Empty = ship full rows. num_columns = table->s->fields.
         std::vector<uint32_t> projection;
         uint32_t projection_num_columns = 0;
+        // Semijoin reduction: keep probe rows only when their join key appears
+        // in an earlier source step.
+        struct Semijoin {
+            uint32_t source_step = 0;
+            uint32_t source_column = 0;
+            uint32_t probe_column = 0;
+            std::string source_filter;
+        };
+        std::vector<Semijoin> semijoins;
     };
     struct ReadPlanStepResult {
         bool found = false;

--- a/proxy/lineairdb_pushdown.cc
+++ b/proxy/lineairdb_pushdown.cc
@@ -263,7 +263,122 @@ static bool item_is_limit_safe_filter(const Item *item) {
          item_is_limit_safe_scalar(args[1]);
 }
 
-// Push the SELECT WHERE into this transaction if LIMIT will depend on it
+/**
+ * @brief Collect predicates that reference only one table from an AND tree.
+ *
+ * @details Cross-table and constant predicates are skipped. Dropping them only
+ * relaxes the pushed filter, because MySQL still evaluates the full WHERE
+ * later.
+ */
+static void collect_table_local_predicates(Item *it, table_map me,
+                                           std::vector<Item *> *out) {
+  if (it == nullptr) return;
+  if (it->type() == Item::COND_ITEM &&
+      down_cast<Item_cond *>(it)->functype() == Item_func::COND_AND_FUNC) {
+    for (Item &child : *down_cast<Item_cond *>(it)->argument_list()) {
+      collect_table_local_predicates(&child, me, out);
+    }
+  } else if (it->used_tables() == me) {
+    out->push_back(it);
+  }
+}
+
+/**
+ * @brief Serialize the table-local necessary condition of an OR predicate.
+ *
+ * @details Every OR branch must constrain this table. If one branch does not,
+ * pushing the OR would be stricter than the query, so this returns false.
+ *
+ * @return true when the OR has a safe table-local predicate.
+ */
+static bool serialize_or_necessary_condition(
+    Item *or_item, table_map me, LineairDB::Protocol::FilterExpr *out) {
+  if (or_item == nullptr || or_item->type() != Item::COND_ITEM ||
+      down_cast<Item_cond *>(or_item)->functype() != Item_func::COND_OR_FUNC)
+    return false;
+  out->set_op(LineairDB::Protocol::FilterExpr::OP_OR);
+
+  // Every OR branch must have a predicate for this table.
+  for (Item &disj : *down_cast<Item_cond *>(or_item)->argument_list()) {
+    std::vector<Item *> branch_predicates;
+    collect_table_local_predicates(&disj, me, &branch_predicates);
+    if (branch_predicates.empty()) return false;  // unconstrained branch
+
+    // Multiple predicates in one branch stay grouped under AND.
+    LineairDB::Protocol::FilterExpr branch;
+    if (branch_predicates.size() == 1) {
+      if (!serialize_item(branch_predicates[0], &branch)) return false;
+    } else {
+      branch.set_op(LineairDB::Protocol::FilterExpr::OP_AND);
+      for (Item *predicate : branch_predicates)
+        if (!serialize_item(predicate, branch.add_children())) return false;
+    }
+    *out->add_children() = std::move(branch);
+  }
+  return out->children_size() > 0;
+}
+
+bool build_single_table_filter(THD *thd, TABLE *table,
+                               std::string *out_serialized) {
+  if (out_serialized == nullptr) return false;
+  out_serialized->clear();
+  if (thd == nullptr || table == nullptr || table->s == nullptr) return false;
+  if (table->pos_in_table_list == nullptr) return false;
+
+  // Read the WHERE from the query block that owns this table reference.
+  Query_block *qb = table->pos_in_table_list->query_block;
+  if (qb == nullptr) return false;
+  Item *where = qb->where_cond();
+  if (where == nullptr) return false;
+
+  const table_map me = table->pos_in_table_list->map();
+
+  std::vector<LineairDB::Protocol::FilterExpr> serialized;
+
+  // Split only the top-level AND; each conjunct can be pushed independently.
+  std::vector<Item *> conjuncts;
+  if (where->type() == Item::COND_ITEM &&
+      down_cast<Item_cond *>(where)->functype() == Item_func::COND_AND_FUNC) {
+    for (Item &c : *down_cast<Item_cond *>(where)->argument_list())
+      conjuncts.push_back(&c);
+  } else {
+    conjuncts.push_back(where);
+  }
+
+  // Serialize table-local predicates. OR must be safe as a necessary condition.
+  for (Item *c : conjuncts) {
+    if (c->type() == Item::COND_ITEM &&
+        down_cast<Item_cond *>(c)->functype() == Item_func::COND_OR_FUNC) {
+      LineairDB::Protocol::FilterExpr or_expr;
+      if (serialize_or_necessary_condition(c, me, &or_expr))
+        serialized.push_back(std::move(or_expr));
+    } else {
+      std::vector<Item *> table_predicates;
+      collect_table_local_predicates(c, me, &table_predicates);
+      for (Item *predicate : table_predicates) {
+        LineairDB::Protocol::FilterExpr expr;
+        if (serialize_item(predicate, &expr))
+          serialized.push_back(std::move(expr));
+      }
+    }
+  }
+  if (serialized.empty()) return false;
+
+  // Combine all pushed pieces with AND and attach the table column count.
+  LineairDB::Protocol::PushedPredicate predicate;
+  predicate.set_num_columns(table->s->fields);
+  if (serialized.size() == 1) {
+    *predicate.mutable_expr() = std::move(serialized[0]);
+  } else {
+    auto *root = predicate.mutable_expr();
+    root->set_op(LineairDB::Protocol::FilterExpr::OP_AND);
+    for (auto &expr : serialized) *root->add_children() = std::move(expr);
+  }
+  predicate.SerializeToString(out_serialized);
+  return !out_serialized->empty();
+}
+
+// Push the SELECT WHERE into this transaction if LIMIT will depend on it.
 bool prepare_select_filter_for_tx(THD *thd, TABLE *table,
                                   LineairDBTransaction *tx,
                                   std::string *serialized_filter) {

--- a/proxy/lineairdb_pushdown.hh
+++ b/proxy/lineairdb_pushdown.hh
@@ -17,4 +17,20 @@ bool prepare_select_filter_for_tx(THD *thd, TABLE *table,
                                   LineairDBTransaction *tx,
                                   std::string *serialized_filter);
 
+/**
+ * @brief Build a predicate that is safe to run on one table's staged scan.
+ *
+ * @details Top-level AND predicates can be pushed when they reference only
+ * `table`. For OR, every branch must contribute a table-local predicate;
+ * otherwise the OR is left for MySQL. MySQL still evaluates the full WHERE, so
+ * under-pushing is safe.
+ *
+ * @param thd Current MySQL session.
+ * @param table Table whose staged scan would receive the predicate.
+ * @param out_serialized Serialized PushedPredicate output.
+ * @return true when a non-empty predicate was serialized.
+ */
+bool build_single_table_filter(THD *thd, TABLE *table,
+                               std::string *out_serialized);
+
 #endif // LINEAIRDB_PUSHDOWN_HH

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -403,6 +403,11 @@ void LineairDBTransaction::execute_read_plan(
           {step.table_name, step_result.actual_start_key,
            step_result.actual_end_key, step.reverse_scan, step.scan_limit,
            std::move(rows), std::move(row_tids)});
+      // Rejected primary keys become local not-found answers for later point
+      // probes into this filtered scan.
+      for (auto& fk : step_result.filtered_keys) {
+        record_row_cache(step.table_name, fk, false, "", 0, true);
+      }
     } else {
       // Keep secondary_keys and primary_keys aligned; lookup walks the pairs.
       LocalSecondaryScanEntry cached;
@@ -429,6 +434,11 @@ void LineairDBTransaction::execute_read_plan(
         cached.primary_keys.push_back(std::move(key));
       }
       push_secondary_scan_cache(std::move(cached));
+      // Secondary scans also register rejected primary keys as local not-found
+      // rows.
+      for (auto& fk : step_result.filtered_keys) {
+        record_row_cache(step.table_name, fk, false, "", 0, true);
+      }
     }
     step_result = LineairDBProxy::ReadPlanStepResult{};
   }

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -244,19 +244,50 @@ void LineairDBTransaction::execute_read_plan(
   if (!prefetch_mode_ || full_steps.empty()) return;
 
   // Exact point reads already covered by the local view need no staging RPC.
+  // Referenced steps must survive because later bindings/semijoins point at
+  // them by source_step index.
+  std::vector<bool> referenced(full_steps.size(), false);
+  for (const auto& step : full_steps) {
+    for (const auto& b : step.bindings) {
+      if (b.source_step < referenced.size()) referenced[b.source_step] = true;
+    }
+    for (const auto& b : step.end_bindings) {
+      if (b.source_step < referenced.size()) referenced[b.source_step] = true;
+    }
+    for (const auto& sj : step.semijoins) {
+      if (sj.source_step < referenced.size())
+        referenced[sj.source_step] = true;
+    }
+  }
+
   std::vector<LineairDBProxy::ReadPlanStep> steps;
   steps.reserve(full_steps.size());
-  for (const auto& step : full_steps) {
+  std::vector<uint32_t> new_index(full_steps.size(), 0);
+  size_t covered = 0;
+  for (size_t si = 0; si < full_steps.size(); ++si) {
+    const auto& step = full_steps[si];
     const bool constant_point_read = !step.is_scan && !step.for_each &&
                                      step.bindings.empty() &&
                                      step.end_bindings.empty() &&
                                      !step.key_prefix.empty();
-    if (constant_point_read &&
+    if (constant_point_read && !referenced[si] &&
         (lookup_write_set(step.table_name, step.key_prefix) ||
          lookup_row_cache(step.table_name, step.key_prefix))) {
+      ++covered;
       continue;
     }
+    new_index[si] = static_cast<uint32_t>(steps.size());
     steps.push_back(step);
+  }
+  if (covered > 0) {
+    // Remap source_step after dropping covered point reads.
+    for (auto& step : steps) {
+      for (auto& b : step.bindings) b.source_step = new_index[b.source_step];
+      for (auto& b : step.end_bindings)
+        b.source_step = new_index[b.source_step];
+      for (auto& sj : step.semijoins)
+        sj.source_step = new_index[sj.source_step];
+    }
   }
   if (steps.empty()) return;
 

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -291,6 +291,19 @@ void LineairDBTransaction::execute_read_plan(
   }
   if (steps.empty()) return;
 
+  // Suppress negative coverage only when this table has one filtered scan step;
+  // no later same-table point probe can need those rejected keys.
+  {
+    std::unordered_map<std::string, int> table_step_count;
+    for (const auto& s : steps) table_step_count[s.table_name]++;
+    for (auto& s : steps) {
+      if (s.is_scan && !s.serialized_filter.empty() &&
+          table_step_count[s.table_name] == 1) {
+        s.suppress_filtered_keys = true;
+      }
+    }
+  }
+
   rpc_trace_.record_local_view("plan_request:steps=" +
                                std::to_string(steps.size()));
   auto result = lineairdb_proxy->tx_execute_read_plan(steps);

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -1,6 +1,7 @@
 #ifndef LINEAIRDB_TRANSACTION_HH
 #define LINEAIRDB_TRANSACTION_HH
 
+#include <atomic>
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
@@ -166,6 +167,21 @@ public:
   const std::string& get_pushed_filter() const { return pushed_filter_; }
   void clear_pushed_filter() { pushed_filter_.clear(); }
 
+  // Projection pushdown stores kept field ordinals per physical table.
+  static uint64_t load_projection_global_epoch() {
+    return projection_epoch_.load(std::memory_order_relaxed);
+  }
+  void set_table_projection(const std::string& table_name,
+                            std::vector<uint32_t> kept) {
+    table_projection_[table_name] = std::move(kept);
+    projection_epoch_.fetch_add(1, std::memory_order_relaxed);
+  }
+  const std::vector<uint32_t>* load_table_projection(
+      const std::string& table_name) const {
+    auto it = table_projection_.find(table_name);
+    return it == table_projection_.end() ? nullptr : &it->second;
+  }
+
   void add_rowcount_delta(LineairDB_share *share, const std::string &table_name, int64_t delta);
   int64_t peek_rowcount_delta(const LineairDB_share *share) const;
 
@@ -293,6 +309,11 @@ private:
 
   // Predicate pushdown: serialized PushedPredicate for scan filtering
   std::string pushed_filter_;
+
+  // Physical table name -> kept field ordinals for projected staged rows.
+  std::unordered_map<std::string, std::vector<uint32_t>> table_projection_;
+  // Process-wide registration epoch for handler decode memo refresh.
+  static inline std::atomic<uint64_t> projection_epoch_{0};
 
   // Max number of buffered write/delete ops before an automatic flush
   static constexpr size_t WRITE_BATCH_SIZE = 1024;

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -610,7 +610,7 @@ void LineairDBRpc::handleTxStatelessBatchRead(const std::string& message,
 namespace flat_plan {
 // Native-endian bytes spell "LDBFLATP" (LineairDB flat payload).
 static constexpr uint64_t kMagic = 0x5054414C4642444Cull;
-static constexpr uint8_t kVersion = 1;
+static constexpr uint8_t kVersion = 2;
 
 template <class Sink>
 void w_u8(Sink& out, uint8_t v) {
@@ -659,6 +659,8 @@ void encode_step(
     for (const auto& k : s.group_start_keys()) w_bytes(out, k);
     w_u64(out, static_cast<uint64_t>(s.group_end_keys_size()));
     for (const auto& k : s.group_end_keys()) w_bytes(out, k);
+    w_u64(out, static_cast<uint64_t>(s.filtered_keys_size()));
+    for (const auto& k : s.filtered_keys()) w_bytes(out, k);
 }
 
 // Destructive: release each StepResult after encoding it so large read-plan
@@ -846,7 +848,11 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                 return;
             }
             for (auto& row : scan_result.rows) {
-                if (!row_passes(row.value)) continue;
+                if (!row_passes(row.value)) {
+                    // Negative coverage for point probes into this scan.
+                    step_result->add_filtered_keys(std::move(row.key));
+                    continue;
+                }
                 step_result->add_scan_keys(std::move(row.key));
                 step_result->add_scan_values(std::move(row.value));
                 step_result->add_scan_tids(row.tid);
@@ -864,7 +870,11 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                 return;
             }
             for (auto& row : scan_result.rows) {
-                if (!row_passes(row.value)) continue;
+                if (!row_passes(row.value)) {
+                    // Secondary scans report rejected rows by primary key.
+                    step_result->add_filtered_keys(std::move(row.primary_key));
+                    continue;
+                }
                 step_result->add_secondary_keys(std::move(row.secondary_key));
                 step_result->add_scan_keys(std::move(row.primary_key));
                 step_result->add_scan_values(std::move(row.value));

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -26,6 +26,54 @@ std::string next_lexicographic_key(std::string key) {
     return {};
 }
 
+/**
+ * @brief Trim a serialized row value to the projected columns.
+ *
+ * @details Row format is [null_flags][col_0]..[col_n], where each field is
+ * [byteSize:1B][len:byteSize B][bytes] and byteSize==0xFF means NULL. The
+ * output keeps the full null_flags field and emits only the kept columns.
+ * Returns false on malformed input; the caller then fails the read-plan
+ * response instead of shipping a mismatched row layout.
+ */
+bool trim_row_value(const std::string& full,
+                    const google::protobuf::RepeatedField<uint32_t>& kept,
+                    uint32_t num_columns, std::string& out) {
+    out.clear();
+    const char* end = full.data() + full.size();
+    auto read_field = [&](const char*& q, const char*& fstart,
+                          size_t& flen) -> bool {
+        fstart = q;
+        if (q >= end) return false;
+        uint8_t bs = static_cast<uint8_t>(*q);
+        if (bs == 0xFF) { flen = 1; q += 1; return true; }
+        if (q + 1 + bs > end) return false;
+        size_t len = 0;
+        for (uint8_t i = 0; i < bs; i++)
+            len |= static_cast<size_t>(static_cast<uint8_t>(q[1 + i])) << (8 * i);
+        if (q + 1 + bs + len > end) return false;
+        flen = 1 + bs + len;
+        q += flen;
+        return true;
+    };
+    const char* q = full.data();
+    const char* fs;
+    size_t fl;
+    if (!read_field(q, fs, fl)) return false;  // field 0 = null_flags
+    out.append(fs, fl);
+    int ki = 0;
+    for (uint32_t c = 0; c < num_columns; c++) {  // column c is field index c+1
+        const char* cs;
+        size_t cl;
+        if (!read_field(q, cs, cl)) return false;
+        if (ki < kept.size() &&
+            kept.Get(ki) == static_cast<uint32_t>(c)) {
+            out.append(cs, cl);
+            ki++;
+        }
+    }
+    return ki == kept.size();  // every requested column was present
+}
+
 // Return the bytes of column `column_index` from a serialized MySQL row payload.
 std::string_view extract_value_column(const std::string& row,
                                       int column_index) {
@@ -730,6 +778,22 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             return step_eval.evaluate(*step_filter);
         };
 
+        // Filters read the full row. Projection then trims emitted VALUES to
+        // the kept columns; malformed rows fail the plan instead of mixing
+        // full and projected layouts.
+        const bool step_has_projection = step.has_projection();
+        bool projection_failed = false;
+        auto project_value = [&](std::string&& v) -> std::string {
+            if (!step_has_projection || v.empty()) return std::move(v);
+            std::string out;
+            if (trim_row_value(v, step.projection().field_indexes(),
+                               step.projection().num_columns(), out)) {
+                return out;
+            }
+            projection_failed = true;
+            return std::move(v);
+        };
+
         if (step.for_each()) {
             int source_step = -1;
             if (step.bindings_size() > 0) {
@@ -773,7 +837,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                         for (auto& r : scan_result.rows) {
                             if (!row_passes(r.value)) continue;
                             step_result->add_scan_keys(std::move(r.key));
-                            step_result->add_scan_values(std::move(r.value));
+                            step_result->add_scan_values(
+                                project_value(std::move(r.value)));
                             step_result->add_scan_tids(r.tid);
                             ++group_rows;
                         }
@@ -794,7 +859,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                             step_result->add_secondary_keys(
                                 std::move(r.secondary_key));
                             step_result->add_scan_keys(std::move(r.primary_key));
-                            step_result->add_scan_values(std::move(r.value));
+                            step_result->add_scan_values(
+                                project_value(std::move(r.value)));
                             step_result->add_scan_tids(r.tid);
                             ++group_rows;
                         }
@@ -813,10 +879,15 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                 step_result->add_scan_tids(read_result.tid);
                 if (read_result.found) {
                     step_result->add_scan_values(
-                        std::move(read_result.value));
+                        project_value(std::move(read_result.value)));
                 } else {
                     step_result->add_scan_values("");
                 }
+            }
+            if (projection_failed) {
+                response.set_ok(false);
+                flat_plan::encode_to_string(response, result);
+                return;
             }
             continue;
         }
@@ -830,7 +901,12 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             step_result->set_found(read_result.found);
             step_result->set_tid(read_result.tid);
             if (read_result.found) {
-                step_result->set_value(std::move(read_result.value));
+                step_result->set_value(project_value(std::move(read_result.value)));
+            }
+            if (projection_failed) {
+                response.set_ok(false);
+                flat_plan::encode_to_string(response, result);
+                return;
             }
             continue;
         }
@@ -854,7 +930,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                     continue;
                 }
                 step_result->add_scan_keys(std::move(row.key));
-                step_result->add_scan_values(std::move(row.value));
+                step_result->add_scan_values(project_value(std::move(row.value)));
                 step_result->add_scan_tids(row.tid);
             }
         } else {
@@ -877,9 +953,14 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                 }
                 step_result->add_secondary_keys(std::move(row.secondary_key));
                 step_result->add_scan_keys(std::move(row.primary_key));
-                step_result->add_scan_values(std::move(row.value));
+                step_result->add_scan_values(project_value(std::move(row.value)));
                 step_result->add_scan_tids(row.tid);
             }
+        }
+        if (projection_failed) {
+            response.set_ok(false);
+            flat_plan::encode_to_string(response, result);
+            return;
         }
     }
 

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -804,6 +804,46 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                 continue;
             }
 
+            // Build membership sets from earlier source steps, then drop
+            // probe rows whose join key is absent.
+            struct FeSemijoin {
+                std::unordered_set<std::string> keys;
+                uint32_t probe_column;
+            };
+            std::vector<FeSemijoin> fe_semijoins;
+            const int this_step_idx =
+                static_cast<int>(previous_results.size()) - 1;
+            for (const auto& sj : step.semijoins()) {
+                const int ss = static_cast<int>(sj.source_step());
+                if (ss < 0 || ss >= this_step_idx) continue;
+                FeSemijoin fsj;
+                fsj.probe_column = sj.probe_column();
+                const bool sf_on =
+                    sj.has_source_filter() && sj.source_filter().has_expr();
+                const uint32_t sf_cols =
+                    sf_on ? sj.source_filter().num_columns() : 0;
+                for (const auto& v : previous_results[ss]->scan_values()) {
+                    if (v.empty()) continue;
+                    if (sf_on) {
+                        PredicateEvaluator se;
+                        if (se.parse_row(v.data(), v.size(), sf_cols) &&
+                            !se.evaluate(sj.source_filter().expr()))
+                            continue;
+                    }
+                    auto col = extract_value_column(v, sj.source_column());
+                    if (!col.empty()) fsj.keys.emplace(col);
+                }
+                fe_semijoins.push_back(std::move(fsj));
+            }
+            auto sj_reject = [&](const std::string& value) -> bool {
+                for (const auto& fsj : fe_semijoins) {
+                    auto col = extract_value_column(value, fsj.probe_column);
+                    if (fsj.keys.find(std::string(col)) == fsj.keys.end())
+                        return true;  // no join partner -> drop
+                }
+                return false;
+            };
+
             const auto* source = previous_results[source_step];
             const int row_count =
                 std::max(source->scan_keys_size(), source->scan_values_size());
@@ -836,6 +876,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                         }
                         for (auto& r : scan_result.rows) {
                             if (!row_passes(r.value)) continue;
+                            if (!fe_semijoins.empty() && sj_reject(r.value))
+                                continue;
                             step_result->add_scan_keys(std::move(r.key));
                             step_result->add_scan_values(
                                 project_value(std::move(r.value)));
@@ -856,6 +898,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                         }
                         for (auto& r : scan_result.rows) {
                             if (!row_passes(r.value)) continue;
+                            if (!fe_semijoins.empty() && sj_reject(r.value))
+                                continue;
                             step_result->add_secondary_keys(
                                 std::move(r.secondary_key));
                             step_result->add_scan_keys(std::move(r.primary_key));
@@ -877,10 +921,13 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                         step.table_name(), row_key);
                 step_result->add_scan_keys(row_key);
                 step_result->add_scan_tids(read_result.tid);
-                if (read_result.found) {
+                if (read_result.found &&
+                    !(!fe_semijoins.empty() &&
+                      sj_reject(read_result.value))) {
                     step_result->add_scan_values(
                         project_value(std::move(read_result.value)));
                 } else {
+                    // Semijoin-rejected point probes are covered as not-found.
                     step_result->add_scan_values("");
                 }
             }

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -777,6 +777,9 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             }
             return step_eval.evaluate(*step_filter);
         };
+        // Negative-coverage keys are dead weight when the planner proved no
+        // other step reads this table (see PlanStep.suppress_filtered_keys).
+        const bool suppress_fkeys = step.suppress_filtered_keys();
 
         // Filters read the full row. Projection then trims emitted VALUES to
         // the kept columns; malformed rows fail the plan instead of mixing
@@ -973,7 +976,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             for (auto& row : scan_result.rows) {
                 if (!row_passes(row.value)) {
                     // Negative coverage for point probes into this scan.
-                    step_result->add_filtered_keys(std::move(row.key));
+                    if (!suppress_fkeys)
+                        step_result->add_filtered_keys(std::move(row.key));
                     continue;
                 }
                 step_result->add_scan_keys(std::move(row.key));
@@ -995,7 +999,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             for (auto& row : scan_result.rows) {
                 if (!row_passes(row.value)) {
                     // Secondary scans report rejected rows by primary key.
-                    step_result->add_filtered_keys(std::move(row.primary_key));
+                    if (!suppress_fkeys)
+                        step_result->add_filtered_keys(std::move(row.primary_key));
                     continue;
                 }
                 step_result->add_secondary_keys(std::move(row.secondary_key));


### PR DESCRIPTION
## Summary

- Push table-local predicates into staged scan steps and keep MySQL as the final WHERE evaluator.
- Ship projected staged row values for read-only no-validation SELECTs instead of full rows.
- Reduce high-fanout join probes with semijoin membership checks from earlier source steps.
- Suppress filtered_keys for single-step filtered scans where no later same-table probe can consume them.

## Why

The staged prefetch path could execute broader read plans than MySQL ultimately needed. Rows rejected by WHERE, unused columns, and join probe rows with no possible source-side match all inflated server response size and proxy cache work.

This branch reduces that payload on the storage-server side while keeping unsupported predicates, cross-table predicates, and final JOIN/WHERE semantics in MySQL.

## Details

- `build_single_table_filter` serializes predicates that are safe to evaluate against one staged table scan. Cross-table predicates and unsupported expressions are left for MySQL.
- For OR predicates, every branch must provide a table-local predicate; otherwise that OR is not pushed.
- Filtered scan results can carry `filtered_keys` as negative coverage, so later point probes can resolve rejected rows as local not-found entries instead of aborting on cache miss.
- Projection planning records the read column set per physical table and remaps projected VALUES back to the original MySQL field positions during decode.
- Projection is limited to the read-only no-validation SELECT path, where trimmed row buffers cannot be reused for DML row reconstruction.
- Semijoin membership reduction builds a source-side key set from an earlier step and drops probe rows whose join key cannot match.
- Semijoin reduction is limited to result-preserving inner equi-join cases; outer, anti, semi, nested-query-block, nullable-key, and incompatible-key cases keep the old path.
- Covered point-read steps are removed only when no later binding or semijoin references them, and remaining `source_step` indexes are remapped.
- Filtered_keys suppression is applied only when a filtered physical table appears in exactly one read-plan step.
- The aggregation-dependent stateful predicate path is intentionally left for the later aggregation stream.