### PR TITLE
feat: improve Helios optimizer cost estimates

### DIFF
--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -114,6 +114,11 @@ message GetTableStats {
         string index_name = 1;
         bool available = 2; // False when NDV is unavailable for this index.
         repeated uint64 ndv = 3;
+        // Leading-key range histogram. bounds[i] is a raw encoded leading-key
+        // boundary; cum[i] is the cumulative live-row count up to that bound.
+        repeated bytes hist_bounds = 4;
+        repeated uint64 hist_cum = 5;
+        bool hist_available = 6;
     }
     message Response {
         repeated TableRowCount table_stats = 1;

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -129,6 +129,7 @@
 #include "sql/table.h"
 #include "sql/sql_optimizer.h"             // JOIN
 #include "sql/join_optimizer/access_path.h"  // AccessPath (QEP tree)
+#include "sql/join_optimizer/walk_access_paths.h"
 #include "sql/join_optimizer/materialize_path_parameters.h"  // MATERIALIZE param
 #include "sql/query_result.h"                 // Query_result
 #include "sql/item_sum.h"                     // Item_sum
@@ -876,14 +877,58 @@ local_aggregate_fallback:;
 }
 
 /**
+ * @brief Return true when MySQL already chose a small bounded aggregate input.
+ *
+ * @details The aggregate override drives the handler through rnd_init(), which
+ * is a full scan. That is useful for large scan aggregates, but wasteful when
+ * the chosen access path is already a bounded ref/range lookup. If the access
+ * tree cannot be tied back to this query block's single base table, keep the
+ * existing override behavior.
+ */
+static bool helios_has_small_bounded_aggregate_input(AccessPath *root_path,
+                                                     JOIN *join) {
+  if (root_path == nullptr || join == nullptr || join->query_block == nullptr ||
+      join->query_block->leaf_tables == nullptr) {
+    return false;
+  }
+
+  const AccessPath *leaf = nullptr;
+  WalkAccessPaths(root_path, join, WalkAccessPathPolicy::ENTIRE_TREE,
+                  [&leaf](AccessPath *path, const JOIN *) -> bool {
+                    if (GetBasicTable(path) == nullptr)
+                      return false;
+                    leaf = path;
+                    return true;
+                  });
+  if (leaf == nullptr)
+    return false;
+
+  const TABLE *leaf_table = GetBasicTable(leaf);
+  if (leaf_table != join->query_block->leaf_tables->table)
+    return false;
+
+  const bool bounded = leaf->type == AccessPath::REF ||
+                       leaf->type == AccessPath::REF_OR_NULL ||
+                       leaf->type == AccessPath::EQ_REF ||
+                       leaf->type == AccessPath::INDEX_RANGE_SCAN;
+  if (!bounded)
+    return false;
+
+  constexpr double kSmallAggregateInputRows = 1000.0;  // FIXME: make configurable
+  const double rows = leaf->num_output_rows();
+  return rows >= 0.0 && rows < kSmallAggregateInputRows;
+}
+
+/**
  * @brief Install the aggregate executor override for supported query shapes.
  *
  * Unsupported queries leave `override_executor_func` unset and continue through
  * MySQL's normal iterator executor.
  */
-static int lineairdb_push_to_engine(THD *thd, AccessPath * /*root_path*/,
+static int lineairdb_push_to_engine(THD *thd, AccessPath *root_path,
                                     JOIN *join) {
   if (!helios_offloadable_shape(thd, join)) return 0;
+  if (helios_has_small_bounded_aggregate_input(root_path, join)) return 0;
   join->override_executor_func = &helios_override_executor;
   return 0;
 }

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -121,6 +121,7 @@
 #include "sql/item.h"
 #include "sql/item_cmpfunc.h"
 #include "sql/item_func.h"
+#include "sql/key.h"
 #include "sql/sql_class.h"
 #include "sql/sql_lex.h"
 #include "sql/sql_plugin.h"
@@ -2511,6 +2512,45 @@ int ha_lineairdb::rename_table(const char *, const char *, const dd::Table *,
 }
 
 /**
+ * @brief Decode an integer key part from a MySQL range endpoint.
+ *
+ * @details Uses key_restore() into table->record[1] instead of reading raw key
+ * bytes, so MySQL owns signedness and key-format decoding. Unsupported shapes
+ * return false and the caller falls back to the old coarse estimate.
+ */
+static bool helios_decode_keypart_int(TABLE *table, KEY *key, uint part,
+                                      const key_range *range,
+                                      longlong *out_value) {
+  if (table == nullptr || key == nullptr || range == nullptr ||
+      range->key == nullptr || out_value == nullptr) {
+    return false;
+  }
+  if (part >= key->user_defined_key_parts) return false;
+
+  uint required = 0;
+  for (uint i = 0; i <= part; ++i) {
+    required += key->key_part[i].store_length;
+  }
+  if (range->length < required) return false;
+
+  const KEY_PART_INFO &kp = key->key_part[part];
+  Field *field = kp.field;
+  if (field == nullptr || field->result_type() != INT_RESULT) return false;
+  if (field->is_nullable()) return false;
+  if (kp.key_part_flag & HA_REVERSE_SORT) return false;
+  if (table->record[0] == nullptr || table->record[1] == nullptr) return false;
+
+  uchar *scratch = table->record[1];
+  key_restore(scratch, range->key, key, range->length);
+  const ptrdiff_t delta =
+      static_cast<ptrdiff_t>(scratch - table->record[0]);
+  field->move_field_offset(delta);
+  *out_value = field->val_int();
+  field->move_field_offset(-delta);
+  return true;
+}
+
+/**
   @brief
   Given a starting key and an ending key, estimate the number of rows that
   will exist between the two keys.
@@ -2619,9 +2659,29 @@ ha_rows ha_lineairdb::records_in_range(uint inx, key_range *min_key,
     } else {
       estimate = 1;
     }
-    // Range conditions after equality prefix -> halve (NDB heuristic)
+    // Range after an equality prefix: estimate how many distinct trailing
+    // values fall inside the range, then multiply by rows per trailing value.
+    // Unsupported key shapes fall back to the old /2 heuristic.
     if (eq_parts < key_parts_used) {
-      estimate = std::max(static_cast<ha_rows>(1), estimate / 2);
+      longlong lo = 0;
+      longlong hi = 0;
+      if (eq_parts < key->user_defined_key_parts &&
+          key->rec_per_key[eq_parts] > 0 &&
+          helios_decode_keypart_int(table, key, eq_parts, min_key, &lo) &&
+          helios_decode_keypart_int(table, key, eq_parts, max_key, &hi) &&
+          hi >= lo) {
+        const double range_vals =
+            (hi > lo) ? static_cast<double>(hi - lo) : 1.0;
+        double est =
+            range_vals * static_cast<double>(key->rec_per_key[eq_parts]);
+
+        const double cap = static_cast<double>(key->rec_per_key[rpk_idx]);
+        if (cap >= 1.0 && est > cap) est = cap;
+        if (est < 1.0) est = 1.0;
+        estimate = static_cast<ha_rows>(est);
+      } else {
+        estimate = std::max(static_cast<ha_rows>(1), estimate / 2);
+      }
     }
   } else {
     // No equality at all -> pure range scan.

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -112,6 +112,7 @@
 #include <strings.h>
 
 #include "lineairdb_field_types.h"
+#include "lineairdb_keyenc.hh"
 #include "lineairdb_prefetch.hh"
 #include "lineairdb_pushdown.hh"
 #include "lineairdb.pb.h"
@@ -1898,10 +1899,10 @@ bool ha_lineairdb::seed_row_count_from_cache(LineairDBProxy *proxy) {
 }
 
 /**
- * @brief Copy the proxy's latest per-index NDV results into the shared table
+ * @brief Copy the proxy's latest per-index optimizer stats into shared table
  * metadata.
  */
-void ha_lineairdb::load_index_ndv_from_cache(LineairDBProxy *proxy) {
+void ha_lineairdb::load_index_stats_from_cache(LineairDBProxy *proxy) {
   if (proxy == nullptr || share == nullptr)
     return;
 
@@ -1909,9 +1910,32 @@ void ha_lineairdb::load_index_ndv_from_cache(LineairDBProxy *proxy) {
       share->stats_base_records.load(std::memory_order_relaxed);
   std::lock_guard<std::mutex> lock(share->index_ndv_mu_);
   share->index_ndv_.clear();
+  share->index_hist_.clear();
   for (const auto &entry : proxy->last_index_ndv()) {
     if (entry.second.available)
       share->index_ndv_[entry.first] = entry.second.values;
+  }
+  for (const auto &entry : proxy->last_index_hist()) {
+    const auto &hist = entry.second;
+    if (!hist.available || hist.bounds.empty() ||
+        hist.bounds.size() != hist.cum.size())
+      continue;
+
+    bool monotone = true;
+    for (size_t i = 1; i < hist.cum.size(); ++i) {
+      if (hist.cum[i] < hist.cum[i - 1] ||
+          hist.bounds[i] < hist.bounds[i - 1]) {
+        monotone = false;
+        break;
+      }
+    }
+    if (!monotone)
+      continue;
+
+    LineairDB_share::RangeHist range_hist;
+    range_hist.bounds = hist.bounds;
+    range_hist.cum = hist.cum;
+    share->index_hist_[entry.first] = std::move(range_hist);
   }
   share->index_ndv_records_.store(records, std::memory_order_relaxed);
   share->index_ndv_loaded_.store(true, std::memory_order_relaxed);
@@ -1992,7 +2016,7 @@ void ha_lineairdb::seed_optimizer_stats() {
     if (fetched) {
       seed_row_count_from_cache(ctx->proxy.get());
       if (requested_ndv)
-        load_index_ndv_from_cache(ctx->proxy.get());
+        load_index_stats_from_cache(ctx->proxy.get());
     }
   }
 }
@@ -2690,6 +2714,59 @@ ha_rows ha_lineairdb::records_in_range(uint inx, key_range *min_key,
       estimate = std::max(static_cast<ha_rows>(2), total_records / 20);
     } else {
       estimate = std::max(static_cast<ha_rows>(2), total_records / 10);
+    }
+
+    // Leading-key range histogram: use the server-built cumulative counts as
+    // a floor over the heuristic. Missing or malformed stats keep the heuristic.
+    const bool is_primary = table->s != nullptr && inx == table->s->primary_key;
+    const std::string index_name =
+        is_primary ? std::string() : std::string(key->name ? key->name : "");
+    if (share != nullptr) {
+      std::lock_guard<std::mutex> lock(share->index_ndv_mu_);
+      auto hist_it = share->index_hist_.find(index_name);
+      if (hist_it != share->index_hist_.end()) {
+        const LineairDB_share::RangeHist &hist = hist_it->second;
+        if (!hist.bounds.empty() && hist.bounds.size() == hist.cum.size()) {
+          auto rank_le = [&](const std::string &encoded_key) -> double {
+            if (encoded_key >= hist.bounds.back())
+              return static_cast<double>(hist.cum.back());
+            auto it =
+                std::upper_bound(hist.bounds.begin(), hist.bounds.end(),
+                                 encoded_key);
+            if (it == hist.bounds.begin())
+              return 0.0;
+            const size_t pos =
+                static_cast<size_t>((it - hist.bounds.begin()) - 1);
+            return static_cast<double>(hist.cum[pos]);
+          };
+
+          constexpr key_part_map kLeadingPart = 1;
+          bool enc_ok = true;
+          double lo = 0.0;
+          double hi = static_cast<double>(hist.cum.back());
+          if (min_key != nullptr) {
+            std::string encoded = lineairdb_keyenc::convert_key_to_ldbformat(
+                table, inx, min_key->key, kLeadingPart);
+            if (encoded.empty())
+              enc_ok = false;
+            else
+              lo = rank_le(encoded);
+          }
+          if (enc_ok && max_key != nullptr) {
+            std::string encoded = lineairdb_keyenc::convert_key_to_ldbformat(
+                table, inx, max_key->key, kLeadingPart);
+            if (encoded.empty())
+              enc_ok = false;
+            else
+              hi = rank_le(encoded);
+          }
+          const double hist_est = enc_ok ? (hi - lo) : -1.0;
+          if (hist_est >= 1.0 &&
+              static_cast<ha_rows>(hist_est) > estimate) {
+            estimate = static_cast<ha_rows>(hist_est);
+          }
+        }
+      }
     }
   }
 

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -2756,6 +2756,40 @@ static bool lineairdb_predict_prefetch_mode(THD *thd) {
 }
 
 /**
+ * @brief Return whether read_cost() should charge per-row materialization.
+ *
+ * @details Non-covering ref/range reads usually fetch each base row by PK after
+ * the index probe, so they should pay the materialization charge. The exception
+ * is a plain grouped single-table SELECT served through bulk prefetch: rows are
+ * staged/aggregated in bulk, not fetched one by one by PK.
+ */
+bool ha_lineairdb::helios_charge_materialise() const {
+  const TABLE *t = table;
+  if (t == nullptr || t->in_use == nullptr) return true;
+
+  THD *thd = t->in_use;
+  if (thd->lex == nullptr) return true;
+
+  // Only plain read-only SELECTs can use the bulk grouped path.
+  if (thd->lex->sql_command != SQLCOM_SELECT || thd->lex->is_explain())
+    return true;
+  if (t->reginfo.lock_type > TL_READ) return true;
+  if (!lineairdb_predict_prefetch_mode(thd)) return true;
+
+  // The grouped bulk path is recognizable before the final QEP exists.
+  Table_ref *tr = t->pos_in_table_list;
+  if (tr == nullptr || tr->query_block == nullptr) return true;
+  Query_block *qb = tr->query_block;
+  if (qb->leaf_table_count != 1 || !qb->is_grouped()) return true;
+  if (qb->is_distinct() || qb->olap != UNSPECIFIED_OLAP_TYPE ||
+      qb->has_windows()) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
  * @brief Advertise custom batch MRR for primary-key point lookups.
  *
  * In non-prefetch ("batched") mode, clear HA_MRR_USE_DEFAULT_IMPL for PK lookups

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -2758,14 +2758,19 @@ static bool lineairdb_predict_prefetch_mode(THD *thd) {
 /**
  * @brief Return whether read_cost() should charge per-row materialization.
  *
- * @details Non-covering ref/range reads usually fetch each base row by PK after
- * the index probe, so they should pay the materialization charge. The exception
- * is a plain grouped single-table SELECT served through bulk prefetch: rows are
- * staged/aggregated in bulk, not fetched one by one by PK.
+ * @details Non-covering secondary ref/range reads usually fetch each base row
+ * by PK after the index probe, so they should pay the materialization charge.
+ * Primary-key reads already produce the base row, and grouped single-table
+ * SELECTs served by bulk prefetch do not fetch rows one by one by PK.
  */
-bool ha_lineairdb::helios_charge_materialise() const {
+bool ha_lineairdb::helios_charge_materialise(uint index) const {
   const TABLE *t = table;
   if (t == nullptr || t->in_use == nullptr) return true;
+
+  if (t->s != nullptr && t->s->primary_key != MAX_KEY &&
+      index == t->s->primary_key) {
+    return false;
+  }
 
   THD *thd = t->in_use;
   if (thd->lex == nullptr) return true;

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -388,6 +388,15 @@ public:
     return v;
   }
 
+  /**
+   * @brief Return whether read_cost() should charge remote row materialization.
+   *
+   * The default is true. It returns false only for bulk-prefetched grouped
+   * single-table SELECTs, where rows are staged/aggregated in bulk instead of
+   * fetched one-by-one by PK.
+   */
+  bool helios_charge_materialise() const;
+
   double helios_row_bytes() const {
     // stats.mean_rec_length is set in info() from table->s->reclength (>=100).
     // Must NOT deref table->s here: TABLE is incomplete in this header.
@@ -420,10 +429,11 @@ public:
     Cost_estimate c = helios_ref_cost(ranges, rows);
 
     // read_cost() is the non-covering path: the index narrows keys, then each
-    // matching base row is fetched by PK. Charge that row materialization here;
-    // covering scans use index_scan_cost() and stay cheap.
-    c.add_io(std::ceil(rows / kEffBatch()) * kC_rpc());
-    c.add_cpu(rows * kC_materialise());
+    // matching base row is fetched by PK. Covering scans use index_scan_cost().
+    if (helios_charge_materialise()) {
+      c.add_io(std::ceil(rows / kEffBatch()) * kC_rpc());
+      c.add_cpu(rows * kC_materialise());
+    }
     return c;
   }
 

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -98,6 +98,14 @@ public:
 
   // ANALYZE TABLE sets this so the next NDV fetch recomputes server stats.
   std::atomic<bool> index_ndv_force_refresh_{false};
+
+  // Per-index range histogram on the leading key part. Empty index name means
+  // primary key. Guarded by index_ndv_mu_ and refreshed with NDV stats.
+  struct RangeHist {
+    std::vector<std::string> bounds;
+    std::vector<uint64_t> cum;
+  };
+  std::unordered_map<std::string, RangeHist> index_hist_;
 };
 
 // LIMIT and direction that a handler range scan may push to LineairDB.
@@ -697,7 +705,7 @@ private:
 
   // rec_per_key helpers
   bool seed_row_count_from_cache(LineairDBProxy *proxy);
-  void load_index_ndv_from_cache(LineairDBProxy *proxy);
+  void load_index_stats_from_cache(LineairDBProxy *proxy);
   void mark_stale_index_ndv_for_select();
   void seed_optimizer_stats();
   void set_generic_rec_per_key(KEY *key, uint key_parts, bool is_primary);

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -391,11 +391,11 @@ public:
   /**
    * @brief Return whether read_cost() should charge remote row materialization.
    *
-   * The default is true. It returns false only for bulk-prefetched grouped
-   * single-table SELECTs, where rows are staged/aggregated in bulk instead of
-   * fetched one-by-one by PK.
+   * The default is true. It returns false for clustered primary-key access and
+   * for bulk-prefetched grouped single-table SELECTs, where rows are not fetched
+   * one-by-one by a secondary-key-to-PK lookup.
    */
-  bool helios_charge_materialise() const;
+  bool helios_charge_materialise(uint index) const;
 
   double helios_row_bytes() const {
     // stats.mean_rec_length is set in info() from table->s->reclength (>=100).
@@ -430,7 +430,7 @@ public:
 
     // read_cost() is the non-covering path: the index narrows keys, then each
     // matching base row is fetched by PK. Covering scans use index_scan_cost().
-    if (helios_charge_materialise()) {
+    if (helios_charge_materialise(index)) {
       c.add_io(std::ceil(rows / kEffBatch()) * kC_rpc());
       c.add_cpu(rows * kC_materialise());
     }

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -46,6 +46,7 @@
 
 #include <array>
 #include <atomic>
+#include <cmath>
 #include <cstdint>
 #include <mutex>
 #include <unordered_map>
@@ -378,6 +379,15 @@ public:
     return v;
   }
 
+  // C_materialise: one remote PK row fetch after a non-covering secondary scan.
+  // 8.0 is an inflated steering value: it makes large row-by-row materialization
+  // lose to bulk full-scan+prefetch even when cardinality is underestimated.
+  static double kC_materialise() {
+    static const double v =
+        helios_cost_param("HELIOS_C_MATERIALISE", 8.0);
+    return v;
+  }
+
   double helios_row_bytes() const {
     // stats.mean_rec_length is set in info() from table->s->reclength (>=100).
     // Must NOT deref table->s here: TABLE is incomplete in this header.
@@ -407,7 +417,14 @@ public:
   Cost_estimate read_cost(uint index [[maybe_unused]], double ranges,
                           double rows) override
   {
-    return helios_ref_cost(ranges, rows);
+    Cost_estimate c = helios_ref_cost(ranges, rows);
+
+    // read_cost() is the non-covering path: the index narrows keys, then each
+    // matching base row is fetched by PK. Charge that row materialization here;
+    // covering scans use index_scan_cost() and stay cheap.
+    c.add_io(std::ceil(rows / kEffBatch()) * kC_rpc());
+    c.add_cpu(rows * kC_materialise());
+    return c;
   }
 
   Cost_estimate index_scan_cost(uint index [[maybe_unused]], double ranges,

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -306,6 +306,116 @@ public:
     return (double)ranges * 1.0 + (double)rows * 0.5;
   }
 
+  /**
+   * @brief Helios cost model for the MySQL 8.0 Cost_estimate API.
+   *
+   * @details The join planner uses these methods for scan-vs-ref and
+   * join-order decisions. LineairDB does not pay page-I/O cost like InnoDB;
+   * the dominant costs are RPC round trips, transferred bytes, row
+   * materialization, and batched remote probes.
+   *
+   *   scan : io = C_rpc + bytes*C_byte               ; cpu = rows*(C_row + C_remote)
+   *   ref  : io = ranges*(C_rpc/batch) + bytes*C_byte ; cpu = rows*(C_probe + C_row)
+   *
+   * Ref probes are batched, so a nested-loop chain is charged by effective
+   * batches instead of one RPC per outer row.
+   *
+   * @note Defaults are optimizer units, not wall-clock time. Later calibration
+   * can fit them with NNLS (non-negative least squares):
+   *
+   *   measured_time ~= C_rpc*rpc_count + C_byte*bytes + C_row*rows + ...
+   *
+   * NNLS keeps every coefficient >= 0, so more RPCs/bytes/rows cannot make the
+   * fitted cost cheaper.
+   */
+  static double helios_cost_param(const char *name, double def) {
+    // Optional calibration knob; the Helios cost model itself is always on.
+    const char *e = std::getenv(name);
+    if (!e || !e[0]) return def;
+    char *end = nullptr;
+    double v = strtod(e, &end);
+    return (end && end != e) ? v : def;
+  }
+  // C_rpc: one client/server round trip. 50.0 means one RPC costs about
+  // 500 row evaluations on MySQL's ROW_EVALUATE_COST=0.1 scale.
+  static double kC_rpc() {
+    static const double v = helios_cost_param("HELIOS_C_RPC", 50.0);
+    return v;
+  }
+
+  // C_byte: one transferred byte. 0.0008 makes 1 KiB cost about 0.82, so
+  // wide rows affect plan choice without overwhelming the fixed RPC cost.
+  static double kC_byte() {
+    static const double v = helios_cost_param("HELIOS_C_BYTE", 0.0008);
+    return v;
+  }
+
+  // C_row: one row materialized and decoded on the MySQL/proxy side. 0.10
+  // matches MySQL's ROW_EVALUATE_COST baseline for one row.
+  static double kC_row() {
+    static const double v = helios_cost_param("HELIOS_C_ROW", 0.10);
+    return v;
+  }
+
+  // C_probe: one ref/index probe key before row materialization. 0.05 treats
+  // probe handling as lighter than decoding a full row.
+  static double kC_probe() {
+    static const double v = helios_cost_param("HELIOS_C_PROBE", 0.05);
+    return v;
+  }
+
+  // C_remote: one row scanned on the LineairDB server side. 0.05 models remote
+  // scan work as lighter than decoding a full row on the MySQL side.
+  static double kC_remote() {
+    static const double v = helios_cost_param("HELIOS_C_REMOTE", 0.05);
+    return v;
+  }
+
+  // B_eff: effective probe batch size used to amortize RPC cost. 1024 is a
+  // steering estimate, not a protocol limit.
+  static double kEffBatch() {
+    static const double v = helios_cost_param("HELIOS_BATCH", 1024.0);
+    return v;
+  }
+
+  double helios_row_bytes() const {
+    // stats.mean_rec_length is set in info() from table->s->reclength (>=100).
+    // Must NOT deref table->s here: TABLE is incomplete in this header.
+    double b = (double)stats.mean_rec_length;
+    return b > 0 ? b : 64.0;                            // floor for unknown
+  }
+  Cost_estimate helios_ref_cost(double ranges, double rows) const {
+    Cost_estimate c;
+    const double bytes = rows * helios_row_bytes();
+    // per-lookup RPC amortized over the prefetch batch size.
+    const double rpc = (ranges > 0 ? ranges : 1.0) * (kC_rpc() / kEffBatch());
+    c.add_io(rpc + bytes * kC_byte());
+    c.add_cpu(rows * (kC_probe() + kC_row()));
+    return c;
+  }
+
+  Cost_estimate table_scan_cost() override
+  {
+    Cost_estimate c;
+    const double rows = (double)stats.records;
+    const double bytes = rows * helios_row_bytes();
+    c.add_io(kC_rpc() + bytes * kC_byte());      // 1 scan RPC + transfer wait
+    c.add_cpu(rows * (kC_row() + kC_remote()));  // materialize + remote scan CPU
+    return c;
+  }
+
+  Cost_estimate read_cost(uint index [[maybe_unused]], double ranges,
+                          double rows) override
+  {
+    return helios_ref_cost(ranges, rows);
+  }
+
+  Cost_estimate index_scan_cost(uint index [[maybe_unused]], double ranges,
+                                double rows) override
+  {
+    return helios_ref_cost(ranges, rows);
+  }
+
   /*
     Everything below are methods that we implement in ha_lineairdb.cc.
 

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -131,11 +131,21 @@ bool LineairDBProxy::fetch_table_stats(
         table_stats_cache_[ts.table_name()] = ts.row_count();
     }
     last_index_ndv_.clear();
+    last_index_hist_.clear();
     for (const auto& in : response.index_ndv()) {
         IndexNdvResult result;
         result.available = in.available();
         result.values.assign(in.ndv().begin(), in.ndv().end());
         last_index_ndv_[in.index_name()] = std::move(result);
+
+        if (in.hist_available() && in.hist_bounds_size() > 0 &&
+            in.hist_bounds_size() == in.hist_cum_size()) {
+            IndexHistResult hist;
+            hist.available = true;
+            hist.bounds.assign(in.hist_bounds().begin(), in.hist_bounds().end());
+            hist.cum.assign(in.hist_cum().begin(), in.hist_cum().end());
+            last_index_hist_[in.index_name()] = std::move(hist);
+        }
     }
     return true;
 }

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -108,6 +108,11 @@ public:
         // values[i] is the NDV for the first i+1 key parts.
         std::vector<uint64_t> values;
     };
+    struct IndexHistResult {
+        bool available = false;
+        std::vector<std::string> bounds;
+        std::vector<uint64_t> cum;
+    };
     // Refresh row counts, and optionally per-index NDV for one table.
     bool fetch_table_stats(
         const std::string& ndv_table = std::string(),
@@ -115,6 +120,9 @@ public:
         bool force_ndv = false);
     const std::unordered_map<std::string, IndexNdvResult>& last_index_ndv() const {
         return last_index_ndv_;
+    }
+    const std::unordered_map<std::string, IndexHistResult>& last_index_hist() const {
+        return last_index_hist_;
     }
     void tx_abort(int64_t tx_id);
 
@@ -333,6 +341,7 @@ public:
 private:
     std::unordered_map<std::string, int64_t> table_stats_cache_;
     std::unordered_map<std::string, IndexNdvResult> last_index_ndv_;
+    std::unordered_map<std::string, IndexHistResult> last_index_hist_;
     template<typename RequestType, typename ResponseType>
     bool send_protobuf_message(const RequestType& request, ResponseType& response,
                                MessageType message_type, const std::string& meta = "");

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -806,6 +806,8 @@ std::string build_plan_key(
 std::mutex LineairDBRpc::ndv_cache_mu_;
 std::unordered_map<std::string, std::pair<bool, std::vector<uint64_t>>>
     LineairDBRpc::ndv_cache_;
+std::unordered_map<std::string, LineairDBRpc::HistEntry>
+    LineairDBRpc::hist_cache_;
 
 LineairDBRpc::LineairDBRpc(std::shared_ptr<DatabaseManager> db_manager,
                            std::shared_ptr<TransactionManager> tx_manager,
@@ -1026,6 +1028,42 @@ void LineairDBRpc::handleTxGetTableStats(const std::string& message,
             out->set_available(available);
             if (available) {
                 for (uint64_t value : ndv) out->add_ndv(value);
+            }
+
+            constexpr uint32_t kHistogramBuckets = 64;
+            HistEntry hist;
+            bool hist_cached = false;
+            {
+                std::lock_guard<std::mutex> lock(ndv_cache_mu_);
+                if (request.ndv_force_recompute()) hist_cache_.erase(cache_key);
+                auto it = hist_cache_.find(cache_key);
+                if (it != hist_cache_.end()) {
+                    hist_cached = true;
+                    hist = it->second;
+                }
+            }
+
+            if (!hist_cached) {
+                hist.available = db && db->ComputeIndexHistogram(
+                                            request.ndv_table(),
+                                            desc.index_name(),
+                                            kHistogramBuckets,
+                                            hist.bounds,
+                                            hist.cum);
+                if (!hist.available) {
+                    hist.bounds.clear();
+                    hist.cum.clear();
+                }
+                std::lock_guard<std::mutex> lock(ndv_cache_mu_);
+                hist_cache_[cache_key] = hist;
+            }
+
+            out->set_hist_available(hist.available);
+            if (hist.available) {
+                for (const auto& bound : hist.bounds)
+                    out->add_hist_bounds(bound);
+                for (uint64_t value : hist.cum)
+                    out->add_hist_cum(value);
             }
         }
     }

--- a/server/rpc/lineairdb_rpc.hh
+++ b/server/rpc/lineairdb_rpc.hh
@@ -53,6 +53,14 @@ private:
     static std::unordered_map<std::string,
                               std::pair<bool, std::vector<uint64_t>>> ndv_cache_;
 
+    // Range histogram cache shared with the NDV stats fetch path.
+    struct HistEntry {
+        bool available = false;
+        std::vector<std::string> bounds;
+        std::vector<uint64_t> cum;
+    };
+    static std::unordered_map<std::string, HistEntry> hist_cache_;
+
     // Transaction lifecycle
     void handleTxBeginTransaction(const std::string& message, std::string& result);
     void handleTxGetTableStats(const std::string& message, std::string& result);


### PR DESCRIPTION
## Summary

- Add Helios-specific optimizer cost estimates for table scans, index scans, and ref reads.
- Model the main costs of the Helios storage path: RPCs, transferred bytes, row decoding, remote scan work, and batched index probes.
- Add an extra cost for non-covering secondary-index reads, where the engine must fetch base rows after reading the index.
- Avoid that extra materialization cost for primary-key reads and grouped queries that are already served through bulk prefetch.
- Improve range cardinality estimates for composite indexes and leading-key range scans.
- Add leading-key range histograms to LineairDB table stats and use them in MySQL optimizer estimates.
- Keep aggregate pushdown from taking over small bounded ref/range inputs where MySQL already chose a narrow access path.

## Why

MySQL's generic storage-engine cost estimates do not describe Helios well.

Helios reads data through a remote LineairDB server. A good plan depends less on page I/O and more on RPC count, transferred row bytes, local row decoding, server-side scan work, and whether index probes can be batched. When those costs are not visible to the optimizer, MySQL can choose poor join orders or prefer row-by-row secondary-index access over a cheaper bulk scan.

This branch gives the optimizer a cost model that better matches the Helios execution path, and improves the row-count estimates that feed into those cost decisions.

## Details

- `table_scan_cost()` now charges for one scan RPC, transferred row bytes, local row decode work, and remote scan work.
- `read_cost()` and `index_scan_cost()` now use a shared batched-probe model.
- Non-covering secondary-index reads now pay an additional row materialization cost.
- Primary-key reads skip that materialization charge because they already read the base row directly.
- Grouped single-table SELECTs served by bulk prefetch also skip the row-by-row materialization charge.
- Cost constants can still be tuned through `HELIOS_C_RPC`, `HELIOS_C_BYTE`, `HELIOS_C_ROW`, `HELIOS_C_PROBE`, `HELIOS_C_REMOTE`, `HELIOS_BATCH`, and `HELIOS_C_MATERIALISE`.
- Composite-index range estimates now use the equality prefix plus the trailing integer range width instead of only halving the equality estimate.
- `GetTableStats` now carries optional leading-key histogram bounds and cumulative row counts.
- The proxy caches those histograms with NDV stats and uses them for leading-key range estimates.
- The LineairDB submodule is updated to `22a662a` for histogram support.