### PR TITLE
feat: backfill secondary indexes on CREATE INDEX

### DIFF
--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -2883,7 +2883,28 @@ enum_alter_inplace_result ha_lineairdb::check_if_supported_inplace_alter(
   return HA_ALTER_INPLACE_EXCLUSIVE_LOCK;
 }
 
-bool ha_lineairdb::inplace_alter_table(TABLE *altered_table [[maybe_unused]],
+bool ha_lineairdb::backfill_commit_chunk(
+    std::vector<LineairDBProxy::BatchOp> &ops) {
+  if (ops.empty()) return true;
+
+  auto *chunk_tx =
+      new LineairDBTransaction(ha_thd(), get_proxy(), lineairdb_hton, FENCE);
+  chunk_tx->set_prefetch_mode(false);
+  chunk_tx->begin_transaction();
+  chunk_tx->choose_table(db_table_name);
+
+  // One checked batch write per chunk so a server-side abort is observed.
+  const bool wrote = chunk_tx->batch_write(db_table_name, ops);
+  ops.clear();
+  if (!wrote || chunk_tx->is_aborted()) {
+    chunk_tx->set_status_to_abort();
+    chunk_tx->end_transaction();
+    return false;
+  }
+  return chunk_tx->end_transaction();
+}
+
+bool ha_lineairdb::inplace_alter_table(TABLE *altered_table,
                                        Alter_inplace_info *ha_alter_info,
                                        const dd::Table *old_table_def
                                        [[maybe_unused]],
@@ -2891,20 +2912,98 @@ bool ha_lineairdb::inplace_alter_table(TABLE *altered_table [[maybe_unused]],
                                        [[maybe_unused]]) {
   DBUG_TRACE;
 
+  // Fill each new secondary index from existing rows. The EXCLUSIVE metadata
+  // lock is node-local, so this covers single-node ADD INDEX only; cross-node
+  // DDL coordination belongs to the ddl-sync work.
   userThread = ha_thd();
   auto proxy = get_proxy();
 
+  // Rows per backfill transaction; bounds each OCC write-set.
+  static constexpr uint64_t kBackfillWriteChunkRows = 2000;  // FIXME: make configurable
+
+  if (altered_table == nullptr || altered_table->s == nullptr) return true;
+
   for (uint i = 0; i < ha_alter_info->index_add_count; i++) {
-    uint key_idx = ha_alter_info->index_add_buffer[i];
-    KEY *key_info = &ha_alter_info->key_info_buffer[key_idx];
+    const uint key_idx = ha_alter_info->index_add_buffer[i];
+    const KEY *key_info = &ha_alter_info->key_info_buffer[key_idx];
+    const std::string index_name(key_info->name ? key_info->name : "");
+    if (index_name.empty()) return true;  // fail closed: unnamed index
 
-    uint index_type = (key_info->flags & HA_NOSAME) ? LDB_INDEX_UNIQUE : 0;
+    const uint index_type = (key_info->flags & HA_NOSAME) ? LDB_INDEX_UNIQUE : 0;
 
-    // In a disaggregated setup, another MySQL node may have already created
-    // this secondary index on the shared LineairDB server. Treat "already
-    // exists" as success — the MySQL-side metadata still needs to be updated.
-    proxy->db_create_secondary_index(
-        db_table_name, std::string(key_info->name), index_type);
+    // key_info_buffer and TABLE::key_info use different field-number bases;
+    // resolve the runtime KEY by name or the encoder reads the wrong column.
+    const KEY *runtime_key = nullptr;
+    for (uint k = 0; k < altered_table->s->keys; ++k) {
+      const KEY *candidate = &altered_table->key_info[k];
+      if (candidate->name != nullptr && index_name == candidate->name) {
+        runtime_key = candidate;
+        break;
+      }
+    }
+    if (runtime_key == nullptr) return true;
+
+    // LineairDB treats an encoded NULL key as a duplicate, but SQL allows many
+    // NULLs in a UNIQUE index; reject nullable UNIQUE backfill instead.
+    if (key_info->flags & HA_NOSAME) {
+      for (uint p = 0; p < runtime_key->user_defined_key_parts; ++p) {
+        if (runtime_key->key_part[p].null_bit != 0) return true;
+      }
+    }
+
+    // Register the index; fail closed on error. On a multi-index ALTER a later
+    // failure leaves earlier backfilled indexes on the server (the DD rollback
+    // hides them); purging them is the ddl-sync DROP work.
+    if (!proxy->db_create_secondary_index(db_table_name, index_name,
+                                          index_type)) {
+      return true;
+    }
+
+    auto *scan_tx = get_transaction(ha_thd());
+    if (scan_tx == nullptr || scan_tx->is_aborted()) return true;
+    scan_tx->choose_table(db_table_name);
+
+    // Fill from existing base rows in bounded chunks.
+    std::vector<LineairDBProxy::BatchOp> write_chunk;
+    write_chunk.reserve(kBackfillWriteChunkRows);
+    auto rows =
+        scan_tx->get_matching_keys_and_values_from_prefix(std::string());
+    if (scan_tx->is_aborted()) return true;  // aborted scan: emit no writes
+
+    bool failed = false;
+    for (auto &row : rows) {
+      if (row.second.empty()) continue;
+
+      const auto *value =
+          reinterpret_cast<const std::byte *>(row.second.data());
+      if (set_fields_from_lineairdb(table->record[0], value,
+                                    row.second.size())) {
+        failed = true;
+        break;
+      }
+
+      LineairDBProxy::BatchOp op;
+      op.type = LineairDBProxy::BatchOp::Type::SecondaryIndexWrite;
+      op.table_name = db_table_name;
+      op.index_name = index_name;
+      op.primary_key = std::move(row.first);
+      op.secondary_key =
+          build_secondary_key_from_row(table->record[0], *runtime_key);
+      write_chunk.push_back(std::move(op));
+
+      if (write_chunk.size() >= kBackfillWriteChunkRows &&
+          !backfill_commit_chunk(write_chunk)) {
+        failed = true;
+        break;
+      }
+    }
+
+    // Release the per-row blob arena on every loop exit.
+    blobroot.Clear();
+    if (failed || scan_tx->is_aborted() ||
+        !backfill_commit_chunk(write_chunk)) {
+      return true;
+    }
   }
 
   return false;

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -694,6 +694,15 @@ private:
   std::string autogenerate_key();
   std::string extract_key_from_mysql(const uchar *row_buffer);
 
+  /**
+   * @brief Commit one CREATE INDEX backfill chunk in its own transaction.
+   *
+   * @details Backfill may touch every row in the table. Chunking keeps each OCC
+   * transaction bounded while preserving the normal secondary-index write path.
+   * `ops` is cleared before return.
+   */
+  bool backfill_commit_chunk(std::vector<LineairDBProxy::BatchOp> &ops);
+
   void set_write_buffer(uchar *buf);
   bool is_primary_key_exists();
   bool is_primary_key_type_int();

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -920,6 +920,7 @@ std::vector<KeyValue> LineairDBProxy::tx_get_matching_keys_and_values_from_prefi
     LOG_DEBUG("CLIENT: tx_get_matching_keys_and_values_from_prefix called with tx_id=%ld, prefix=%s", tx_id, prefix.c_str());
     if (!connected_) {
         LOG_ERROR("RPC failed: Not connected to server");
+        tx->set_aborted(true);  // fail closed: a dead connection is not "no rows"
         return {};
     }
 
@@ -937,6 +938,7 @@ std::vector<KeyValue> LineairDBProxy::tx_get_matching_keys_and_values_from_prefi
     std::string raw_response;
     if (!send_protobuf_recv_binary(request, raw_response, MessageType::TX_GET_MATCHING_KEYS_AND_VALUES_FROM_PREFIX)) {
         LOG_ERROR("RPC failed: Failed to send message to server");
+        tx->set_aborted(true);  // fail closed: a transport failure is not "no rows"
         return {};
     }
 


### PR DESCRIPTION
## Summary

- Fill a new secondary index from the table's existing rows when `CREATE INDEX` runs on a populated table.
- Reuse the normal row-insert key encoder so backfilled index entries match an index built during data load.
- Commit the fill in bounded row chunks instead of one whole-table transaction.
- Fail the statement closed on a create error, an unnamed or nullable-unique index, a scan abort, or a chunk-commit failure.
- Abort the transaction when a prefix scan cannot reach the storage server, so a failed scan is not read as an empty table.

## Why

`CREATE INDEX` on a table that already held rows registered an empty secondary index. The existing rows were never added, so queries that used the new index returned wrong or empty results, and the standard benchmark index set could not be rebuilt after load.

This branch makes the storage engine scan the existing base rows and fill the new index during the `ALTER`, so a backfilled index returns the same rows as an index that was present during the load.

The fill runs under the exclusive metadata lock that the engine already requests for add-index, so it is scoped to single-node DDL. Coordinating online index creation across query layers is left to the DDL version-sync work.

## Details

- `inplace_alter_table` resolves the runtime `KEY` by name, because `key_info_buffer` and `TABLE::key_info` use different field-number bases and indexing by the add-buffer position would encode the wrong column.
- For each added index it registers the index on the shared server, then scans the base rows and builds secondary-index entries with `build_secondary_key_from_row`.
- `backfill_commit_chunk` commits each chunk in an independent transaction with a single checked batch write, so a server-side abort fails the statement instead of being dropped.
- The chunk size bounds each optimistic-concurrency write set so a whole-table fill never runs as one transaction.
- Nullable unique indexes are rejected, because LineairDB treats an encoded NULL key as a duplicate while SQL allows multiple NULLs.
- On a multi-index `ALTER`, a later failure can leave an earlier backfilled index on the server; MySQL rolls back the data dictionary so it stays invisible, and a server-side purge is left to the DROP work.
- `tx_get_matching_keys_and_values_from_prefix` marks the transaction aborted on its disconnected and send-failure paths, so every caller treats a failed scan as an abort rather than an empty result.
