### PR TITLE
perf: speed up bulk load and secondary-index backfill

### DIFF
--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -106,6 +106,7 @@
 #include <optional>
 #include <sstream>
 #include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
 // for ::strcasecmp
@@ -143,6 +144,11 @@
 
 // LineairDB SecondaryIndexOption::Constraint wire bit for UNIQUE.
 static constexpr uint LDB_INDEX_UNIQUE = 1u;
+
+// Rows per backfill commit; bounds each OCC write-set.
+static constexpr uint64_t kBackfillWriteChunkRows = 2000;  // FIXME: make configurable
+// Worker threads that commit a non-unique index backfill in parallel.
+static constexpr size_t kBackfillParallelWorkers = 16;  // FIXME: make configurable
 
 // LineairDB server connection target (GLOBAL sysvars backing storage)
 static char *srv_server_host = nullptr;
@@ -2893,14 +2899,12 @@ enum_alter_inplace_result ha_lineairdb::check_if_supported_inplace_alter(
 }
 
 bool ha_lineairdb::backfill_commit_chunk(
-    std::vector<LineairDBProxy::BatchOp> &ops, bool use_stateless_commit) {
+    std::vector<LineairDBProxy::BatchOp> &ops) {
   if (ops.empty()) return true;
 
   auto *chunk_tx =
       new LineairDBTransaction(ha_thd(), get_proxy(), lineairdb_hton, FENCE);
-  // FIXME: set_prefetch_mode is misnamed -- the flag selects the stateless commit
-  // path (true skips the staging read-set/write-set scans), not a read-prefetch toggle.
-  chunk_tx->set_prefetch_mode(use_stateless_commit);
+  chunk_tx->set_prefetch_mode(false);
   chunk_tx->begin_transaction();
   chunk_tx->choose_table(db_table_name);
 
@@ -2913,6 +2917,121 @@ bool ha_lineairdb::backfill_commit_chunk(
     return false;
   }
   return chunk_tx->end_transaction();
+}
+
+bool ha_lineairdb::backfill_indexes_parallel(
+    std::vector<std::pair<std::string, std::string>> &rows,
+    const std::vector<std::pair<std::string, const KEY *>> &specs) {
+  // Phase A: decode each row once, build one write per index, and bucket it by
+  // secondary-key hash. Single-threaded -- decode uses the shared record buffer.
+  std::vector<std::vector<LineairDBProxy::BatchOp>> partition(
+      kBackfillParallelWorkers);
+  std::hash<std::string> hasher;
+  bool decode_failed = false;
+  for (auto &row : rows) {
+    if (row.second.empty()) continue;
+    const auto *value = reinterpret_cast<const std::byte *>(row.second.data());
+    if (set_fields_from_lineairdb(table->record[0], value, row.second.size())) {
+      decode_failed = true;
+      break;
+    }
+    for (const auto &spec : specs) {
+      LineairDBProxy::BatchOp op;
+      op.type = LineairDBProxy::BatchOp::Type::SecondaryIndexWrite;
+      op.table_name = db_table_name;
+      op.index_name = spec.first;
+      op.primary_key = row.first;
+      op.secondary_key =
+          build_secondary_key_from_row(table->record[0], *spec.second);
+      partition[hasher(op.secondary_key) % kBackfillParallelWorkers].push_back(
+          std::move(op));
+    }
+  }
+  blobroot.Clear();
+  if (decode_failed) return false;
+
+  // Phase B: one worker per partition, each on its own connection. The hash
+  // partition commits every op for a secondary key on one worker, so no two
+  // workers mutate the same index DataItem; distinct keys are distinct DataItems
+  // committed through the normal concurrent path LineairDB serves for multiple
+  // query layers. Workers touch no MySQL state; a failure sets the shared flag
+  // for the caller to report.
+  std::atomic<bool> failed{false};
+  const std::string host =
+      srv_server_host ? srv_server_host : std::string("127.0.0.1");
+  const int port = static_cast<int>(srv_server_port);
+  std::vector<std::thread> workers;
+  workers.reserve(kBackfillParallelWorkers);
+  for (size_t w = 0; w < kBackfillParallelWorkers; ++w) {
+    if (partition[w].empty()) continue;
+    workers.emplace_back([&, w]() {
+      LineairDBProxy conn(host, port);
+      std::vector<LineairDBProxy::BatchOp> chunk;
+      chunk.reserve(kBackfillWriteChunkRows);
+      // Ship the buffered writes as one stateless commit (no reads to validate).
+      auto commit_chunk = [&]() -> bool {
+        if (chunk.empty()) return true;
+        std::string reason;
+        const bool ok = conn.tx_validate_and_commit({}, {}, {}, {}, chunk, {},
+                                                     FENCE, &reason);
+        chunk.clear();
+        return ok;
+      };
+      for (auto &op : partition[w]) {
+        if (failed.load(std::memory_order_relaxed)) return;
+        chunk.push_back(std::move(op));
+        if (chunk.size() >= kBackfillWriteChunkRows && !commit_chunk()) {
+          failed.store(true, std::memory_order_relaxed);
+          return;
+        }
+      }
+      if (!commit_chunk()) failed.store(true, std::memory_order_relaxed);
+    });
+  }
+  for (auto &t : workers) t.join();
+  return !failed.load(std::memory_order_relaxed);
+}
+
+bool ha_lineairdb::backfill_unique_serial(const std::string &index_name,
+                                          const KEY &runtime_key) {
+  // A unique index scans and commits serially through the staging path, which
+  // keeps the in-write duplicate check. Its cost is small (no unique index is on
+  // the large fact table); the parallel scan-once path is for the non-unique set.
+  auto *scan_tx = get_transaction(ha_thd());
+  if (scan_tx == nullptr || scan_tx->is_aborted()) return false;
+  scan_tx->choose_table(db_table_name);
+  auto rows = scan_tx->get_matching_keys_and_values_from_prefix(std::string());
+  if (scan_tx->is_aborted()) return false;
+
+  std::vector<LineairDBProxy::BatchOp> write_chunk;
+  write_chunk.reserve(kBackfillWriteChunkRows);
+  bool failed = false;
+  for (auto &row : rows) {
+    if (row.second.empty()) continue;
+    const auto *value = reinterpret_cast<const std::byte *>(row.second.data());
+    if (set_fields_from_lineairdb(table->record[0], value, row.second.size())) {
+      failed = true;
+      break;
+    }
+    LineairDBProxy::BatchOp op;
+    op.type = LineairDBProxy::BatchOp::Type::SecondaryIndexWrite;
+    op.table_name = db_table_name;
+    op.index_name = index_name;
+    op.primary_key = std::move(row.first);
+    op.secondary_key = build_secondary_key_from_row(table->record[0], runtime_key);
+    write_chunk.push_back(std::move(op));
+    if (write_chunk.size() >= kBackfillWriteChunkRows &&
+        !backfill_commit_chunk(write_chunk)) {
+      failed = true;
+      break;
+    }
+  }
+  blobroot.Clear();
+  if (failed || scan_tx->is_aborted() ||
+      !backfill_commit_chunk(write_chunk)) {
+    return false;
+  }
+  return true;
 }
 
 bool ha_lineairdb::inplace_alter_table(TABLE *altered_table,
@@ -2929,11 +3048,12 @@ bool ha_lineairdb::inplace_alter_table(TABLE *altered_table,
   userThread = ha_thd();
   auto proxy = get_proxy();
 
-  // Rows per backfill transaction; bounds each OCC write-set.
-  static constexpr uint64_t kBackfillWriteChunkRows = 2000;  // FIXME: make configurable
-
   if (altered_table == nullptr || altered_table->s == nullptr) return true;
 
+  // Non-unique indexes are collected and backfilled together below so a single
+  // scan and decode pass feeds them all. A unique index keeps the staging commit
+  // path (its in-write duplicate check) and is backfilled serially.
+  std::vector<std::pair<std::string, const KEY *>> nu_specs;
   for (uint i = 0; i < ha_alter_info->index_add_count; i++) {
     const uint key_idx = ha_alter_info->index_add_buffer[i];
     const KEY *key_info = &ha_alter_info->key_info_buffer[key_idx];
@@ -2941,9 +3061,6 @@ bool ha_lineairdb::inplace_alter_table(TABLE *altered_table,
     if (index_name.empty()) return true;  // fail closed: unnamed index
 
     const uint index_type = (key_info->flags & HA_NOSAME) ? LDB_INDEX_UNIQUE : 0;
-    // A unique index keeps the staging commit path for its in-write duplicate
-    // check; only a non-unique index is safe to route through the stateless path.
-    const bool use_stateless_commit = (index_type != LDB_INDEX_UNIQUE);
 
     // key_info_buffer and TABLE::key_info use different field-number bases;
     // resolve the runtime KEY by name or the encoder reads the wrong column.
@@ -2973,51 +3090,24 @@ bool ha_lineairdb::inplace_alter_table(TABLE *altered_table,
       return true;
     }
 
+    if (index_type == LDB_INDEX_UNIQUE) {
+      if (!backfill_unique_serial(index_name, *runtime_key)) return true;
+    } else {
+      nu_specs.emplace_back(index_name, runtime_key);
+    }
+  }
+
+  // Non-unique indexes share one scan and one decode pass, then commit in
+  // parallel. A multi-index ALTER on the fact table makes this the common path.
+  if (!nu_specs.empty()) {
     auto *scan_tx = get_transaction(ha_thd());
     if (scan_tx == nullptr || scan_tx->is_aborted()) return true;
     scan_tx->choose_table(db_table_name);
 
-    // Fill from existing base rows in bounded chunks.
-    std::vector<LineairDBProxy::BatchOp> write_chunk;
-    write_chunk.reserve(kBackfillWriteChunkRows);
     auto rows =
         scan_tx->get_matching_keys_and_values_from_prefix(std::string());
     if (scan_tx->is_aborted()) return true;  // aborted scan: emit no writes
-
-    bool failed = false;
-    for (auto &row : rows) {
-      if (row.second.empty()) continue;
-
-      const auto *value =
-          reinterpret_cast<const std::byte *>(row.second.data());
-      if (set_fields_from_lineairdb(table->record[0], value,
-                                    row.second.size())) {
-        failed = true;
-        break;
-      }
-
-      LineairDBProxy::BatchOp op;
-      op.type = LineairDBProxy::BatchOp::Type::SecondaryIndexWrite;
-      op.table_name = db_table_name;
-      op.index_name = index_name;
-      op.primary_key = std::move(row.first);
-      op.secondary_key =
-          build_secondary_key_from_row(table->record[0], *runtime_key);
-      write_chunk.push_back(std::move(op));
-
-      if (write_chunk.size() >= kBackfillWriteChunkRows &&
-          !backfill_commit_chunk(write_chunk, use_stateless_commit)) {
-        failed = true;
-        break;
-      }
-    }
-
-    // Release the per-row blob arena on every loop exit.
-    blobroot.Clear();
-    if (failed || scan_tx->is_aborted() ||
-        !backfill_commit_chunk(write_chunk, use_stateless_commit)) {
-      return true;
-    }
+    if (!backfill_indexes_parallel(rows, nu_specs)) return true;
   }
 
   return false;

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -2926,6 +2926,16 @@ bool ha_lineairdb::backfill_indexes_parallel(
   // secondary-key hash. Single-threaded -- decode uses the shared record buffer.
   std::vector<std::vector<LineairDBProxy::BatchOp>> partition(
       kBackfillParallelWorkers);
+  // Reserve each bucket to its expected hash share so the per-row push_back
+  // below does not repeatedly reallocate the per-worker write buffers.
+  const size_t total_ops = rows.size() * specs.size();
+  const size_t reserve_per_bucket =
+      total_ops == 0 ? 0
+                     : total_ops / kBackfillParallelWorkers +
+                           total_ops / (kBackfillParallelWorkers * 8) + 1;
+  if (reserve_per_bucket != 0) {
+    for (auto &bucket : partition) bucket.reserve(reserve_per_bucket);
+  }
   std::hash<std::string> hasher;
   bool decode_failed = false;
   for (auto &row : rows) {

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -2893,12 +2893,14 @@ enum_alter_inplace_result ha_lineairdb::check_if_supported_inplace_alter(
 }
 
 bool ha_lineairdb::backfill_commit_chunk(
-    std::vector<LineairDBProxy::BatchOp> &ops) {
+    std::vector<LineairDBProxy::BatchOp> &ops, bool use_stateless_commit) {
   if (ops.empty()) return true;
 
   auto *chunk_tx =
       new LineairDBTransaction(ha_thd(), get_proxy(), lineairdb_hton, FENCE);
-  chunk_tx->set_prefetch_mode(false);
+  // FIXME: set_prefetch_mode is misnamed -- the flag selects the stateless commit
+  // path (true skips the staging read-set/write-set scans), not a read-prefetch toggle.
+  chunk_tx->set_prefetch_mode(use_stateless_commit);
   chunk_tx->begin_transaction();
   chunk_tx->choose_table(db_table_name);
 
@@ -2939,6 +2941,9 @@ bool ha_lineairdb::inplace_alter_table(TABLE *altered_table,
     if (index_name.empty()) return true;  // fail closed: unnamed index
 
     const uint index_type = (key_info->flags & HA_NOSAME) ? LDB_INDEX_UNIQUE : 0;
+    // A unique index keeps the staging commit path for its in-write duplicate
+    // check; only a non-unique index is safe to route through the stateless path.
+    const bool use_stateless_commit = (index_type != LDB_INDEX_UNIQUE);
 
     // key_info_buffer and TABLE::key_info use different field-number bases;
     // resolve the runtime KEY by name or the encoder reads the wrong column.
@@ -3001,7 +3006,7 @@ bool ha_lineairdb::inplace_alter_table(TABLE *altered_table,
       write_chunk.push_back(std::move(op));
 
       if (write_chunk.size() >= kBackfillWriteChunkRows &&
-          !backfill_commit_chunk(write_chunk)) {
+          !backfill_commit_chunk(write_chunk, use_stateless_commit)) {
         failed = true;
         break;
       }
@@ -3010,7 +3015,7 @@ bool ha_lineairdb::inplace_alter_table(TABLE *altered_table,
     // Release the per-row blob arena on every loop exit.
     blobroot.Clear();
     if (failed || scan_tx->is_aborted() ||
-        !backfill_commit_chunk(write_chunk)) {
+        !backfill_commit_chunk(write_chunk, use_stateless_commit)) {
       return true;
     }
   }

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -697,10 +697,13 @@ private:
    * @brief Commit one CREATE INDEX backfill chunk in its own transaction.
    *
    * @details Backfill may touch every row in the table. Chunking keeps each OCC
-   * transaction bounded while preserving the normal secondary-index write path.
-   * `ops` is cleared before return.
+   * transaction bounded. When `use_stateless_commit` is true the chunk commits
+   * through the stateless path, which skips the staging per-write read-set and
+   * write-set scans; it is reserved for non-unique indexes. `ops` is cleared
+   * before return.
    */
-  bool backfill_commit_chunk(std::vector<LineairDBProxy::BatchOp> &ops);
+  bool backfill_commit_chunk(std::vector<LineairDBProxy::BatchOp> &ops,
+                             bool use_stateless_commit);
 
   void set_write_buffer(uchar *buf);
   bool is_primary_key_exists();

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -697,13 +697,36 @@ private:
    * @brief Commit one CREATE INDEX backfill chunk in its own transaction.
    *
    * @details Backfill may touch every row in the table. Chunking keeps each OCC
-   * transaction bounded. When `use_stateless_commit` is true the chunk commits
-   * through the stateless path, which skips the staging per-write read-set and
-   * write-set scans; it is reserved for non-unique indexes. `ops` is cleared
-   * before return.
+   * transaction bounded while preserving the normal secondary-index write path.
+   * `ops` is cleared before return.
    */
-  bool backfill_commit_chunk(std::vector<LineairDBProxy::BatchOp> &ops,
-                             bool use_stateless_commit);
+  bool backfill_commit_chunk(std::vector<LineairDBProxy::BatchOp> &ops);
+
+  /**
+   * @brief Backfill one or more non-unique secondary indexes in parallel.
+   *
+   * @details Decodes each row once on the calling thread and builds one write
+   * per index in `specs` (name, runtime KEY), so a single scan and decode feed
+   * every index. Writes are partitioned by secondary-key hash and committed on
+   * per-partition worker threads, each with its own server connection. The hash
+   * partition commits every op for a secondary key on one worker, so no two
+   * workers mutate the same index DataItem; distinct keys commit through the
+   * normal concurrent path LineairDB serves for multiple query layers.
+   * Returns false if any worker commit fails; the caller fails the ALTER.
+   */
+  bool backfill_indexes_parallel(
+      std::vector<std::pair<std::string, std::string>> &rows,
+      const std::vector<std::pair<std::string, const KEY *>> &specs);
+
+  /**
+   * @brief Backfill one unique secondary index serially via the staging path.
+   *
+   * @details Scans the table and commits in bounded chunks, keeping the staging
+   * commit path so the server's in-write duplicate check runs. Returns false on
+   * any failure; the caller fails the ALTER.
+   */
+  bool backfill_unique_serial(const std::string &index_name,
+                              const KEY &runtime_key);
 
   void set_write_buffer(uchar *buf);
   bool is_primary_key_exists();

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -1033,12 +1033,9 @@ bool LineairDBTransaction::flush_write_buffer_for_table(
 std::optional<LineairDBTransaction::LocalRowEntry>
 LineairDBTransaction::lookup_write_set(
     const std::string& table_name, const std::string& key) const {
-  for (auto it = own_writes_.rbegin(); it != own_writes_.rend(); ++it) {
-    if (it->table_name == table_name && it->key == key) {
-      return *it;
-    }
-  }
-  return std::nullopt;
+  auto it = own_writes_index_.find(make_row_cache_key(table_name, key));
+  if (it == own_writes_index_.end()) return std::nullopt;
+  return own_writes_[it->second];
 }
 
 std::optional<LineairDBTransaction::LocalRowEntry>
@@ -1205,14 +1202,18 @@ void LineairDBTransaction::record_write(const std::string& table_name,
   // A later write/delete replaces any cached read for the same key
   drop_row_cache(table_name, key);
 
-  for (auto& entry : own_writes_) {
-    if (entry.table_name == table_name && entry.key == key) {
-      entry.found = found;
-      entry.value = value;
-      return;
-    }
+  std::string index_key = make_row_cache_key(table_name, key);
+  auto it = own_writes_index_.find(index_key);
+  if (it != own_writes_index_.end()) {
+    LocalRowEntry& entry = own_writes_[it->second];
+    entry.found = found;
+    entry.value = value;
+    return;
   }
+  // Append first so a throwing push_back leaves both containers untouched; the
+  // index entry then points at the element that is already in place.
   own_writes_.push_back({table_name, key, found, value});
+  own_writes_index_.emplace(std::move(index_key), own_writes_.size() - 1);
 }
 
 void LineairDBTransaction::record_row_cache(

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -266,6 +266,9 @@ private:
   }
   // Proxy-side write set for exact primary-key writes/deletes
   std::vector<LocalRowEntry> own_writes_;
+  // Dedup/lookup index into own_writes_, keyed like row_cache_. own_writes_ only
+  // ever grows by push_back, so a stored index never moves and stays valid.
+  std::unordered_map<std::string, size_t> own_writes_index_;
 
   // OCC commit-time read validation, two append-only sets (Silo read_set
   // style); the server re-checks each at commit and aborts on a mismatch:


### PR DESCRIPTION
## Summary

- Index the transaction write set so bulk-load `record_write` dedup and read-your-own-write lookups are constant-time instead of a linear scan per buffered write.
- Backfill a non-unique `CREATE INDEX` through the scan-free stateless commit, scanning each table once for all its non-unique indexes and committing on parallel per-partition connections.
- Bump benchbase so the TPC-H loader adds a table's indexes in one `ALTER`, which the single-scan backfill needs to build them together.

## Why

Loading the benchmark data and rebuilding its secondary indexes runs through the proxy, where two paths scaled badly. The bulk insert's `record_write` scanned `own_writes_` linearly on every buffered write, which is quadratic in the write count. `CREATE INDEX` backfill committed through the staging path, which scans the read and write sets on every secondary-index write and decoded the whole table once per index on a single connection.

This branch makes both single-pass: an indexed write set, and a non-unique backfill on the scan-free stateless commit built from one parallel scan. A unique index keeps the serial staging path for its in-write duplicate check, so duplicate detection is unchanged.

## Details

### Constant-time write set

An `unordered_map` keyed like `row_cache_` replaces the linear `own_writes_` scan in `record_write` and `lookup_write_set`. `own_writes_` only grows by `push_back`, so a stored index stays valid; appending before inserting keeps both containers consistent if an allocation throws.

### Single-scan parallel backfill

A non-unique index routes through the stateless validate-and-commit, skipping the read/write-set scans the staging path runs on every secondary-index write; a unique index keeps staging for its duplicate check. A table's non-unique indexes are scanned and decoded once together and committed on per-partition worker threads, each on its own server connection. The hash partition commits every entry for a secondary key on one worker, so no two workers mutate the same index entry, and distinct keys commit through the concurrent path LineairDB already serves for multiple query layers. Per-worker write buffers are reserved to their hash share before bucketing to avoid reallocation, and the benchbase TPC-H loader adds a table's indexes in one `ALTER` so the single scan can build them together.