### PR TITLE
feat(proxy): offload joined aggregate query blocks to LineairDB

### DIFF
--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -734,6 +734,18 @@ message QueryBlockAggregate {
     repeated QueryBlockAggFunc aggs = 3;
     // Optional predicate over the emitted group row.
     PushedPredicate having = 4;
+    // Optional regrouping over this aggregate's output rows.
+    //
+    // Ordinals address the first-stage row layout:
+    //   0..group_columns_size-1 are group values
+    //   group_columns_size.. are aggregate values
+    // When this is present, QueryBlockOutputExpr ordinals address the regrouped
+    // layout: GROUP i is group_value_ordinals[i], AGG 0 is COUNT(*).
+    message Regroup {
+        repeated uint32 group_value_ordinals = 1;
+        bool count_star = 2;
+    }
+    Regroup regroup = 5;
 }
 
 message QueryBlockSortKey {

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -52,6 +52,10 @@ enum OpCode {
     TX_VALIDATE_AND_COMMIT = 29;
     TX_EXECUTE_READ_PLAN = 30;
     TX_GET_TABLE_STATS = 31;
+
+    // Secondary-engine computation pushdown.
+    // Executes a query-block operator tree on the LineairDB server.
+    TX_EXECUTE_QUERY_BLOCK = 36;
 }
 
 enum BatchOpType {
@@ -675,6 +679,101 @@ message TxFetchLastSecondaryEntryInRange {
         bool found = 1;
         SecondaryIndexEntry entry = 2;
         bool is_aborted = 3;
+    }
+}
+
+// Secondary-engine query-block request representation.
+//
+// A query block is represented as a tree of scan, join, and aggregate
+// operators over base tables. This is not SQL text, MySQL's AccessPath, or a
+// MySQL Query Execution Plan object; the proxy lowers supported query shapes
+// into this RPC form so the LineairDB server can execute them. Server execution
+// keeps rows as table row references until an expression needs a column value.
+// The response carries final rows in the proxy row format, one field per output
+// expression.
+message QueryBlockAggFunc {
+    enum Kind { COUNT = 0; SUM = 1; AVG = 2; MIN = 3; MAX = 4; }
+    Kind kind = 1;
+    // Table the argument reads from, as an index into Request.tables.
+    uint32 arg_table = 2;
+    // Argument expression over that table's columns. Unset for COUNT(*).
+    FilterExpr arg = 3;
+    // Optional per-row predicate, for conditional aggregates.
+    PushedPredicate filter = 4;
+    // Decimal scale of the argument for result formatting.
+    uint32 arg_scale = 5;
+    // MIN/MAX comparison semantics: 0=numeric decimal, 1=binary string.
+    uint32 cmp_kind = 6;
+}
+
+message QueryBlockColumnRef {
+    uint32 table_idx = 1;
+    uint32 column = 2;      // 0-based TABLE::field index.
+    uint32 cmp_kind = 3;    // 0=int64, 1=binary string, 2=decimal-as-number.
+}
+
+message QueryBlockScan {
+    uint32 table_idx = 1;
+    // Fully pushed single-table predicates for this scan.
+    PushedPredicate filter = 2;
+}
+
+message QueryBlockJoin {
+    uint32 build = 1;  // Node index into TxExecuteQueryBlock.Request.nodes.
+    uint32 probe = 2;
+    // Equi-key pairs, stored as parallel arrays.
+    repeated QueryBlockColumnRef build_keys = 3;
+    repeated QueryBlockColumnRef probe_keys = 4;
+    enum Type { INNER = 0; LEFT = 1; SEMI = 2; ANTI = 3; }
+    Type type = 5;
+}
+
+message QueryBlockAggregate {
+    uint32 input = 1;                       // Node index.
+    repeated QueryBlockColumnRef group_columns = 2; // Byte-equality grouping keys.
+    repeated QueryBlockAggFunc aggs = 3;
+    // Optional predicate over the emitted group row.
+    PushedPredicate having = 4;
+}
+
+message QueryBlockSortKey {
+    uint32 output_ordinal = 1;
+    bool descending = 2;
+    uint32 cmp_kind = 3;  // 0=int64 numeric, 1=binary string, 2=decimal numeric.
+}
+
+message QueryBlockNode {
+    oneof op {
+        QueryBlockScan scan = 1;
+        QueryBlockJoin join = 2;
+        QueryBlockAggregate aggregate = 3;
+    }
+}
+
+message QueryBlockOutputExpr {
+    enum Source { GROUP = 0; AGG = 1; COLUMN = 2; }
+    Source source = 1;
+    uint32 ordinal = 2;      // GROUP: group key index; AGG: aggregate index.
+    QueryBlockColumnRef column = 3;  // Used when source is COLUMN.
+}
+
+message TxExecuteQueryBlock {
+    message TableDesc {
+        string table_name = 1;
+    }
+    message Request {
+        repeated TableDesc tables = 1;
+        // Topological order; the last node is the root.
+        repeated QueryBlockNode nodes = 2;
+        repeated QueryBlockOutputExpr output = 3;
+        repeated QueryBlockSortKey order_by = 4;
+        uint64 limit = 5;  // 0 means no limit.
+        uint64 offset = 6;
+    }
+    message Response {
+        bool ok = 1;
+        string error = 2;
+        repeated bytes rows = 3;  // Proxy row format, output order.
     }
 }
 

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -696,7 +696,10 @@ message QueryBlockAggFunc {
     Kind kind = 1;
     // Table the argument reads from, as an index into Request.tables.
     uint32 arg_table = 2;
-    // Argument expression over that table's columns. Unset for COUNT(*).
+    // Argument expression over that table's columns. COLUMN_REF nodes may
+    // address another request table by encoding (table_idx << 16) | column in
+    // column_index; arg_table remains the default table for untagged refs.
+    // Unset for COUNT(*).
     FilterExpr arg = 3;
     // Optional per-row predicate, for conditional aggregates.
     PushedPredicate filter = 4;
@@ -710,6 +713,8 @@ message QueryBlockColumnRef {
     uint32 table_idx = 1;
     uint32 column = 2;      // 0-based TABLE::field index.
     uint32 cmp_kind = 3;    // 0=int64, 1=binary string, 2=decimal-as-number.
+    // When nonzero, grouping and output use only the first N cell bytes.
+    uint32 prefix_len = 4;
 }
 
 message QueryBlockScan {

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -247,18 +247,15 @@ bool GroupColumnIsBinarySafe(const Field *field) {
  * @brief Return the visible output ordinal used by an ORDER BY item.
  */
 int OrderOutputOrdinal(Item *order_item,
-                       const std::vector<Item *> &output_items, TABLE *table) {
+                       const std::vector<Item *> &output_items) {
   Item *order_real = order_item->real_item();
   for (size_t i = 0; i < output_items.size(); i++) {
     Item *output_real = output_items[i]->real_item();
     if (output_real == order_real) return static_cast<int>(i);
     if (order_real->type() == Item::FIELD_ITEM &&
         output_real->type() == Item::FIELD_ITEM) {
-      const Field *order_field = ResolveBaseField(
-          down_cast<Item_field *>(order_real)->field, table);
-      const Field *output_field = ResolveBaseField(
-          down_cast<Item_field *>(output_real)->field, table);
-      if (order_field != nullptr && order_field == output_field) {
+      if (down_cast<Item_field *>(order_real)->field ==
+          down_cast<Item_field *>(output_real)->field) {
         return static_cast<int>(i);
       }
     }
@@ -267,14 +264,105 @@ int OrderOutputOrdinal(Item *order_item,
 }
 
 /**
- * @brief Recognize single-table aggregate blocks supported by LINEAIRDB_COLUMNAR.
+ * @brief Flatten a top-level AND tree into individual predicates.
+ */
+void FlattenAnd(Item *condition, std::vector<Item *> *predicates) {
+  if (condition == nullptr) return;
+  if (condition->type() == Item::COND_ITEM &&
+      down_cast<Item_cond *>(condition)->functype() ==
+          Item_func::COND_AND_FUNC) {
+    List_iterator<Item> it(
+        *down_cast<Item_cond *>(condition)->argument_list());
+    for (Item *child = it++; child != nullptr; child = it++) {
+      FlattenAnd(child, predicates);
+    }
+    return;
+  }
+  predicates->push_back(condition);
+}
+
+/**
+ * @brief Convert SUM(CASE WHEN pred THEN 1 ELSE 0 END) to a COUNT filter.
+ */
+Item *CaseToCountFilter(Item *argument) {
+  if (argument->type() != Item::FUNC_ITEM) return nullptr;
+  auto *function = down_cast<Item_func *>(argument);
+  if (function->functype() != Item_func::CASE_FUNC) return nullptr;
+  if (function->argument_count() != 3) return nullptr;
+
+  Item *predicate = function->arguments()[0];
+  Item *then_item = function->arguments()[1];
+  Item *else_item = function->arguments()[2];
+  if (!then_item->const_item() || !else_item->const_item()) return nullptr;
+  if (then_item->val_int() != 1 || else_item->val_int() != 0) return nullptr;
+  return predicate;
+}
+
+struct QueryBlockTable {
+  TABLE *table = nullptr;
+  table_map map = 0;
+};
+
+/**
+ * @brief Return the only query table referenced by a table_map.
+ */
+int SingleTableOf(table_map used, const std::vector<QueryBlockTable> &tables) {
+  int found = -1;
+  for (size_t i = 0; i < tables.size(); i++) {
+    if ((used & tables[i].map) == 0) continue;
+    if (found >= 0) return -1;
+    found = static_cast<int>(i);
+  }
+  return found;
+}
+
+/**
+ * @brief Resolve a Field to the query table that owns it.
+ */
+int TableIndexOfField(const Field *field,
+                      const std::vector<QueryBlockTable> &tables) {
+  if (field == nullptr) return -1;
+  for (size_t i = 0; i < tables.size(); i++) {
+    if (field->table == tables[i].table) return static_cast<int>(i);
+  }
+  int found = -1;
+  for (size_t i = 0; i < tables.size(); i++) {
+    if (ResolveBaseField(field, tables[i].table) != nullptr) {
+      if (found >= 0) return -1;
+      found = static_cast<int>(i);
+    }
+  }
+  return found;
+}
+
+/**
+ * @brief Serialize one table's pushed predicates as a single PushedPredicate.
+ */
+bool SerializeTableFilters(const std::vector<Item *> &filters, TABLE *table,
+                           LineairDB::Protocol::PushedPredicate *predicate) {
+  if (filters.empty()) return true;
+  predicate->set_num_columns(table->s->fields);
+  if (filters.size() == 1) {
+    return serialize_item(filters[0], predicate->mutable_expr());
+  }
+
+  auto *root = predicate->mutable_expr();
+  root->set_op(LineairDB::Protocol::FilterExpr::OP_AND);
+  for (Item *filter : filters) {
+    if (!serialize_item(filter, root->add_children())) return false;
+  }
+  return true;
+}
+
+/**
+ * @brief Recognize aggregate query blocks supported by LINEAIRDB_COLUMNAR.
  *
  * Unsupported shapes return false and set `why`; callers convert that into a
  * secondary-engine reject that may fall back to the primary engine when the
  * session allows it.
  */
-bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
-                                   const char **why) {
+bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
+                         const char **why) {
 #define LDB_COL_REJECT(reason) \
   do {                         \
     *why = (reason);           \
@@ -292,13 +380,6 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
   if (unit == nullptr || !unit->is_simple())
     LDB_COL_REJECT("not simple unit");
 
-  Table_ref *table_ref = qb->leaf_tables;
-  if (table_ref == nullptr || table_ref->next_leaf != nullptr)
-    LDB_COL_REJECT("not single table");
-
-  TABLE *table = table_ref->table;
-  if (table == nullptr || table->s == nullptr) LDB_COL_REJECT("no TABLE");
-
   if (qb->having_cond() != nullptr) LDB_COL_REJECT("has HAVING");
   if (qb->is_distinct()) LDB_COL_REJECT("has DISTINCT");
   if (qb->has_windows()) LDB_COL_REJECT("has windows");
@@ -306,36 +387,164 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
   if (!join->implicit_grouping && qb->group_list.elements == 0)
     LDB_COL_REJECT("no aggregation");
 
-  if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
-    LDB_COL_REJECT("not SECONDARY_LOADed");
+  // The request table order is the stable numbering used by scan, join,
+  // grouping, and aggregate argument references.
+  std::vector<QueryBlockTable> tables;
+  for (Table_ref *table_ref = qb->leaf_tables; table_ref != nullptr;
+       table_ref = table_ref->next_leaf) {
+    TABLE *table = table_ref->table;
+    if (table == nullptr || table->s == nullptr) LDB_COL_REJECT("no TABLE");
+    if (table_ref->outer_join) LDB_COL_REJECT("outer join");
+    if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
+      LDB_COL_REJECT("not SECONDARY_LOADed");
+    tables.push_back({table, table_ref->map()});
+  }
+  if (tables.empty()) LDB_COL_REJECT("no tables");
 
-  auto &request = ctx->query_block_request;
-  request.add_tables()->set_table_name(table->s->normalized_path.str);
+  struct JoinEdge {
+    int left_table = -1;
+    int right_table = -1;
+    const Field *left_field = nullptr;
+    const Field *right_field = nullptr;
+  };
 
-  auto *scan_node = request.add_nodes();
-  auto *scan = scan_node->mutable_scan();
-  scan->set_table_idx(0);
+  std::vector<std::vector<Item *>> table_filters(tables.size());
+  std::vector<JoinEdge> join_edges;
   Item *where_cond =
       qb->where_cond() != nullptr ? qb->where_cond() : join->where_cond;
-  if (where_cond != nullptr) {
-    auto *predicate = scan->mutable_filter();
-    if (!serialize_item(where_cond, predicate->mutable_expr()))
-      LDB_COL_REJECT("WHERE not pushable");
-    predicate->set_num_columns(table->s->fields);
+  std::vector<Item *> predicates;
+  FlattenAnd(where_cond, &predicates);
+
+  // Local predicates become scan filters. Cross-table integer equalities become
+  // join edges; other cross-table shapes stay on the primary engine path.
+  for (Item *predicate : predicates) {
+    const table_map used = predicate->used_tables() & ~PSEUDO_TABLE_BITS;
+    const int table_idx = SingleTableOf(used, tables);
+    if (table_idx >= 0) {
+      table_filters[table_idx].push_back(predicate);
+      continue;
+    }
+    if (used == 0) {
+      table_filters[0].push_back(predicate);
+      continue;
+    }
+
+    if (predicate->type() != Item::FUNC_ITEM ||
+        down_cast<Item_func *>(predicate)->functype() != Item_func::EQ_FUNC) {
+      LDB_COL_REJECT("non-equi join predicate");
+    }
+    auto *equals = down_cast<Item_func *>(predicate);
+    Item *left = equals->arguments()[0]->real_item();
+    Item *right = equals->arguments()[1]->real_item();
+    if (left->type() != Item::FIELD_ITEM ||
+        right->type() != Item::FIELD_ITEM) {
+      LDB_COL_REJECT("join key not a column");
+    }
+
+    const Field *left_raw = down_cast<Item_field *>(left)->field;
+    const Field *right_raw = down_cast<Item_field *>(right)->field;
+    const int left_table = TableIndexOfField(left_raw, tables);
+    const int right_table = TableIndexOfField(right_raw, tables);
+    if (left_table < 0 || right_table < 0 || left_table == right_table) {
+      LDB_COL_REJECT("join key tables");
+    }
+    if (left_raw->result_type() != INT_RESULT ||
+        right_raw->result_type() != INT_RESULT) {
+      LDB_COL_REJECT("non-integer join key");
+    }
+
+    const Field *left_field =
+        ResolveBaseField(left_raw, tables[left_table].table);
+    const Field *right_field =
+        ResolveBaseField(right_raw, tables[right_table].table);
+    if (left_field == nullptr || right_field == nullptr) {
+      LDB_COL_REJECT("join key unresolvable");
+    }
+    join_edges.push_back({left_table, right_table, left_field, right_field});
+  }
+  if (tables.size() > 1 && join_edges.empty()) LDB_COL_REJECT("cross join");
+
+  // Scan every table once, attaching only predicates that read that table.
+  auto &request = ctx->query_block_request;
+  std::vector<int> scan_nodes(tables.size(), -1);
+  for (size_t table_idx = 0; table_idx < tables.size(); table_idx++) {
+    TABLE *table = tables[table_idx].table;
+    request.add_tables()->set_table_name(table->s->normalized_path.str);
+    auto *scan_node = request.add_nodes();
+    auto *scan = scan_node->mutable_scan();
+    scan->set_table_idx(static_cast<uint32_t>(table_idx));
+    scan_nodes[table_idx] = request.nodes_size() - 1;
+    if (!table_filters[table_idx].empty() &&
+        !SerializeTableFilters(table_filters[table_idx], table,
+                               scan->mutable_filter())) {
+      LDB_COL_REJECT("filter not pushable");
+    }
+  }
+
+  // Build a left-deep INNER join tree in FROM-clause order. Each new table must
+  // have at least one equality edge to the already joined side.
+  int current_node = scan_nodes[0];
+  std::vector<bool> joined(tables.size(), false);
+  joined[0] = true;
+  for (size_t table_idx = 1; table_idx < tables.size(); table_idx++) {
+    bool connected = false;
+    auto *join_node = request.add_nodes()->mutable_join();
+    join_node->set_type(LineairDB::Protocol::QueryBlockJoin::INNER);
+    join_node->set_build(scan_nodes[table_idx]);
+    join_node->set_probe(current_node);
+
+    for (const JoinEdge &edge : join_edges) {
+      const Field *build_field = nullptr;
+      const Field *probe_field = nullptr;
+      int probe_table = -1;
+      if (edge.left_table == static_cast<int>(table_idx) &&
+          joined[edge.right_table]) {
+        build_field = edge.left_field;
+        probe_field = edge.right_field;
+        probe_table = edge.right_table;
+      } else if (edge.right_table == static_cast<int>(table_idx) &&
+                 joined[edge.left_table]) {
+        build_field = edge.right_field;
+        probe_field = edge.left_field;
+        probe_table = edge.left_table;
+      } else {
+        continue;
+      }
+
+      auto *build_key = join_node->add_build_keys();
+      build_key->set_table_idx(static_cast<uint32_t>(table_idx));
+      build_key->set_column(build_field->field_index());
+      auto *probe_key = join_node->add_probe_keys();
+      probe_key->set_table_idx(static_cast<uint32_t>(probe_table));
+      probe_key->set_column(probe_field->field_index());
+      connected = true;
+    }
+
+    if (!connected) LDB_COL_REJECT("disconnected join graph");
+    joined[table_idx] = true;
+    current_node = request.nodes_size() - 1;
   }
 
   auto *aggregate_node = request.add_nodes();
   auto *aggregate = aggregate_node->mutable_aggregate();
-  aggregate->set_input(0);
-  std::vector<const Field *> group_fields;
+  aggregate->set_input(current_node);
+  struct GroupField {
+    int table = -1;
+    const Field *field = nullptr;
+  };
+  std::vector<GroupField> group_fields;
   for (ORDER *group = qb->group_list.first; group != nullptr;
        group = group->next) {
     Item *group_item = (*group->item)->real_item();
     if (group_item->type() != Item::FIELD_ITEM)
       LDB_COL_REJECT("group item not a column");
 
-    const Field *group_field = ResolveBaseField(
-        down_cast<Item_field *>(group_item)->field, table);
+    const Field *raw_group_field =
+        down_cast<Item_field *>(group_item)->field;
+    const int group_table = TableIndexOfField(raw_group_field, tables);
+    if (group_table < 0) LDB_COL_REJECT("group column foreign");
+    const Field *group_field =
+        ResolveBaseField(raw_group_field, tables[group_table].table);
     if (group_field == nullptr) LDB_COL_REJECT("group column foreign");
     if (group_field->is_nullable() ||
         !GroupColumnIsBinarySafe(group_field)) {
@@ -343,28 +552,36 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
     }
 
     auto *group_column = aggregate->add_group_columns();
-    group_column->set_table_idx(0);
+    group_column->set_table_idx(static_cast<uint32_t>(group_table));
     group_column->set_column(group_field->field_index());
     group_column->set_cmp_kind(group_field->result_type() == STRING_RESULT ? 1
                                                                            : 0);
-    group_fields.push_back(group_field);
+    group_fields.push_back({group_table, group_field});
   }
 
   std::vector<Item *> output_items;
   for (Item *item : VisibleFields(qb->fields)) output_items.push_back(item);
 
+  // The response must match MySQL's visible SELECT list exactly: grouped
+  // columns refer back to group keys, aggregate items refer to aggregate slots.
   for (Item *item : output_items) {
     Item *real = item->real_item();
     auto *output = request.add_output();
     if (real->type() == Item::FIELD_ITEM) {
-      const Field *output_field = ResolveBaseField(
-          down_cast<Item_field *>(real)->field, table);
+      const Field *raw_output_field = down_cast<Item_field *>(real)->field;
+      const int output_table = TableIndexOfField(raw_output_field, tables);
+      const Field *output_field =
+          output_table >= 0
+              ? ResolveBaseField(raw_output_field,
+                                 tables[output_table].table)
+              : nullptr;
       if (output_field == nullptr)
         LDB_COL_REJECT("output column unresolvable");
 
       int group_position = -1;
       for (size_t i = 0; i < group_fields.size(); i++) {
-        if (group_fields[i] == output_field) {
+        if (group_fields[i].table == output_table &&
+            group_fields[i].field == output_field) {
           group_position = static_cast<int>(i);
           break;
         }
@@ -384,10 +601,9 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
     if (sum->argument_count() > 1) LDB_COL_REJECT("aggregate arg count");
 
     auto *function = aggregate->add_aggs();
-    function->set_arg_table(0);
-
     switch (sum->sum_func()) {
       case Item_sum::COUNT_FUNC: {
+        function->set_arg_table(0);
         if (sum->argument_count() > 0) {
           Item *arg = sum->get_arg(0)->real_item();
           if (arg->const_item()) {
@@ -396,10 +612,17 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
           } else {
             if (arg->type() != Item::FIELD_ITEM)
               LDB_COL_REJECT("COUNT arg shape");
-            const Field *count_field = ResolveBaseField(
-                down_cast<Item_field *>(arg)->field, table);
+            const Field *raw_count_field =
+                down_cast<Item_field *>(arg)->field;
+            const int count_table = TableIndexOfField(raw_count_field, tables);
+            const Field *count_field =
+                count_table >= 0
+                    ? ResolveBaseField(raw_count_field,
+                                       tables[count_table].table)
+                    : nullptr;
             if (count_field == nullptr || count_field->is_nullable())
               LDB_COL_REJECT("COUNT arg nullable");
+            function->set_arg_table(static_cast<uint32_t>(count_table));
           }
         }
 
@@ -411,14 +634,33 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
       case Item_sum::AVG_FUNC: {
         if (sum->argument_count() != 1) LDB_COL_REJECT("aggregate arg count");
         Item *arg = sum->get_arg(0)->real_item();
+        if (sum->sum_func() == Item_sum::SUM_FUNC) {
+          if (Item *filter = CaseToCountFilter(arg)) {
+            const int filter_table = SingleTableOf(
+                filter->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+            if (filter_table < 0) LDB_COL_REJECT("CASE filter tables");
+            auto *predicate = function->mutable_filter();
+            predicate->set_num_columns(tables[filter_table].table->s->fields);
+            if (!serialize_item(filter, predicate->mutable_expr()))
+              LDB_COL_REJECT("CASE filter not pushable");
+            function->set_arg_table(static_cast<uint32_t>(filter_table));
+            function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
+            break;
+          }
+        }
         if (arg->result_type() != DECIMAL_RESULT &&
             arg->result_type() != INT_RESULT) {
           LDB_COL_REJECT("aggregate arg type");
         }
 
+        const int argument_table =
+            SingleTableOf(arg->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+        if (argument_table < 0) LDB_COL_REJECT("aggregate arg tables");
         if (arg->type() == Item::FIELD_ITEM) {
+          const Field *raw_argument_field =
+              down_cast<Item_field *>(arg)->field;
           const Field *argument_field = ResolveBaseField(
-              down_cast<Item_field *>(arg)->field, table);
+              raw_argument_field, tables[argument_table].table);
           if (argument_field == nullptr)
             LDB_COL_REJECT("aggregate arg unresolvable");
 
@@ -432,6 +674,7 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
           }
         }
 
+        function->set_arg_table(static_cast<uint32_t>(argument_table));
         function->set_kind(
             sum->sum_func() == Item_sum::SUM_FUNC
                 ? LineairDB::Protocol::QueryBlockAggFunc::SUM
@@ -445,13 +688,21 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
         if (sum->argument_count() != 1) LDB_COL_REJECT("aggregate arg count");
         Item *arg = sum->get_arg(0)->real_item();
         if (arg->type() != Item::FIELD_ITEM) LDB_COL_REJECT("minmax arg");
-        const Field *argument_field = ResolveBaseField(
-            down_cast<Item_field *>(arg)->field, table);
+        const Field *raw_argument_field =
+            down_cast<Item_field *>(arg)->field;
+        const int argument_table =
+            TableIndexOfField(raw_argument_field, tables);
+        const Field *argument_field =
+            argument_table >= 0
+                ? ResolveBaseField(raw_argument_field,
+                                   tables[argument_table].table)
+                : nullptr;
         if (argument_field == nullptr) LDB_COL_REJECT("minmax unresolvable");
 
         auto *ref = function->mutable_arg();
         ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
         ref->set_column_index(argument_field->field_index());
+        function->set_arg_table(static_cast<uint32_t>(argument_table));
         function->set_kind(
             sum->sum_func() == Item_sum::MIN_FUNC
                 ? LineairDB::Protocol::QueryBlockAggFunc::MIN
@@ -475,7 +726,7 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
   for (ORDER *order = qb->order_list.first; order != nullptr;
        order = order->next) {
     const int output_ordinal =
-        OrderOutputOrdinal(*order->item, output_items, table);
+        OrderOutputOrdinal(*order->item, output_items);
     if (output_ordinal < 0)
       LDB_COL_REJECT("ORDER BY not an output column");
 
@@ -592,7 +843,7 @@ bool OptimizeSecondaryEngine(THD *, LEX *lex) {
   Query_block *query_block = lex->unit->first_query_block();
   JOIN *join = query_block != nullptr ? query_block->join : nullptr;
   const char *why = "no JOIN";
-  if (join == nullptr || !RecognizeSingleTableAggregate(join, ctx, &why)) {
+  if (join == nullptr || !RecognizeQueryBlock(join, ctx, &why)) {
     char message[128];
     snprintf(message, sizeof(message),
              "LINEAIRDB_COLUMNAR unsupported shape: %s", why ? why : "?");

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -287,6 +287,40 @@ void FlattenAnd(Item *condition, std::vector<Item *> *predicates) {
 }
 
 /**
+ * @brief Return true when an Item shape is a boolean filter predicate.
+ */
+bool IsBooleanFilterShape(Item *item) {
+  item = item == nullptr ? nullptr : item->real_item();
+  if (item == nullptr) return false;
+
+  if (item->type() == Item::COND_ITEM) {
+    const auto *condition = down_cast<const Item_cond *>(item);
+    return condition->functype() == Item_func::COND_AND_FUNC ||
+           condition->functype() == Item_func::COND_OR_FUNC;
+  }
+
+  if (item->type() != Item::FUNC_ITEM) return false;
+
+  switch (down_cast<const Item_func *>(item)->functype()) {
+    case Item_func::EQ_FUNC:
+    case Item_func::NE_FUNC:
+    case Item_func::LT_FUNC:
+    case Item_func::LE_FUNC:
+    case Item_func::GT_FUNC:
+    case Item_func::GE_FUNC:
+    case Item_func::BETWEEN:
+    case Item_func::IN_FUNC:
+    case Item_func::LIKE_FUNC:
+    case Item_func::ISNULL_FUNC:
+    case Item_func::ISNOTNULL_FUNC:
+    case Item_func::NOT_FUNC:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
  * @brief Convert SUM(CASE WHEN pred THEN 1 ELSE 0 END) to a COUNT filter.
  */
 Item *CaseToCountFilter(Item *argument) {
@@ -300,6 +334,7 @@ Item *CaseToCountFilter(Item *argument) {
   Item *else_item = function->arguments()[2];
   if (!then_item->const_item() || !else_item->const_item()) return nullptr;
   if (then_item->val_int() != 1 || else_item->val_int() != 0) return nullptr;
+  if (!IsBooleanFilterShape(predicate)) return nullptr;
   return predicate;
 }
 
@@ -586,6 +621,9 @@ bool RecognizeDerivedRegroup(JOIN *join, ColumnarExecutionContext *ctx,
     if (preserved_key->result_type() != INT_RESULT ||
         nullable_key->result_type() != INT_RESULT) {
       LDB_COL_REJECT("inner join key type");
+    }
+    if (preserved_key->is_nullable() || nullable_key->is_nullable()) {
+      LDB_COL_REJECT("inner join key nullable");
     }
   }
   if (preserved_key == nullptr) LDB_COL_REJECT("inner join key missing");
@@ -899,6 +937,9 @@ bool RecognizeFlattenedAggregate(JOIN *join, ColumnarExecutionContext *ctx,
         ResolveBaseField(right_raw, tables[right_table].table);
     if (left_field == nullptr || right_field == nullptr) {
       LDB_COL_REJECT("inner join key unresolvable");
+    }
+    if (left_field->is_nullable() || right_field->is_nullable()) {
+      LDB_COL_REJECT("inner join key nullable");
     }
     join_edges.push_back(
         {left_table, right_table, left_field, right_field});
@@ -1218,6 +1259,9 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
     if (left_field == nullptr || right_field == nullptr) {
       LDB_COL_REJECT("join key unresolvable");
     }
+    if (left_field->is_nullable() || right_field->is_nullable()) {
+      LDB_COL_REJECT("join key nullable");
+    }
     join_edges.push_back({left_table, right_table, left_field, right_field});
   }
   if (tables.size() > 1 && join_edges.empty()) LDB_COL_REJECT("cross join");
@@ -1522,6 +1566,11 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
                                    tables[argument_table].table)
                 : nullptr;
         if (argument_field == nullptr) LDB_COL_REJECT("minmax unresolvable");
+        if (argument_field->is_nullable()) LDB_COL_REJECT("minmax nullable");
+        if (argument_field->result_type() == STRING_RESULT &&
+            !argument_field->binary()) {
+          LDB_COL_REJECT("minmax collation");
+        }
 
         auto *ref = function->mutable_arg();
         ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -627,6 +627,9 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
             if (count_field == nullptr || count_field->is_nullable())
               LDB_COL_REJECT("COUNT arg nullable");
             function->set_arg_table(static_cast<uint32_t>(count_table));
+            auto *ref = function->mutable_arg();
+            ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+            ref->set_column_index(count_field->field_index());
           }
         }
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -231,10 +231,14 @@ const Field *ResolveBaseField(const Field *field, TABLE *table) {
 
 /**
  * @brief Return true when raw-byte GROUP BY keys match MySQL equality.
+ *
+ * DECIMAL cells are stored as canonical base-10 text in PAX, so equal values
+ * have equal bytes within one schema.
  */
 bool GroupColumnIsBinarySafe(const Field *field) {
   switch (field->result_type()) {
     case INT_RESULT:
+    case DECIMAL_RESULT:
       return true;
     case STRING_RESULT:
       return field->binary();

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -18,6 +18,7 @@
 #include "sql/handler.h"
 #include "sql/item.h"
 #include "sql/item_sum.h"
+#include "sql/item_timefunc.h"
 #include "sql/mem_root_array.h"
 #include "sql/query_result.h"
 #include "sql/sql_const.h"
@@ -337,6 +338,114 @@ int TableIndexOfField(const Field *field,
     }
   }
   return found;
+}
+
+/**
+ * @brief Encode a column reference inside an aggregate expression.
+ *
+ * Untagged column refs read from the aggregate function's default table. Tagged
+ * refs use the upper bits for the query-block table index, allowing one SUM
+ * expression to read columns from multiple joined tables.
+ */
+uint32_t EncodeAggregateColumnRef(uint32_t default_table_idx,
+                                  uint32_t table_idx, uint32_t column_idx) {
+  if (table_idx == default_table_idx) return column_idx;
+  return (table_idx << 16) | column_idx;
+}
+
+/**
+ * @brief Serialize arithmetic aggregate arguments with table-aware column refs.
+ *
+ * Supports column refs, integer constants, and +, -, *, and unary minus. This
+ * is used only when the expression may read more than one joined table; single
+ * table aggregate expressions keep using the shared serializer.
+ */
+bool SerializeAggregateExpressionForTables(
+    Item *item, const std::vector<QueryBlockTable> &tables,
+    uint32_t default_table_idx, LineairDB::Protocol::FilterExpr *out) {
+  item = item->real_item();
+  switch (item->type()) {
+    case Item::FIELD_ITEM: {
+      const Field *raw_field = down_cast<Item_field *>(item)->field;
+      const int table_idx = TableIndexOfField(raw_field, tables);
+      if (table_idx < 0) return false;
+      const Field *field =
+          ResolveBaseField(raw_field, tables[table_idx].table);
+      if (field == nullptr) return false;
+
+      out->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+      out->set_column_index(EncodeAggregateColumnRef(
+          default_table_idx, static_cast<uint32_t>(table_idx),
+          field->field_index()));
+      return true;
+    }
+    case Item::INT_ITEM: {
+      out->set_op(LineairDB::Protocol::FilterExpr::CONST_INT);
+      out->set_int_val(item->val_int());
+      return true;
+    }
+    case Item::FUNC_ITEM: {
+      auto *function = down_cast<Item_func *>(item);
+      using FilterExpr = LineairDB::Protocol::FilterExpr;
+      FilterExpr::Op op;
+      switch (function->functype()) {
+        case Item_func::PLUS_FUNC:
+          op = FilterExpr::OP_ADD;
+          break;
+        case Item_func::MINUS_FUNC:
+          op = FilterExpr::OP_SUB;
+          break;
+        case Item_func::MUL_FUNC:
+          op = FilterExpr::OP_MUL;
+          break;
+        case Item_func::NEG_FUNC:
+          op = FilterExpr::OP_NEG;
+          break;
+        default:
+          return false;
+      }
+
+      out->set_op(op);
+      if (op == FilterExpr::OP_NEG) {
+        if (function->argument_count() != 1) return false;
+        return SerializeAggregateExpressionForTables(
+            function->arguments()[0], tables, default_table_idx,
+            out->add_children());
+      }
+      if (function->argument_count() != 2) return false;
+      return SerializeAggregateExpressionForTables(
+                 function->arguments()[0], tables, default_table_idx,
+                 out->add_children()) &&
+             SerializeAggregateExpressionForTables(
+                 function->arguments()[1], tables, default_table_idx,
+                 out->add_children());
+    }
+    default:
+      return false;
+  }
+}
+
+/**
+ * @brief Return the date field inside EXTRACT(YEAR FROM field), if supported.
+ */
+const Field *ExtractYearField(Item *item) {
+  Item *real = item->real_item();
+  if (real->type() != Item::FUNC_ITEM) return nullptr;
+  auto *function = down_cast<Item_func *>(real);
+  if (function->functype() != Item_func::EXTRACT_FUNC) return nullptr;
+
+  auto *extract = down_cast<Item_extract *>(function);
+  if (extract->int_type != INTERVAL_YEAR) return nullptr;
+  Item *arg = extract->arguments()[0]->real_item();
+  if (arg->type() != Item::FIELD_ITEM) return nullptr;
+
+  const Field *field = down_cast<Item_field *>(arg)->field;
+  if (field->type() != MYSQL_TYPE_DATE &&
+      field->type() != MYSQL_TYPE_DATETIME &&
+      field->type() != MYSQL_TYPE_NEWDATE) {
+    return nullptr;
+  }
+  return field;
 }
 
 /**
@@ -796,12 +905,34 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
     }
   }
 
-  // Build a left-deep INNER join tree in FROM-clause order. Each new table must
-  // have at least one equality edge to the already joined side.
+  // Build a left-deep INNER join tree by walking FROM order and retrying tables
+  // whose equality edges are not connected yet.
   int current_node = scan_nodes[0];
   std::vector<bool> joined(tables.size(), false);
   joined[0] = true;
+  std::vector<int> pending_tables;
   for (size_t table_idx = 1; table_idx < tables.size(); table_idx++) {
+    pending_tables.push_back(static_cast<int>(table_idx));
+  }
+  while (!pending_tables.empty()) {
+    int table_idx = -1;
+    size_t pending_idx = 0;
+    for (size_t idx = 0; idx < pending_tables.size(); idx++) {
+      for (const JoinEdge &edge : join_edges) {
+        if ((edge.left_table == pending_tables[idx] &&
+             joined[edge.right_table]) ||
+            (edge.right_table == pending_tables[idx] &&
+             joined[edge.left_table])) {
+          table_idx = pending_tables[idx];
+          pending_idx = idx;
+          break;
+        }
+      }
+      if (table_idx >= 0) break;
+    }
+    if (table_idx < 0) LDB_COL_REJECT("disconnected join graph");
+    pending_tables.erase(pending_tables.begin() + pending_idx);
+
     bool connected = false;
     auto *join_node = request.add_nodes()->mutable_join();
     join_node->set_type(LineairDB::Protocol::QueryBlockJoin::INNER);
@@ -848,9 +979,30 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
     const Field *field = nullptr;
   };
   std::vector<GroupField> group_fields;
+  std::vector<Item *> group_items;
   for (ORDER *group = qb->group_list.first; group != nullptr;
        group = group->next) {
     Item *group_item = (*group->item)->real_item();
+    group_items.push_back(group_item);
+    if (const Field *year_field = ExtractYearField(group_item)) {
+      const int group_table = TableIndexOfField(year_field, tables);
+      const Field *group_field =
+          group_table >= 0
+              ? ResolveBaseField(year_field, tables[group_table].table)
+              : nullptr;
+      if (group_field == nullptr || group_field->is_nullable()) {
+        LDB_COL_REJECT("group year column");
+      }
+
+      auto *group_column = aggregate->add_group_columns();
+      group_column->set_table_idx(static_cast<uint32_t>(group_table));
+      group_column->set_column(group_field->field_index());
+      group_column->set_prefix_len(4);
+      group_column->set_cmp_kind(0);
+      group_fields.push_back({group_table, nullptr});
+      continue;
+    }
+
     if (group_item->type() != Item::FIELD_ITEM)
       LDB_COL_REJECT("group item not a column");
 
@@ -895,7 +1047,8 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
 
       int group_position = -1;
       for (size_t i = 0; i < group_fields.size(); i++) {
-        if (group_fields[i].table == output_table &&
+        if (group_fields[i].field != nullptr &&
+            group_fields[i].table == output_table &&
             group_fields[i].field == output_field) {
           group_position = static_cast<int>(i);
           break;
@@ -909,8 +1062,21 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
       continue;
     }
 
-    if (real->type() != Item::SUM_FUNC_ITEM)
-      LDB_COL_REJECT("output not aggregate");
+    if (real->type() != Item::SUM_FUNC_ITEM) {
+      int group_position = -1;
+      for (size_t group_idx = 0; group_idx < group_items.size();
+           group_idx++) {
+        if (group_items[group_idx] == real ||
+            group_items[group_idx]->eq(real, true)) {
+          group_position = static_cast<int>(group_idx);
+          break;
+        }
+      }
+      if (group_position < 0) LDB_COL_REJECT("output not aggregate");
+      output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::GROUP);
+      output->set_ordinal(group_position);
+      continue;
+    }
 
     Item_sum *sum = down_cast<Item_sum *>(real);
     if (sum->argument_count() > 1) LDB_COL_REJECT("aggregate arg count");
@@ -971,10 +1137,9 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
           LDB_COL_REJECT("aggregate arg type");
         }
 
-        const int argument_table =
+        int argument_table =
             SingleTableOf(arg->used_tables() & ~PSEUDO_TABLE_BITS, tables);
-        if (argument_table < 0) LDB_COL_REJECT("aggregate arg tables");
-        if (arg->type() == Item::FIELD_ITEM) {
+        if (argument_table >= 0 && arg->type() == Item::FIELD_ITEM) {
           const Field *raw_argument_field =
               down_cast<Item_field *>(arg)->field;
           const Field *argument_field = ResolveBaseField(
@@ -985,9 +1150,16 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
           auto *ref = function->mutable_arg();
           ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
           ref->set_column_index(argument_field->field_index());
-        } else {
+        } else if (argument_table >= 0) {
           if (!lineairdb::serialize_aggregate_expression(
                   arg, function->mutable_arg())) {
+            LDB_COL_REJECT("aggregate expr not pushable");
+          }
+        } else {
+          argument_table = 0;
+          if (!SerializeAggregateExpressionForTables(
+                  arg, tables, static_cast<uint32_t>(argument_table),
+                  function->mutable_arg())) {
             LDB_COL_REJECT("aggregate expr not pushable");
           }
         }

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -359,6 +359,312 @@ bool SerializeTableFilters(const std::vector<Item *> &filters, TABLE *table,
 }
 
 /**
+ * @brief Recognize a derived-table aggregate that regroups an inner aggregate.
+ *
+ * The supported shape is an outer GROUP BY over a materialized derived table
+ * whose inner query is a two-table LEFT join grouped on the preserved side.
+ * The inner block becomes scan + scan + LEFT join + aggregate; the outer block
+ * becomes QueryBlockAggregate::regroup over the inner aggregate's output row.
+ */
+bool RecognizeDerivedRegroup(JOIN *join, ColumnarExecutionContext *ctx,
+                             const char **why) {
+#define LDB_COL_REJECT(reason) \
+  do {                         \
+    *why = (reason);           \
+    return false;              \
+  } while (0)
+
+  Query_block *qb = join->query_block;
+  Table_ref *derived_ref = qb->leaf_tables;
+  if (derived_ref == nullptr || derived_ref->next_leaf != nullptr ||
+      !derived_ref->is_view_or_derived() || derived_ref->table == nullptr) {
+    LDB_COL_REJECT("not single derived table");
+  }
+
+  Query_expression *inner_unit = derived_ref->derived_query_expression();
+  if (inner_unit == nullptr || !inner_unit->is_simple())
+    LDB_COL_REJECT("derived not simple");
+  Query_block *inner_qb = inner_unit->first_query_block();
+  if (inner_qb == nullptr) LDB_COL_REJECT("no inner query block");
+
+  if (qb->having_cond() != nullptr) LDB_COL_REJECT("outer has HAVING");
+  if (qb->is_distinct()) LDB_COL_REJECT("outer has DISTINCT");
+  if (qb->has_windows()) LDB_COL_REJECT("outer has windows");
+  if (qb->olap != UNSPECIFIED_OLAP_TYPE) LDB_COL_REJECT("outer has ROLLUP");
+  if (qb->where_cond() != nullptr) LDB_COL_REJECT("outer has WHERE");
+  if (qb->group_list.elements == 0) LDB_COL_REJECT("outer not grouped");
+
+  if (inner_qb->having_cond() != nullptr) LDB_COL_REJECT("inner has HAVING");
+  if (inner_qb->is_distinct()) LDB_COL_REJECT("inner has DISTINCT");
+  if (inner_qb->has_windows()) LDB_COL_REJECT("inner has windows");
+  if (inner_qb->olap != UNSPECIFIED_OLAP_TYPE)
+    LDB_COL_REJECT("inner has ROLLUP");
+  if (inner_qb->where_cond() != nullptr) LDB_COL_REJECT("inner has WHERE");
+  if (inner_qb->order_list.elements > 0 || inner_qb->has_limit())
+    LDB_COL_REJECT("inner has order or limit");
+
+  Table_ref *left_ref = inner_qb->leaf_tables;
+  Table_ref *right_ref = left_ref != nullptr ? left_ref->next_leaf : nullptr;
+  if (left_ref == nullptr || right_ref == nullptr ||
+      right_ref->next_leaf != nullptr) {
+    LDB_COL_REJECT("inner not two tables");
+  }
+
+  Table_ref *nullable_ref = nullptr;
+  if (left_ref->outer_join && !right_ref->outer_join) {
+    nullable_ref = left_ref;
+  } else if (right_ref->outer_join && !left_ref->outer_join) {
+    nullable_ref = right_ref;
+  } else {
+    LDB_COL_REJECT("inner join shape");
+  }
+  Table_ref *preserved_ref = nullable_ref == left_ref ? right_ref : left_ref;
+  TABLE *preserved_table = preserved_ref->table;
+  TABLE *nullable_table = nullable_ref->table;
+  if (preserved_table == nullptr || preserved_table->s == nullptr ||
+      nullable_table == nullptr || nullable_table->s == nullptr) {
+    LDB_COL_REJECT("inner no TABLE");
+  }
+  if (!loaded_tables->contains(preserved_table->s->db.str,
+                               preserved_table->s->table_name.str) ||
+      !loaded_tables->contains(nullable_table->s->db.str,
+                               nullable_table->s->table_name.str)) {
+    LDB_COL_REJECT("inner not SECONDARY_LOADed");
+  }
+
+  Item *join_condition = nullable_ref->join_cond();
+  if (join_condition == nullptr) LDB_COL_REJECT("inner join has no ON");
+  std::vector<Item *> join_predicates;
+  FlattenAnd(join_condition, &join_predicates);
+
+  const Field *preserved_key = nullptr;
+  const Field *nullable_key = nullptr;
+  std::vector<Item *> nullable_filters;
+  for (Item *predicate : join_predicates) {
+    const table_map used = predicate->used_tables() & ~PSEUDO_TABLE_BITS;
+    if ((used & nullable_ref->map()) != 0 &&
+        (used & preserved_ref->map()) == 0) {
+      nullable_filters.push_back(predicate);
+      continue;
+    }
+
+    if (predicate->type() != Item::FUNC_ITEM ||
+        down_cast<Item_func *>(predicate)->functype() != Item_func::EQ_FUNC) {
+      LDB_COL_REJECT("inner join predicate not equality");
+    }
+    auto *equals = down_cast<Item_func *>(predicate);
+    Item *left = equals->arguments()[0]->real_item();
+    Item *right = equals->arguments()[1]->real_item();
+    if (left->type() != Item::FIELD_ITEM ||
+        right->type() != Item::FIELD_ITEM) {
+      LDB_COL_REJECT("inner join key not a column");
+    }
+
+    const Field *left_field = down_cast<Item_field *>(left)->field;
+    const Field *right_field = down_cast<Item_field *>(right)->field;
+    if (preserved_key != nullptr) LDB_COL_REJECT("multiple inner join keys");
+    if (left_field->table == preserved_table &&
+        right_field->table == nullable_table) {
+      preserved_key = left_field;
+      nullable_key = right_field;
+    } else if (left_field->table == nullable_table &&
+               right_field->table == preserved_table) {
+      preserved_key = right_field;
+      nullable_key = left_field;
+    } else {
+      LDB_COL_REJECT("inner join key tables");
+    }
+    if (preserved_key->result_type() != INT_RESULT ||
+        nullable_key->result_type() != INT_RESULT) {
+      LDB_COL_REJECT("inner join key type");
+    }
+  }
+  if (preserved_key == nullptr) LDB_COL_REJECT("inner join key missing");
+
+  if (inner_qb->group_list.elements != 1)
+    LDB_COL_REJECT("inner group arity");
+  Item *inner_group_item = (*inner_qb->group_list.first->item)->real_item();
+  if (inner_group_item->type() != Item::FIELD_ITEM)
+    LDB_COL_REJECT("inner group shape");
+  const Field *inner_group_field =
+      down_cast<Item_field *>(inner_group_item)->field;
+  if (inner_group_field->table != preserved_table ||
+      inner_group_field->is_nullable() ||
+      !GroupColumnIsBinarySafe(inner_group_field)) {
+    LDB_COL_REJECT("inner group column");
+  }
+
+  std::vector<Item *> inner_outputs;
+  for (Item *item : VisibleFields(inner_qb->fields)) {
+    inner_outputs.push_back(item);
+  }
+  if (inner_outputs.size() != 2) LDB_COL_REJECT("inner output arity");
+
+  std::vector<int> first_stage_ordinals(inner_outputs.size(), -1);
+  const Field *count_arg_field = nullptr;
+  bool saw_inner_count = false;
+  for (size_t output_idx = 0; output_idx < inner_outputs.size();
+       ++output_idx) {
+    Item *real = inner_outputs[output_idx]->real_item();
+    if (real->type() == Item::FIELD_ITEM &&
+        down_cast<Item_field *>(real)->field == inner_group_field) {
+      first_stage_ordinals[output_idx] = 0;
+      continue;
+    }
+
+    if (real->type() != Item::SUM_FUNC_ITEM)
+      LDB_COL_REJECT("inner output shape");
+    Item_sum *sum = down_cast<Item_sum *>(real);
+    if (sum->sum_func() != Item_sum::COUNT_FUNC ||
+        sum->argument_count() != 1) {
+      LDB_COL_REJECT("inner aggregate not COUNT");
+    }
+    Item *arg = sum->get_arg(0)->real_item();
+    if (arg->const_item()) LDB_COL_REJECT("inner COUNT(*) under LEFT");
+    if (arg->type() != Item::FIELD_ITEM) LDB_COL_REJECT("inner COUNT arg");
+    const Field *field = down_cast<Item_field *>(arg)->field;
+    if (field->table != nullable_table || field->is_nullable()) {
+      LDB_COL_REJECT("inner COUNT arg column");
+    }
+    count_arg_field = field;
+    saw_inner_count = true;
+    first_stage_ordinals[output_idx] = 1;
+  }
+  if (!saw_inner_count) LDB_COL_REJECT("inner COUNT missing");
+
+  auto &request = ctx->query_block_request;
+  request.Clear();
+  request.add_tables()->set_table_name(preserved_table->s->normalized_path.str);
+  request.add_tables()->set_table_name(nullable_table->s->normalized_path.str);
+
+  auto *preserved_scan = request.add_nodes()->mutable_scan();
+  preserved_scan->set_table_idx(0);
+  auto *nullable_scan = request.add_nodes()->mutable_scan();
+  nullable_scan->set_table_idx(1);
+  if (!nullable_filters.empty() &&
+      !SerializeTableFilters(nullable_filters, nullable_table,
+                             nullable_scan->mutable_filter())) {
+    LDB_COL_REJECT("inner ON filter not pushable");
+  }
+
+  auto *left_join = request.add_nodes()->mutable_join();
+  left_join->set_type(LineairDB::Protocol::QueryBlockJoin::LEFT);
+  left_join->set_build(1);
+  left_join->set_probe(0);
+  auto *build_key = left_join->add_build_keys();
+  build_key->set_table_idx(1);
+  build_key->set_column(nullable_key->field_index());
+  auto *probe_key = left_join->add_probe_keys();
+  probe_key->set_table_idx(0);
+  probe_key->set_column(preserved_key->field_index());
+
+  auto *aggregate = request.add_nodes()->mutable_aggregate();
+  aggregate->set_input(2);
+  auto *group_column = aggregate->add_group_columns();
+  group_column->set_table_idx(0);
+  group_column->set_column(inner_group_field->field_index());
+  group_column->set_cmp_kind(
+      inner_group_field->result_type() == STRING_RESULT ? 1 : 0);
+
+  auto *function = aggregate->add_aggs();
+  function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
+  function->set_arg_table(1);
+  auto *count_ref = function->mutable_arg();
+  count_ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+  count_ref->set_column_index(count_arg_field->field_index());
+
+  auto *regroup = aggregate->mutable_regroup();
+  regroup->set_count_star(true);
+
+  struct OuterGroup {
+    const Field *field = nullptr;
+    int regroup_slot = -1;
+  };
+  std::vector<OuterGroup> outer_groups;
+  for (ORDER *group = qb->group_list.first; group != nullptr;
+       group = group->next) {
+    Item *group_item = (*group->item)->real_item();
+    if (group_item->type() != Item::FIELD_ITEM)
+      LDB_COL_REJECT("outer group shape");
+    const Field *field = down_cast<Item_field *>(group_item)->field;
+    if (field->table != derived_ref->table)
+      LDB_COL_REJECT("outer group table");
+    const uint32_t inner_output_idx = field->field_index();
+    if (inner_output_idx >= first_stage_ordinals.size() ||
+        first_stage_ordinals[inner_output_idx] < 0) {
+      LDB_COL_REJECT("outer group mapping");
+    }
+    regroup->add_group_value_ordinals(
+        static_cast<uint32_t>(first_stage_ordinals[inner_output_idx]));
+    outer_groups.push_back(
+        {field, regroup->group_value_ordinals_size() - 1});
+  }
+
+  std::vector<Item *> output_items;
+  for (Item *item : VisibleFields(qb->fields)) output_items.push_back(item);
+  for (Item *item : output_items) {
+    Item *real = item->real_item();
+    auto *output = request.add_output();
+    if (real->type() == Item::FIELD_ITEM) {
+      const Field *field = down_cast<Item_field *>(real)->field;
+      int regroup_slot = -1;
+      for (const OuterGroup &group : outer_groups) {
+        if (group.field == field) {
+          regroup_slot = group.regroup_slot;
+          break;
+        }
+      }
+      if (regroup_slot < 0) LDB_COL_REJECT("outer output not grouped");
+      output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::GROUP);
+      output->set_ordinal(regroup_slot);
+      continue;
+    }
+
+    if (real->type() != Item::SUM_FUNC_ITEM)
+      LDB_COL_REJECT("outer output shape");
+    Item_sum *sum = down_cast<Item_sum *>(real);
+    if (sum->sum_func() != Item_sum::COUNT_FUNC)
+      LDB_COL_REJECT("outer aggregate not COUNT");
+    if (sum->argument_count() > 0) {
+      Item *arg = sum->get_arg(0)->real_item();
+      if (!arg->const_item() || arg->is_nullable() || arg->is_null()) {
+        LDB_COL_REJECT("outer aggregate not COUNT(*)");
+      }
+    }
+    output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::AGG);
+    output->set_ordinal(0);
+  }
+
+  for (ORDER *order = qb->order_list.first; order != nullptr;
+       order = order->next) {
+    const int output_ordinal = OrderOutputOrdinal(*order->item, output_items);
+    if (output_ordinal < 0) LDB_COL_REJECT("outer ORDER BY");
+    auto *sort_key = request.add_order_by();
+    sort_key->set_output_ordinal(output_ordinal);
+    sort_key->set_descending(order->direction == ORDER_DESC);
+    Item *output_item = output_items[output_ordinal]->real_item();
+    sort_key->set_cmp_kind(output_item->result_type() == STRING_RESULT ? 1 : 0);
+  }
+
+  Query_expression *outer_unit = qb->master_query_expression();
+  if (qb->has_limit()) {
+    if (outer_unit->select_limit_cnt != HA_POS_ERROR)
+      request.set_limit(outer_unit->select_limit_cnt);
+    if (outer_unit->offset_limit_cnt > 0) {
+      request.set_offset(outer_unit->offset_limit_cnt);
+      if (request.limit() > 0)
+        request.set_limit(request.limit() - outer_unit->offset_limit_cnt);
+    }
+  }
+
+  ctx->query_block_ready = true;
+  *why = nullptr;
+  return true;
+
+#undef LDB_COL_REJECT
+}
+
+/**
  * @brief Recognize aggregate query blocks supported by LINEAIRDB_COLUMNAR.
  *
  * Unsupported shapes return false and set `why`; callers convert that into a
@@ -383,6 +689,11 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
   Query_expression *unit = qb->master_query_expression();
   if (unit == nullptr || !unit->is_simple())
     LDB_COL_REJECT("not simple unit");
+
+  if (qb->leaf_tables != nullptr && qb->leaf_tables->next_leaf == nullptr &&
+      qb->leaf_tables->is_view_or_derived()) {
+    return RecognizeDerivedRegroup(join, ctx, why);
+  }
 
   if (qb->having_cond() != nullptr) LDB_COL_REJECT("has HAVING");
   if (qb->is_distinct()) LDB_COL_REJECT("has DISTINCT");

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -30,7 +30,6 @@
 #include "thr_lock.h"
 
 #include "aggregate_pushdown.hh"
-#include "lineairdb_keyenc.hh"
 #include "lineairdb.pb.h"
 #include "lineairdb_proxy.hh"
 #include "lineairdb_pushdown.hh"
@@ -141,14 +140,9 @@ class ItemColumnarValue final : public Item_string {
   void set_null_value() { null_value = true; }
 };
 
-struct OutBinding {
-  bool is_aggregate = false;
-  int index = 0;
-};
-
 // Statement-local state owned by LEX::secondary_engine_execution_context.
-// Recognition fills the serialized LineairDB request and output bindings;
-// execution consumes them after MySQL calls JOIN::override_executor_func.
+// Recognition fills the LineairDB query-block request; execution consumes it
+// after MySQL calls JOIN::override_executor_func.
 class ColumnarExecutionContext : public Secondary_engine_execution_context {
  public:
   bool BestPlanSoFar(const JOIN &join, double cost) {
@@ -163,12 +157,8 @@ class ColumnarExecutionContext : public Secondary_engine_execution_context {
     return cheaper;
   }
 
-  std::string table_name;
-  std::string serialized_filter;
-  std::string serialized_aggregate;
-  std::vector<OutBinding> bindings;
-  int group_column_count = 0;
-  int aggregate_count = 0;
+  LineairDB::Protocol::TxExecuteQueryBlock::Request query_block_request;
+  bool query_block_ready = false;
 
  private:
   const JOIN *current_join_ = nullptr;
@@ -254,6 +244,29 @@ bool GroupColumnIsBinarySafe(const Field *field) {
 }
 
 /**
+ * @brief Return the visible output ordinal used by an ORDER BY item.
+ */
+int OrderOutputOrdinal(Item *order_item,
+                       const std::vector<Item *> &output_items, TABLE *table) {
+  Item *order_real = order_item->real_item();
+  for (size_t i = 0; i < output_items.size(); i++) {
+    Item *output_real = output_items[i]->real_item();
+    if (output_real == order_real) return static_cast<int>(i);
+    if (order_real->type() == Item::FIELD_ITEM &&
+        output_real->type() == Item::FIELD_ITEM) {
+      const Field *order_field = ResolveBaseField(
+          down_cast<Item_field *>(order_real)->field, table);
+      const Field *output_field = ResolveBaseField(
+          down_cast<Item_field *>(output_real)->field, table);
+      if (order_field != nullptr && order_field == output_field) {
+        return static_cast<int>(i);
+      }
+    }
+  }
+  return -1;
+}
+
+/**
  * @brief Recognize single-table aggregate blocks supported by LINEAIRDB_COLUMNAR.
  *
  * Unsupported shapes return false and set `why`; callers convert that into a
@@ -268,12 +281,8 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
     return false;              \
   } while (0)
 
-  ctx->table_name.clear();
-  ctx->serialized_filter.clear();
-  ctx->serialized_aggregate.clear();
-  ctx->bindings.clear();
-  ctx->group_column_count = 0;
-  ctx->aggregate_count = 0;
+  ctx->query_block_request.Clear();
+  ctx->query_block_ready = false;
 
   Query_block *qb = join->query_block;
   if (qb == nullptr || qb->outer_query_block() != nullptr)
@@ -291,10 +300,7 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
   if (table == nullptr || table->s == nullptr) LDB_COL_REJECT("no TABLE");
 
   if (qb->having_cond() != nullptr) LDB_COL_REJECT("has HAVING");
-  if (join->order.order != nullptr || qb->order_list.elements > 0)
-    LDB_COL_REJECT("has ORDER BY");
   if (qb->is_distinct()) LDB_COL_REJECT("has DISTINCT");
-  if (qb->has_limit()) LDB_COL_REJECT("has LIMIT");
   if (qb->has_windows()) LDB_COL_REJECT("has windows");
   if (qb->olap != UNSPECIFIED_OLAP_TYPE) LDB_COL_REJECT("has ROLLUP");
   if (!join->implicit_grouping && qb->group_list.elements == 0)
@@ -303,18 +309,24 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
   if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
     LDB_COL_REJECT("not SECONDARY_LOADed");
 
+  auto &request = ctx->query_block_request;
+  request.add_tables()->set_table_name(table->s->normalized_path.str);
+
+  auto *scan_node = request.add_nodes();
+  auto *scan = scan_node->mutable_scan();
+  scan->set_table_idx(0);
   Item *where_cond =
       qb->where_cond() != nullptr ? qb->where_cond() : join->where_cond;
-  LineairDB::Protocol::PushedPredicate predicate;
   if (where_cond != nullptr) {
-    if (!serialize_item(where_cond, predicate.mutable_expr()))
+    auto *predicate = scan->mutable_filter();
+    if (!serialize_item(where_cond, predicate->mutable_expr()))
       LDB_COL_REJECT("WHERE not pushable");
-    predicate.set_num_columns(table->s->fields);
+    predicate->set_num_columns(table->s->fields);
   }
 
-  LineairDB::Protocol::AggregateSpec spec;
-  spec.set_num_columns(table->s->fields);
-
+  auto *aggregate_node = request.add_nodes();
+  auto *aggregate = aggregate_node->mutable_aggregate();
+  aggregate->set_input(0);
   std::vector<const Field *> group_fields;
   for (ORDER *group = qb->group_list.first; group != nullptr;
        group = group->next) {
@@ -330,12 +342,20 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
       LDB_COL_REJECT("group column not binary-safe");
     }
 
-    spec.add_group_columns(group_field->field_index());
+    auto *group_column = aggregate->add_group_columns();
+    group_column->set_table_idx(0);
+    group_column->set_column(group_field->field_index());
+    group_column->set_cmp_kind(group_field->result_type() == STRING_RESULT ? 1
+                                                                           : 0);
     group_fields.push_back(group_field);
   }
 
-  for (Item *item : VisibleFields(qb->fields)) {
+  std::vector<Item *> output_items;
+  for (Item *item : VisibleFields(qb->fields)) output_items.push_back(item);
+
+  for (Item *item : output_items) {
     Item *real = item->real_item();
+    auto *output = request.add_output();
     if (real->type() == Item::FIELD_ITEM) {
       const Field *output_field = ResolveBaseField(
           down_cast<Item_field *>(real)->field, table);
@@ -352,7 +372,8 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
       if (group_position < 0)
         LDB_COL_REJECT("output field not a group column");
 
-      ctx->bindings.push_back({false, group_position});
+      output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::GROUP);
+      output->set_ordinal(group_position);
       continue;
     }
 
@@ -362,12 +383,12 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
     Item_sum *sum = down_cast<Item_sum *>(real);
     if (sum->argument_count() > 1) LDB_COL_REJECT("aggregate arg count");
 
-    auto *aggregate = spec.add_aggs();
-    aggregate->set_result_scale(0);
+    auto *function = aggregate->add_aggs();
+    function->set_arg_table(0);
 
     switch (sum->sum_func()) {
       case Item_sum::COUNT_FUNC: {
-        if (sum->argument_count() == 1) {
+        if (sum->argument_count() > 0) {
           Item *arg = sum->get_arg(0)->real_item();
           if (arg->const_item()) {
             if (arg->is_nullable() || arg->is_null())
@@ -382,36 +403,62 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
           }
         }
 
-        aggregate->set_kind(LineairDB::Protocol::AggFunc::AGG_COUNT);
+        function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
         break;
       }
 
-      case Item_sum::SUM_FUNC: {
-        if (sum->argument_count() != 1) LDB_COL_REJECT("SUM arg count");
+      case Item_sum::SUM_FUNC:
+      case Item_sum::AVG_FUNC: {
+        if (sum->argument_count() != 1) LDB_COL_REJECT("aggregate arg count");
         Item *arg = sum->get_arg(0)->real_item();
         if (arg->result_type() != DECIMAL_RESULT &&
             arg->result_type() != INT_RESULT) {
-          LDB_COL_REJECT("SUM arg type");
+          LDB_COL_REJECT("aggregate arg type");
         }
 
         if (arg->type() == Item::FIELD_ITEM) {
-          const Field *sum_field = ResolveBaseField(
+          const Field *argument_field = ResolveBaseField(
               down_cast<Item_field *>(arg)->field, table);
-          if (sum_field == nullptr) LDB_COL_REJECT("SUM arg unresolvable");
+          if (argument_field == nullptr)
+            LDB_COL_REJECT("aggregate arg unresolvable");
 
-          auto *ref = aggregate->mutable_arg();
+          auto *ref = function->mutable_arg();
           ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
-          ref->set_column_index(sum_field->field_index());
-        } else if (qb->group_list.elements == 0) {
-          if (!lineairdb::serialize_aggregate_expression(
-                  arg, aggregate->mutable_arg())) {
-            LDB_COL_REJECT("SUM expr not pushable");
-          }
+          ref->set_column_index(argument_field->field_index());
         } else {
-          LDB_COL_REJECT("SUM expr under GROUP BY");
+          if (!lineairdb::serialize_aggregate_expression(
+                  arg, function->mutable_arg())) {
+            LDB_COL_REJECT("aggregate expr not pushable");
+          }
         }
 
-        aggregate->set_kind(LineairDB::Protocol::AggFunc::AGG_SUM);
+        function->set_kind(
+            sum->sum_func() == Item_sum::SUM_FUNC
+                ? LineairDB::Protocol::QueryBlockAggFunc::SUM
+                : LineairDB::Protocol::QueryBlockAggFunc::AVG);
+        function->set_arg_scale(arg->decimals);
+        break;
+      }
+
+      case Item_sum::MIN_FUNC:
+      case Item_sum::MAX_FUNC: {
+        if (sum->argument_count() != 1) LDB_COL_REJECT("aggregate arg count");
+        Item *arg = sum->get_arg(0)->real_item();
+        if (arg->type() != Item::FIELD_ITEM) LDB_COL_REJECT("minmax arg");
+        const Field *argument_field = ResolveBaseField(
+            down_cast<Item_field *>(arg)->field, table);
+        if (argument_field == nullptr) LDB_COL_REJECT("minmax unresolvable");
+
+        auto *ref = function->mutable_arg();
+        ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+        ref->set_column_index(argument_field->field_index());
+        function->set_kind(
+            sum->sum_func() == Item_sum::MIN_FUNC
+                ? LineairDB::Protocol::QueryBlockAggFunc::MIN
+                : LineairDB::Protocol::QueryBlockAggFunc::MAX);
+        function->set_cmp_kind(argument_field->result_type() == STRING_RESULT
+                                   ? 1
+                                   : 0);
         break;
       }
 
@@ -419,18 +466,37 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
         LDB_COL_REJECT("aggregate kind unsupported");
     }
 
-    ctx->bindings.push_back({true, spec.aggs_size() - 1});
+    output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::AGG);
+    output->set_ordinal(aggregate->aggs_size() - 1);
   }
 
-  if (spec.aggs_size() == 0) LDB_COL_REJECT("no aggregates");
+  if (aggregate->aggs_size() == 0) LDB_COL_REJECT("no aggregates");
 
-  ctx->table_name.assign(table->s->normalized_path.str);
-  ctx->group_column_count = spec.group_columns_size();
-  ctx->aggregate_count = spec.aggs_size();
-  if (where_cond != nullptr) {
-    predicate.SerializeToString(&ctx->serialized_filter);
+  for (ORDER *order = qb->order_list.first; order != nullptr;
+       order = order->next) {
+    const int output_ordinal =
+        OrderOutputOrdinal(*order->item, output_items, table);
+    if (output_ordinal < 0)
+      LDB_COL_REJECT("ORDER BY not an output column");
+
+    auto *sort_key = request.add_order_by();
+    sort_key->set_output_ordinal(output_ordinal);
+    sort_key->set_descending(order->direction == ORDER_DESC);
+    Item *output_item = output_items[output_ordinal]->real_item();
+    sort_key->set_cmp_kind(output_item->result_type() == STRING_RESULT ? 1 : 0);
   }
-  spec.SerializeToString(&ctx->serialized_aggregate);
+
+  if (qb->has_limit()) {
+    if (unit->select_limit_cnt != HA_POS_ERROR)
+      request.set_limit(unit->select_limit_cnt);
+    if (unit->offset_limit_cnt > 0) {
+      request.set_offset(unit->offset_limit_cnt);
+      if (request.limit() > 0)
+        request.set_limit(request.limit() - unit->offset_limit_cnt);
+    }
+  }
+
+  ctx->query_block_ready = true;
 
   *why = nullptr;
   return true;
@@ -442,14 +508,14 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
  * @brief Execute a recognized aggregate block through LineairDB.
  *
  * MySQL has already sent result-set metadata for the original SELECT list. This
- * override runs one aggregate read-plan step and sends value-only Item carriers
+ * override runs one query-block RPC and sends value-only Item carriers
  * that match that already-described metadata.
  */
 bool ExecuteColumnarAggregate(JOIN *join, Query_result *result) {
   THD *thd = join->thd;
   auto *ctx = static_cast<ColumnarExecutionContext *>(
       thd->lex->secondary_engine_execution_context());
-  if (ctx == nullptr || ctx->serialized_aggregate.empty()) {
+  if (ctx == nullptr || !ctx->query_block_ready) {
     return RaiseColumnarError(thd, "LINEAIRDB_COLUMNAR: no offload plan");
   }
 
@@ -458,67 +524,42 @@ bool ExecuteColumnarAggregate(JOIN *join, Query_result *result) {
     return RaiseColumnarError(thd, "LINEAIRDB_COLUMNAR: no server connection");
   }
 
-  LineairDBProxy::ReadPlanStep step;
-  step.table_name = ctx->table_name;
-  step.is_scan = true;
-  step.end_key_prefix = lineairdb_keyenc::scan_end_sentinel();
-  step.serialized_filter = ctx->serialized_filter;
-  step.aggregate_serialized = ctx->serialized_aggregate;
-
-  LineairDBProxy::ReadPlanResult rpc = proxy->tx_execute_read_plan({step});
-  if (!rpc.ok || rpc.steps.size() != 1) {
-    return RaiseColumnarError(thd,
-                              "LINEAIRDB_COLUMNAR: aggregate scan RPC failed");
+  LineairDB::Protocol::TxExecuteQueryBlock::Response rpc;
+  if (!proxy->tx_execute_query_block(ctx->query_block_request, &rpc) ||
+      !rpc.ok()) {
+    char message[192];
+    snprintf(message, sizeof(message), "LINEAIRDB_COLUMNAR: %s",
+             rpc.error().empty() ? "query block RPC failed"
+                                 : rpc.error().c_str());
+    return RaiseColumnarError(thd, message);
   }
 
   mem_root_deque<Item *> output_items(thd->mem_root);
   std::vector<ItemColumnarValue *> values;
-  values.reserve(ctx->bindings.size());
   for (Item *item : VisibleFields(join->query_block->fields)) {
     auto *value = new (thd->mem_root) ItemColumnarValue(item);
     if (value == nullptr) return true;
     values.push_back(value);
     output_items.push_back(value);
   }
-  if (values.size() != ctx->bindings.size()) {
-    return RaiseColumnarError(thd,
-                              "LINEAIRDB_COLUMNAR: output binding mismatch");
-  }
 
   std::vector<DecodedField> fields;
-  for (const std::string &row : rpc.steps[0].scan_values) {
-    if (!DecodeRowFields(row, &fields)) {
-      return RaiseColumnarError(thd,
-                                "LINEAIRDB_COLUMNAR: malformed group row");
-    }
-
-    // Server aggregate rows are [null_flags][group cols][value,count per agg].
-    const size_t expected = 1 + static_cast<size_t>(ctx->group_column_count) +
-                            2 * static_cast<size_t>(ctx->aggregate_count);
-    if (fields.size() != expected) {
+  const size_t expected = 1 + values.size();
+  for (const std::string &row : rpc.rows()) {
+    if (!DecodeRowFields(row, &fields) || fields.size() != expected) {
       return RaiseColumnarError(
-          thd, "LINEAIRDB_COLUMNAR: unexpected group row shape");
+          thd, "LINEAIRDB_COLUMNAR: malformed query-block row");
     }
 
-    for (size_t i = 0; i < ctx->bindings.size(); i++) {
-      const OutBinding &binding = ctx->bindings[i];
-      const DecodedField &field =
-          binding.is_aggregate
-              ? fields[1 + ctx->group_column_count + 2 * binding.index]
-              : fields[1 + binding.index];
-
+    // Field 0 is a placeholder for the proxy row null-flags field. The server
+    // emits one following field per SELECT output item.
+    for (size_t i = 0; i < values.size(); i++) {
+      const DecodedField &field = fields[1 + i];
       if (!field.empty) {
         values[i]->set_value(field.ptr, field.len);
         continue;
       }
-
-      // Empty aggregate fields are SQL NULL, while GROUP BY fields are
-      // non-nullable by recognition and represent an empty byte string.
-      if (binding.is_aggregate) {
-        values[i]->set_null_value();
-      } else {
-        values[i]->set_value("", 0);
-      }
+      values[i]->set_null_value();
     }
 
     if (result->send_data(thd, output_items)) return true;

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -774,6 +774,339 @@ bool RecognizeDerivedRegroup(JOIN *join, ColumnarExecutionContext *ctx,
 }
 
 /**
+ * @brief Recognize an outer aggregate over a non-aggregating derived join.
+ *
+ * The outer block groups and aggregates columns exposed by a derived table.
+ * This recognizer dereferences those derived columns back to the inner SELECT
+ * expressions, then builds one server query block over the inner base tables.
+ */
+bool RecognizeFlattenedAggregate(JOIN *join, ColumnarExecutionContext *ctx,
+                                 const char **why) {
+#define LDB_COL_REJECT(reason) \
+  do {                         \
+    *why = (reason);           \
+    return false;              \
+  } while (0)
+
+  Query_block *qb = join->query_block;
+  Table_ref *derived_ref = qb->leaf_tables;
+  if (derived_ref == nullptr || derived_ref->next_leaf != nullptr ||
+      !derived_ref->is_view_or_derived() || derived_ref->table == nullptr) {
+    LDB_COL_REJECT("not single derived table");
+  }
+
+  Query_expression *inner_unit = derived_ref->derived_query_expression();
+  if (inner_unit == nullptr || !inner_unit->is_simple())
+    LDB_COL_REJECT("derived not simple");
+  Query_block *inner_qb = inner_unit->first_query_block();
+  if (inner_qb == nullptr) LDB_COL_REJECT("no inner query block");
+
+  if (qb->having_cond() != nullptr) LDB_COL_REJECT("outer has HAVING");
+  if (qb->is_distinct()) LDB_COL_REJECT("outer has DISTINCT");
+  if (qb->has_windows()) LDB_COL_REJECT("outer has windows");
+  if (qb->olap != UNSPECIFIED_OLAP_TYPE) LDB_COL_REJECT("outer has ROLLUP");
+  if (qb->where_cond() != nullptr) LDB_COL_REJECT("outer has WHERE");
+  if (qb->group_list.elements == 0) LDB_COL_REJECT("outer not grouped");
+
+  if (inner_qb->having_cond() != nullptr) LDB_COL_REJECT("inner has HAVING");
+  if (inner_qb->is_distinct()) LDB_COL_REJECT("inner has DISTINCT");
+  if (inner_qb->has_windows()) LDB_COL_REJECT("inner has windows");
+  if (inner_qb->olap != UNSPECIFIED_OLAP_TYPE)
+    LDB_COL_REJECT("inner has ROLLUP");
+  if (inner_qb->group_list.elements > 0 || inner_qb->with_sum_func)
+    LDB_COL_REJECT("inner has aggregation");
+  if (inner_qb->order_list.elements > 0 || inner_qb->has_limit())
+    LDB_COL_REJECT("inner has order or limit");
+
+  std::vector<QueryBlockTable> tables;
+  for (Table_ref *table_ref = inner_qb->leaf_tables; table_ref != nullptr;
+       table_ref = table_ref->next_leaf) {
+    TABLE *table = table_ref->table;
+    if (table == nullptr || table->s == nullptr)
+      LDB_COL_REJECT("inner no TABLE");
+    if (table_ref->outer_join) LDB_COL_REJECT("inner outer join");
+    if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
+      LDB_COL_REJECT("inner not SECONDARY_LOADed");
+    tables.push_back({table, table_ref->map()});
+  }
+  if (tables.size() < 2) LDB_COL_REJECT("inner too few tables");
+
+  std::vector<Item *> inner_outputs;
+  for (Item *item : VisibleFields(inner_qb->fields)) {
+    inner_outputs.push_back(item);
+  }
+
+  auto dereference_derived_item = [&](Item *item) -> Item * {
+    Item *real = item->real_item();
+    if (real->type() != Item::FIELD_ITEM) return real;
+    const Field *field = down_cast<Item_field *>(real)->field;
+    if (field == nullptr || field->table != derived_ref->table) return real;
+    const uint32_t field_idx = field->field_index();
+    if (field_idx >= inner_outputs.size()) return nullptr;
+    return inner_outputs[field_idx]->real_item();
+  };
+
+  struct JoinEdge {
+    int left_table = -1;
+    int right_table = -1;
+    const Field *left_field = nullptr;
+    const Field *right_field = nullptr;
+  };
+
+  std::vector<std::vector<Item *>> table_filters(tables.size());
+  std::vector<JoinEdge> join_edges;
+  std::vector<Item *> predicates;
+  FlattenAnd(inner_qb->where_cond(), &predicates);
+  for (Item *predicate : predicates) {
+    const table_map used = predicate->used_tables() & ~PSEUDO_TABLE_BITS;
+    const int table_idx = SingleTableOf(used, tables);
+    if (table_idx >= 0) {
+      table_filters[table_idx].push_back(predicate);
+      continue;
+    }
+    if (used == 0) {
+      table_filters[0].push_back(predicate);
+      continue;
+    }
+
+    if (predicate->type() != Item::FUNC_ITEM ||
+        down_cast<Item_func *>(predicate)->functype() != Item_func::EQ_FUNC) {
+      LDB_COL_REJECT("inner non-equi predicate");
+    }
+    auto *equals = down_cast<Item_func *>(predicate);
+    Item *left = equals->arguments()[0]->real_item();
+    Item *right = equals->arguments()[1]->real_item();
+    if (left->type() != Item::FIELD_ITEM ||
+        right->type() != Item::FIELD_ITEM) {
+      LDB_COL_REJECT("inner join key shape");
+    }
+
+    const Field *left_raw = down_cast<Item_field *>(left)->field;
+    const Field *right_raw = down_cast<Item_field *>(right)->field;
+    const int left_table = TableIndexOfField(left_raw, tables);
+    const int right_table = TableIndexOfField(right_raw, tables);
+    if (left_table < 0 || right_table < 0 || left_table == right_table) {
+      LDB_COL_REJECT("inner join key tables");
+    }
+    if (left_raw->result_type() != INT_RESULT ||
+        right_raw->result_type() != INT_RESULT) {
+      LDB_COL_REJECT("inner join key type");
+    }
+
+    const Field *left_field =
+        ResolveBaseField(left_raw, tables[left_table].table);
+    const Field *right_field =
+        ResolveBaseField(right_raw, tables[right_table].table);
+    if (left_field == nullptr || right_field == nullptr) {
+      LDB_COL_REJECT("inner join key unresolvable");
+    }
+    join_edges.push_back(
+        {left_table, right_table, left_field, right_field});
+  }
+  if (join_edges.empty()) LDB_COL_REJECT("inner cross join");
+
+  auto &request = ctx->query_block_request;
+  request.Clear();
+  std::vector<int> scan_nodes(tables.size(), -1);
+  for (size_t table_idx = 0; table_idx < tables.size(); table_idx++) {
+    TABLE *table = tables[table_idx].table;
+    request.add_tables()->set_table_name(table->s->normalized_path.str);
+    auto *scan = request.add_nodes()->mutable_scan();
+    scan->set_table_idx(static_cast<uint32_t>(table_idx));
+    scan_nodes[table_idx] = request.nodes_size() - 1;
+    if (!table_filters[table_idx].empty() &&
+        !SerializeTableFilters(table_filters[table_idx], table,
+                               scan->mutable_filter())) {
+      LDB_COL_REJECT("inner filter not pushable");
+    }
+  }
+
+  int current_node = scan_nodes[0];
+  std::vector<bool> joined(tables.size(), false);
+  joined[0] = true;
+  std::vector<int> pending_tables;
+  for (size_t table_idx = 1; table_idx < tables.size(); table_idx++) {
+    pending_tables.push_back(static_cast<int>(table_idx));
+  }
+  while (!pending_tables.empty()) {
+    int table_idx = -1;
+    size_t pending_idx = 0;
+    for (size_t idx = 0; idx < pending_tables.size(); idx++) {
+      for (const JoinEdge &edge : join_edges) {
+        if ((edge.left_table == pending_tables[idx] &&
+             joined[edge.right_table]) ||
+            (edge.right_table == pending_tables[idx] &&
+             joined[edge.left_table])) {
+          table_idx = pending_tables[idx];
+          pending_idx = idx;
+          break;
+        }
+      }
+      if (table_idx >= 0) break;
+    }
+    if (table_idx < 0) LDB_COL_REJECT("inner disconnected");
+    pending_tables.erase(pending_tables.begin() + pending_idx);
+
+    auto *join_node = request.add_nodes()->mutable_join();
+    join_node->set_type(LineairDB::Protocol::QueryBlockJoin::INNER);
+    join_node->set_build(scan_nodes[table_idx]);
+    join_node->set_probe(current_node);
+    bool connected = false;
+    for (const JoinEdge &edge : join_edges) {
+      const Field *build_field = nullptr;
+      const Field *probe_field = nullptr;
+      int probe_table = -1;
+      if (edge.left_table == table_idx && joined[edge.right_table]) {
+        build_field = edge.left_field;
+        probe_field = edge.right_field;
+        probe_table = edge.right_table;
+      } else if (edge.right_table == table_idx &&
+                 joined[edge.left_table]) {
+        build_field = edge.right_field;
+        probe_field = edge.left_field;
+        probe_table = edge.left_table;
+      } else {
+        continue;
+      }
+
+      auto *build_key = join_node->add_build_keys();
+      build_key->set_table_idx(static_cast<uint32_t>(table_idx));
+      build_key->set_column(build_field->field_index());
+      auto *probe_key = join_node->add_probe_keys();
+      probe_key->set_table_idx(static_cast<uint32_t>(probe_table));
+      probe_key->set_column(probe_field->field_index());
+      connected = true;
+    }
+    if (!connected) LDB_COL_REJECT("inner disconnected");
+    joined[table_idx] = true;
+    current_node = request.nodes_size() - 1;
+  }
+
+  auto *aggregate = request.add_nodes()->mutable_aggregate();
+  aggregate->set_input(current_node);
+  std::vector<Item *> group_outer_items;
+  for (ORDER *group = qb->group_list.first; group != nullptr;
+       group = group->next) {
+    Item *outer = (*group->item)->real_item();
+    Item *inner = dereference_derived_item(outer);
+    if (inner == nullptr) LDB_COL_REJECT("group dereference");
+
+    auto *group_column = aggregate->add_group_columns();
+    if (const Field *year_field = ExtractYearField(inner)) {
+      const int table_idx = TableIndexOfField(year_field, tables);
+      const Field *field =
+          table_idx >= 0
+              ? ResolveBaseField(year_field, tables[table_idx].table)
+              : nullptr;
+      if (field == nullptr || field->is_nullable()) {
+        LDB_COL_REJECT("group year column");
+      }
+      group_column->set_table_idx(static_cast<uint32_t>(table_idx));
+      group_column->set_column(field->field_index());
+      group_column->set_prefix_len(4);
+      group_column->set_cmp_kind(0);
+    } else if (inner->type() == Item::FIELD_ITEM) {
+      const Field *raw_field = down_cast<Item_field *>(inner)->field;
+      const int table_idx = TableIndexOfField(raw_field, tables);
+      const Field *field =
+          table_idx >= 0
+              ? ResolveBaseField(raw_field, tables[table_idx].table)
+              : nullptr;
+      if (field == nullptr || field->is_nullable() ||
+          !GroupColumnIsBinarySafe(field)) {
+        LDB_COL_REJECT("group column not binary-safe");
+      }
+      group_column->set_table_idx(static_cast<uint32_t>(table_idx));
+      group_column->set_column(field->field_index());
+      group_column->set_cmp_kind(field->result_type() == STRING_RESULT ? 1
+                                                                       : 0);
+    } else {
+      LDB_COL_REJECT("group expression");
+    }
+    group_outer_items.push_back(outer);
+  }
+
+  std::vector<Item *> output_items;
+  for (Item *item : VisibleFields(qb->fields)) output_items.push_back(item);
+  for (Item *item : output_items) {
+    Item *real = item->real_item();
+    auto *output = request.add_output();
+    if (real->type() == Item::FIELD_ITEM) {
+      int group_position = -1;
+      for (size_t group_idx = 0; group_idx < group_outer_items.size();
+           group_idx++) {
+        Item *group_item = group_outer_items[group_idx];
+        if (group_item == real ||
+            (group_item->type() == Item::FIELD_ITEM &&
+             down_cast<Item_field *>(group_item)->field ==
+                 down_cast<Item_field *>(real)->field)) {
+          group_position = static_cast<int>(group_idx);
+          break;
+        }
+      }
+      if (group_position < 0) LDB_COL_REJECT("output not grouped");
+      output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::GROUP);
+      output->set_ordinal(group_position);
+      continue;
+    }
+
+    if (real->type() != Item::SUM_FUNC_ITEM)
+      LDB_COL_REJECT("output shape");
+    Item_sum *sum = down_cast<Item_sum *>(real);
+    if (sum->sum_func() != Item_sum::SUM_FUNC ||
+        sum->argument_count() != 1) {
+      LDB_COL_REJECT("aggregate kind");
+    }
+    Item *arg = dereference_derived_item(sum->get_arg(0));
+    if (arg == nullptr) LDB_COL_REJECT("aggregate dereference");
+    if (arg->result_type() != DECIMAL_RESULT &&
+        arg->result_type() != INT_RESULT) {
+      LDB_COL_REJECT("aggregate arg type");
+    }
+
+    auto *function = aggregate->add_aggs();
+    function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::SUM);
+    function->set_arg_table(0);
+    function->set_arg_scale(arg->decimals);
+    if (!SerializeAggregateExpressionForTables(arg, tables, 0,
+                                               function->mutable_arg())) {
+      LDB_COL_REJECT("aggregate expr not pushable");
+    }
+    output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::AGG);
+    output->set_ordinal(aggregate->aggs_size() - 1);
+  }
+  if (aggregate->aggs_size() == 0) LDB_COL_REJECT("no aggregates");
+
+  for (ORDER *order = qb->order_list.first; order != nullptr;
+       order = order->next) {
+    const int output_ordinal = OrderOutputOrdinal(*order->item, output_items);
+    if (output_ordinal < 0) LDB_COL_REJECT("outer ORDER BY");
+    auto *sort_key = request.add_order_by();
+    sort_key->set_output_ordinal(output_ordinal);
+    sort_key->set_descending(order->direction == ORDER_DESC);
+    Item *output_item = output_items[output_ordinal]->real_item();
+    sort_key->set_cmp_kind(output_item->result_type() == STRING_RESULT ? 1 : 0);
+  }
+
+  Query_expression *outer_unit = qb->master_query_expression();
+  if (qb->has_limit()) {
+    if (outer_unit->select_limit_cnt != HA_POS_ERROR)
+      request.set_limit(outer_unit->select_limit_cnt);
+    if (outer_unit->offset_limit_cnt > 0) {
+      request.set_offset(outer_unit->offset_limit_cnt);
+      if (request.limit() > 0)
+        request.set_limit(request.limit() - outer_unit->offset_limit_cnt);
+    }
+  }
+
+  ctx->query_block_ready = true;
+  *why = nullptr;
+  return true;
+
+#undef LDB_COL_REJECT
+}
+
+/**
  * @brief Recognize aggregate query blocks supported by LINEAIRDB_COLUMNAR.
  *
  * Unsupported shapes return false and set `why`; callers convert that into a
@@ -801,7 +1134,8 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
 
   if (qb->leaf_tables != nullptr && qb->leaf_tables->next_leaf == nullptr &&
       qb->leaf_tables->is_view_or_derived()) {
-    return RecognizeDerivedRegroup(join, ctx, why);
+    if (RecognizeDerivedRegroup(join, ctx, why)) return true;
+    return RecognizeFlattenedAggregate(join, ctx, why);
   }
 
   if (qb->having_cond() != nullptr) LDB_COL_REJECT("has HAVING");

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -430,6 +430,25 @@ LineairDBProxy::tx_stateless_batch_read(
     return results;
 }
 
+bool LineairDBProxy::tx_execute_query_block(
+    const LineairDB::Protocol::TxExecuteQueryBlock::Request& request,
+    LineairDB::Protocol::TxExecuteQueryBlock::Response* response) {
+    if (!connected_) {
+        LOG_ERROR("RPC failed: Not connected to server");
+        return false;
+    }
+    if (response == nullptr) {
+        LOG_ERROR("RPC failed: query block response is null");
+        return false;
+    }
+    if (!send_protobuf_message(request, *response,
+                               MessageType::TX_EXECUTE_QUERY_BLOCK)) {
+        LOG_ERROR("RPC failed: query block message");
+        return false;
+    }
+    return true;
+}
+
 LineairDBProxy::ReadPlanResult LineairDBProxy::tx_execute_read_plan(
     const std::vector<ReadPlanStep>& steps) {
     ReadPlanResult result;

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -255,6 +255,10 @@ public:
         const std::vector<StatelessReadKey>& keys);
     ReadPlanResult tx_execute_read_plan(
         const std::vector<ReadPlanStep>& steps);
+    // Send a prepared query-block request to the LineairDB server.
+    bool tx_execute_query_block(
+        const LineairDB::Protocol::TxExecuteQueryBlock::Request& request,
+        LineairDB::Protocol::TxExecuteQueryBlock::Response* response);
     bool tx_validate_and_commit(
         const std::vector<StatelessReadKey>& reads,
         const std::vector<uint64_t>& read_tids,

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -80,7 +80,10 @@ enum class MessageType : uint32_t {
     TX_STATELESS_BATCH_READ = 28,
     TX_VALIDATE_AND_COMMIT = 29,
     TX_EXECUTE_READ_PLAN = 30,
-    TX_GET_TABLE_STATS = 31
+    TX_GET_TABLE_STATS = 31,
+
+    // Secondary-engine computation pushdown.
+    TX_EXECUTE_QUERY_BLOCK = 36
 };
 
 /**

--- a/proxy/rpc_trace.cc
+++ b/proxy/rpc_trace.cc
@@ -93,6 +93,8 @@ const char* message_type_name(MessageType t) {
       return "TX_EXECUTE_READ_PLAN";
     case MessageType::TX_GET_TABLE_STATS:
       return "TX_GET_TABLE_STATS";
+    case MessageType::TX_EXECUTE_QUERY_BLOCK:
+      return "TX_EXECUTE_QUERY_BLOCK";
   }
   return "UNDEFINED";
 }

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SOURCES
     rpc/transaction_control.cc
     rpc/predicate_evaluator.cc
     rpc/predicate_evaluator.hh
+    rpc/query_block_dispatch.cc
     rpc/query_block_executor.cc
     rpc/query_block_executor.hh
     

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -71,6 +71,8 @@ set(SOURCES
     rpc/transaction_control.cc
     rpc/predicate_evaluator.cc
     rpc/predicate_evaluator.hh
+    rpc/query_block_executor.cc
+    rpc/query_block_executor.hh
     
     # Storage layer
     storage/database_manager.cc

--- a/server/protocol/message.hh
+++ b/server/protocol/message.hh
@@ -58,5 +58,8 @@ enum class MessageType : uint32_t {
     TX_STATELESS_BATCH_READ = 28,
     TX_VALIDATE_AND_COMMIT = 29,
     TX_EXECUTE_READ_PLAN = 30,
-    TX_GET_TABLE_STATS = 31
+    TX_GET_TABLE_STATS = 31,
+
+    // Secondary-engine computation pushdown.
+    TX_EXECUTE_QUERY_BLOCK = 36
 };

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -69,6 +69,10 @@ void LineairDBRpc::handle_rpc(uint64_t sender_id, MessageType message_type,
             handleTxExecuteReadPlan(message, result);
             release_masstree_thread_epoch();
             return;
+        case MessageType::TX_EXECUTE_QUERY_BLOCK:
+            handleTxExecuteQueryBlock(message, result);
+            release_masstree_thread_epoch();
+            return;
 
         // Table statistics
         case MessageType::TX_GET_TABLE_STATS:

--- a/server/rpc/lineairdb_rpc.hh
+++ b/server/rpc/lineairdb_rpc.hh
@@ -82,6 +82,9 @@ private:
     // Read-plan execution
     void handleTxExecuteReadPlan(const std::string& message, std::string& result);
 
+    // Query-block execution
+    void handleTxExecuteQueryBlock(const std::string& message, std::string& result);
+
     // Secondary index operations
     void handleTxReadSecondaryIndex(const std::string& message, std::string& result);
     void handleTxWriteSecondaryIndex(const std::string& message, std::string& result);

--- a/server/rpc/query_block_dispatch.cc
+++ b/server/rpc/query_block_dispatch.cc
@@ -1,0 +1,35 @@
+#include "lineairdb_rpc.hh"
+
+#include <memory>
+#include <string>
+
+#include "lineairdb.pb.h"
+#include "query_block_executor.hh"
+
+// Query-block dispatch: parse TX_EXECUTE_QUERY_BLOCK requests and hand them to
+// the server-side executor. Operator execution stays in query_block_executor.cc.
+
+void LineairDBRpc::handleTxExecuteQueryBlock(const std::string& message,
+                                             std::string& result) {
+    LineairDB::Protocol::TxExecuteQueryBlock::Request request;
+    LineairDB::Protocol::TxExecuteQueryBlock::Response response;
+
+    if (!request.ParseFromString(message)) {
+        response.set_ok(false);
+        response.set_error("failed to parse query-block request");
+        result = response.SerializeAsString();
+        return;
+    }
+
+    std::shared_ptr<LineairDB::Database> db =
+        db_manager_ ? db_manager_->get_database() : nullptr;
+    if (!db) {
+        response.set_ok(false);
+        response.set_error("database is unavailable");
+        result = response.SerializeAsString();
+        return;
+    }
+
+    query_block::ExecuteQueryBlock(db.get(), request, &response);
+    result = response.SerializeAsString();
+}

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -717,6 +717,113 @@ class Executor {
         }
     }
 
+    bool AggregateRowValue(const pb::QueryBlockAggregate& aggregate,
+                           int group_count, const GroupState& state,
+                           uint32_t ordinal, std::string* value,
+                           bool* is_null) {
+        value->clear();
+        *is_null = false;
+        if (ordinal < static_cast<uint32_t>(group_count)) {
+            value->assign(state.keys[ordinal]);
+            return true;
+        }
+
+        const int aggregate_idx = static_cast<int>(ordinal) - group_count;
+        if (aggregate_idx < 0 || aggregate_idx >= aggregate.aggs_size()) {
+            return fail("regroup value ordinal out of range");
+        }
+        value->assign(AggregateValue(aggregate.aggs(aggregate_idx), state,
+                                     aggregate_idx, is_null));
+        return true;
+    }
+
+    static void AppendRegroupKeyPart(std::string* key, std::string_view value,
+                                     bool is_null) {
+        key->push_back(is_null ? '\1' : '\0');
+        if (is_null) return;
+        AppendJoinKeyPart(key, value);
+    }
+
+    struct RegroupState {
+        std::vector<std::string> keys;
+        std::vector<bool> nulls;
+        uint64_t count = 0;
+    };
+
+    bool BuildRegroupedRows(const pb::QueryBlockAggregate& aggregate,
+                            int group_count, const GroupMap& groups,
+                            std::vector<OutputRow>* output_rows) {
+        const auto& regroup = aggregate.regroup();
+        if (!regroup.count_star()) return fail("regroup must count");
+
+        std::unordered_map<std::string, RegroupState> regrouped;
+        std::string key;
+        std::vector<std::string> values;
+        std::vector<bool> nulls;
+        for (const auto& entry : groups) {
+            const GroupState& state = entry.second;
+            key.clear();
+            values.clear();
+            nulls.clear();
+            values.reserve(regroup.group_value_ordinals_size());
+            nulls.reserve(regroup.group_value_ordinals_size());
+
+            for (const uint32_t ordinal : regroup.group_value_ordinals()) {
+                std::string value;
+                bool is_null = false;
+                if (!AggregateRowValue(aggregate, group_count, state, ordinal,
+                                       &value, &is_null)) {
+                    return false;
+                }
+                AppendRegroupKeyPart(&key, value, is_null);
+                values.push_back(std::move(value));
+                nulls.push_back(is_null);
+            }
+
+            auto [it, inserted] = regrouped.emplace(key, RegroupState{});
+            RegroupState& regroup_state = it->second;
+            if (inserted) {
+                regroup_state.keys = values;
+                regroup_state.nulls = nulls;
+            }
+            regroup_state.count += 1;
+        }
+
+        output_rows->clear();
+        output_rows->reserve(regrouped.size());
+        for (const auto& entry : regrouped) {
+            const RegroupState& state = entry.second;
+            OutputRow row;
+            row.values.reserve(request_.output_size());
+            row.nulls.reserve(request_.output_size());
+            for (const pb::QueryBlockOutputExpr& expression :
+                 request_.output()) {
+                switch (expression.source()) {
+                    case pb::QueryBlockOutputExpr::GROUP:
+                        if (expression.ordinal() >= state.keys.size()) {
+                            return fail("regroup output ordinal out of range");
+                        }
+                        row.values.push_back(
+                            state.keys[expression.ordinal()]);
+                        row.nulls.push_back(
+                            state.nulls[expression.ordinal()]);
+                        break;
+                    case pb::QueryBlockOutputExpr::AGG:
+                        if (expression.ordinal() != 0) {
+                            return fail("regroup aggregate ordinal out of range");
+                        }
+                        row.values.push_back(std::to_string(state.count));
+                        row.nulls.push_back(false);
+                        break;
+                    default:
+                        return fail("unsupported regroup output source");
+                }
+            }
+            output_rows->push_back(std::move(row));
+        }
+        return true;
+    }
+
     bool SortOutputRows(std::vector<OutputRow>* output_rows) {
         for (const pb::QueryBlockSortKey& key : request_.order_by()) {
             if (key.output_ordinal() >=
@@ -833,41 +940,53 @@ class Executor {
         }
 
         std::vector<OutputRow> output_rows;
-        output_rows.reserve(groups.size());
-        for (auto& entry : groups) {
-            GroupState& state = entry.second;
-            OutputRow row;
-            row.values.reserve(request_.output_size());
-            row.nulls.reserve(request_.output_size());
-            for (const pb::QueryBlockOutputExpr& expression :
-                 request_.output()) {
-                switch (expression.source()) {
-                    case pb::QueryBlockOutputExpr::GROUP:
-                        if (expression.ordinal() >=
-                            static_cast<uint32_t>(group_count)) {
-                            return fail("group output ordinal out of range");
-                        }
-                        row.values.push_back(
-                            state.keys[expression.ordinal()]);
-                        row.nulls.push_back(false);
-                        break;
-                    case pb::QueryBlockOutputExpr::AGG: {
-                        if (expression.ordinal() >=
-                            static_cast<uint32_t>(aggregate.aggs_size())) {
-                            return fail("aggregate output ordinal out of range");
-                        }
-                        bool is_null = false;
-                        row.values.push_back(AggregateValue(
-                            aggregate.aggs(expression.ordinal()), state,
-                            static_cast<int>(expression.ordinal()), &is_null));
-                        row.nulls.push_back(is_null);
-                        break;
-                    }
-                    default:
-                        return fail("unsupported query-block output source");
-                }
+        if (aggregate.has_regroup()) {
+            if (!BuildRegroupedRows(aggregate, group_count, groups,
+                                    &output_rows)) {
+                return false;
             }
-            output_rows.push_back(std::move(row));
+        } else {
+            output_rows.reserve(groups.size());
+            for (auto& entry : groups) {
+                GroupState& state = entry.second;
+                OutputRow row;
+                row.values.reserve(request_.output_size());
+                row.nulls.reserve(request_.output_size());
+                for (const pb::QueryBlockOutputExpr& expression :
+                     request_.output()) {
+                    switch (expression.source()) {
+                        case pb::QueryBlockOutputExpr::GROUP:
+                            if (expression.ordinal() >=
+                                static_cast<uint32_t>(group_count)) {
+                                return fail(
+                                    "group output ordinal out of range");
+                            }
+                            row.values.push_back(
+                                state.keys[expression.ordinal()]);
+                            row.nulls.push_back(false);
+                            break;
+                        case pb::QueryBlockOutputExpr::AGG: {
+                            if (expression.ordinal() >=
+                                static_cast<uint32_t>(
+                                    aggregate.aggs_size())) {
+                                return fail(
+                                    "aggregate output ordinal out of range");
+                            }
+                            bool is_null = false;
+                            row.values.push_back(AggregateValue(
+                                aggregate.aggs(expression.ordinal()), state,
+                                static_cast<int>(expression.ordinal()),
+                                &is_null));
+                            row.nulls.push_back(is_null);
+                            break;
+                        }
+                        default:
+                            return fail(
+                                "unsupported query-block output source");
+                    }
+                }
+                output_rows.push_back(std::move(row));
+            }
         }
 
         if (!SortOutputRows(&output_rows)) return false;

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -6,13 +6,16 @@
 #include <exception>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include <lineairdb/database.h>
 #include <lineairdb/pax_store.h>
 
+#include "decimal_arithmetic.hh"
 #include "predicate_evaluator.hh"
+#include "row_codec.hh"
 
 namespace query_block {
 namespace {
@@ -134,6 +137,14 @@ class Executor {
         return true;
     }
 
+    PaxRowRef ToRowRef(uint32_t table_idx, uint64_t ref) const {
+        PaxStore* store = stores_[table_idx];
+        return PaxRowRef{
+            store->group(ref / PaxGroup::kRows),
+            static_cast<uint32_t>(ref % PaxGroup::kRows),
+        };
+    }
+
     bool RunScan(const pb::QueryBlockScan& scan, NodeResult* output) {
         if (scan.table_idx() >= static_cast<uint32_t>(request_.tables_size())) {
             return fail("scan table out of range");
@@ -213,6 +224,245 @@ class Executor {
         return true;
     }
 
+    struct GroupState {
+        std::vector<std::string> keys;
+        std::vector<uint64_t> counts;
+        std::vector<DecimalValue> decimals;
+        std::vector<std::string> strings;
+        std::vector<bool> has_value;
+    };
+
+    using GroupMap = std::unordered_map<std::string, GroupState>;
+
+    bool AccumulateRange(const pb::QueryBlockAggregate& aggregate,
+                         const NodeResult& input, size_t begin, size_t end,
+                         GroupMap* groups) {
+        const int group_count = aggregate.group_columns_size();
+        const int aggregate_count = aggregate.aggs_size();
+
+        std::vector<int> group_positions(group_count, -1);
+        for (int group_idx = 0; group_idx < group_count; ++group_idx) {
+            group_positions[group_idx] =
+                input.table_pos(aggregate.group_columns(group_idx).table_idx());
+            if (group_positions[group_idx] < 0) {
+                return fail("group table is not in aggregate input");
+            }
+        }
+
+        std::vector<int> aggregate_positions(aggregate_count, -1);
+        for (int aggregate_idx = 0; aggregate_idx < aggregate_count;
+             ++aggregate_idx) {
+            const pb::QueryBlockAggFunc& function =
+                aggregate.aggs(aggregate_idx);
+            if (function.has_arg() || function.has_filter()) {
+                aggregate_positions[aggregate_idx] =
+                    input.table_pos(function.arg_table());
+                if (aggregate_positions[aggregate_idx] < 0) {
+                    return fail("aggregate table is not in aggregate input");
+                }
+            }
+        }
+
+        PredicateEvaluator evaluator;
+        std::string key_buffer;
+        std::vector<std::string_view> group_values(group_count);
+        for (size_t row_idx = begin; row_idx < end; ++row_idx) {
+            key_buffer.clear();
+            for (int group_idx = 0; group_idx < group_count; ++group_idx) {
+                const pb::QueryBlockColumnRef& column =
+                    aggregate.group_columns(group_idx);
+                const uint64_t ref =
+                    input.refs[group_positions[group_idx]][row_idx];
+                group_values[group_idx] =
+                    extract_value_column(ToRowRef(column.table_idx(), ref),
+                                         column.column());
+                const uint32_t length =
+                    static_cast<uint32_t>(group_values[group_idx].size());
+                key_buffer.append(reinterpret_cast<const char*>(&length),
+                                  sizeof(length));
+                key_buffer.append(group_values[group_idx].data(),
+                                  group_values[group_idx].size());
+            }
+
+            auto group_it = groups->find(key_buffer);
+            GroupState* state = nullptr;
+            if (group_it == groups->end()) {
+                GroupState new_state;
+                new_state.keys.resize(group_count);
+                for (int group_idx = 0; group_idx < group_count; ++group_idx) {
+                    new_state.keys[group_idx] =
+                        std::string(group_values[group_idx]);
+                }
+                new_state.counts.assign(aggregate_count, 0);
+                new_state.decimals.assign(aggregate_count, DecimalValue{});
+                new_state.strings.assign(aggregate_count, {});
+                new_state.has_value.assign(aggregate_count, false);
+                state = &groups->emplace(std::move(key_buffer),
+                                         std::move(new_state))
+                             .first->second;
+                key_buffer.clear();
+            } else {
+                state = &group_it->second;
+            }
+
+            for (int aggregate_idx = 0; aggregate_idx < aggregate_count;
+                 ++aggregate_idx) {
+                const pb::QueryBlockAggFunc& function =
+                    aggregate.aggs(aggregate_idx);
+                const int input_pos = aggregate_positions[aggregate_idx];
+                const uint64_t ref =
+                    input_pos >= 0 ? input.refs[input_pos][row_idx] : 0;
+
+                if (function.has_filter() && function.filter().has_expr()) {
+                    PaxRowRef row = ToRowRef(function.arg_table(), ref);
+                    if (row.group == nullptr ||
+                        !evaluator.set_row_from_pax(
+                            *row.group, row.slot,
+                            function.filter().num_columns())) {
+                        return fail("aggregate filter cannot read PAX columns");
+                    }
+                    if (!evaluator.evaluate(function.filter().expr())) {
+                        continue;
+                    }
+                }
+
+                switch (function.kind()) {
+                    case pb::QueryBlockAggFunc::COUNT:
+                        state->counts[aggregate_idx] += 1;
+                        break;
+                    case pb::QueryBlockAggFunc::SUM:
+                    case pb::QueryBlockAggFunc::AVG: {
+                        DecimalValue value = evaluate_decimal_expression(
+                            function.arg(),
+                            ToRowRef(function.arg_table(), ref));
+                        if (value.is_null) break;
+                        add_decimal_value(state->decimals[aggregate_idx],
+                                          value);
+                        state->counts[aggregate_idx] += 1;
+                        break;
+                    }
+                    case pb::QueryBlockAggFunc::MIN:
+                    case pb::QueryBlockAggFunc::MAX: {
+                        const bool wants_max =
+                            function.kind() == pb::QueryBlockAggFunc::MAX;
+                        if (function.cmp_kind() == 1) {
+                            std::string_view value = extract_value_column(
+                                ToRowRef(function.arg_table(), ref),
+                                function.arg().column_index());
+                            if (!state->has_value[aggregate_idx] ||
+                                (wants_max
+                                     ? value >
+                                           std::string_view(
+                                               state->strings[aggregate_idx])
+                                     : value <
+                                           std::string_view(
+                                               state->strings[aggregate_idx]))) {
+                                state->strings[aggregate_idx] =
+                                    std::string(value);
+                            }
+                        } else {
+                            DecimalValue value = evaluate_decimal_expression(
+                                function.arg(),
+                                ToRowRef(function.arg_table(), ref));
+                            if (value.is_null) break;
+                            if (!state->has_value[aggregate_idx] ||
+                                (wants_max
+                                     ? compare_decimal_values(
+                                           value,
+                                           state->decimals[aggregate_idx]) > 0
+                                     : compare_decimal_values(
+                                           value,
+                                           state->decimals[aggregate_idx]) < 0)) {
+                                state->decimals[aggregate_idx] = value;
+                            }
+                        }
+                        state->has_value[aggregate_idx] = true;
+                        break;
+                    }
+                    default:
+                        return fail("unsupported aggregate function");
+                }
+            }
+        }
+        return true;
+    }
+
+    static void MergeGroups(GroupMap* destination, GroupMap* source,
+                            const pb::QueryBlockAggregate& aggregate) {
+        if (destination->empty()) {
+            *destination = std::move(*source);
+            return;
+        }
+
+        for (auto& entry : *source) {
+            auto destination_it = destination->find(entry.first);
+            if (destination_it == destination->end()) {
+                destination->emplace(entry.first, std::move(entry.second));
+                continue;
+            }
+
+            GroupState& destination_state = destination_it->second;
+            GroupState& source_state = entry.second;
+            for (int aggregate_idx = 0;
+                 aggregate_idx < aggregate.aggs_size(); ++aggregate_idx) {
+                const pb::QueryBlockAggFunc& function =
+                    aggregate.aggs(aggregate_idx);
+                switch (function.kind()) {
+                    case pb::QueryBlockAggFunc::COUNT:
+                        destination_state.counts[aggregate_idx] +=
+                            source_state.counts[aggregate_idx];
+                        break;
+                    case pb::QueryBlockAggFunc::SUM:
+                    case pb::QueryBlockAggFunc::AVG:
+                        if (source_state.counts[aggregate_idx] > 0) {
+                            add_decimal_value(
+                                destination_state.decimals[aggregate_idx],
+                                source_state.decimals[aggregate_idx]);
+                            destination_state.counts[aggregate_idx] +=
+                                source_state.counts[aggregate_idx];
+                        }
+                        break;
+                    case pb::QueryBlockAggFunc::MIN:
+                    case pb::QueryBlockAggFunc::MAX: {
+                        if (!source_state.has_value[aggregate_idx]) break;
+                        const bool wants_max =
+                            function.kind() == pb::QueryBlockAggFunc::MAX;
+                        if (function.cmp_kind() == 1) {
+                            if (!destination_state.has_value[aggregate_idx] ||
+                                (wants_max
+                                     ? source_state.strings[aggregate_idx] >
+                                           destination_state
+                                               .strings[aggregate_idx]
+                                     : source_state.strings[aggregate_idx] <
+                                           destination_state
+                                               .strings[aggregate_idx])) {
+                                destination_state.strings[aggregate_idx] =
+                                    std::move(
+                                        source_state.strings[aggregate_idx]);
+                            }
+                        } else if (
+                            !destination_state.has_value[aggregate_idx] ||
+                            (wants_max
+                                 ? compare_decimal_values(
+                                       source_state.decimals[aggregate_idx],
+                                       destination_state
+                                           .decimals[aggregate_idx]) > 0
+                                 : compare_decimal_values(
+                                       source_state.decimals[aggregate_idx],
+                                       destination_state
+                                           .decimals[aggregate_idx]) < 0)) {
+                            destination_state.decimals[aggregate_idx] =
+                                source_state.decimals[aggregate_idx];
+                        }
+                        destination_state.has_value[aggregate_idx] = true;
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            }
+        }
+    }
     bool RunNodes() {
         results_.resize(request_.nodes_size());
         for (int node_idx = 0; node_idx < request_.nodes_size(); ++node_idx) {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -142,19 +142,24 @@ class Executor {
 
         stores_.assign(request_.tables_size(), nullptr);
         write_counter_snapshots_.assign(request_.tables_size(), {});
+        slot_snapshots_.assign(request_.tables_size(), 0);
+        overflow_snapshots_.assign(request_.tables_size(), 0);
         for (int table_idx = 0; table_idx < request_.tables_size();
              ++table_idx) {
             PaxStore* store =
                 db_->GetPaxStore(request_.tables(table_idx).table_name());
             if (store == nullptr) return fail("table has no PAX store");
-            if (store->overflow_count() > 0) {
+            const uint64_t overflow_snapshot = store->overflow_count();
+            if (overflow_snapshot > 0) {
                 return fail("table has heap fallback rows");
             }
 
             stores_[table_idx] = store;
+            slot_snapshots_[table_idx] = store->slots_allocated();
+            overflow_snapshots_[table_idx] = overflow_snapshot;
 
             // Capture each allocated group's writer counter before operators
-            // read strip cells. A changed counter rejects the whole request.
+            // read strip cells. A changed or odd counter rejects the request.
             std::vector<uint64_t>& snapshot =
                 write_counter_snapshots_[table_idx];
             snapshot.resize(store->group_count());
@@ -165,6 +170,9 @@ class Executor {
                     group == nullptr
                         ? 0
                         : group->write_counter.load(std::memory_order_acquire);
+                if ((snapshot[group_idx] & 1u) != 0) {
+                    return fail("table has in-progress PAX writes");
+                }
             }
         }
         return true;
@@ -359,7 +367,8 @@ class Executor {
         }
 
         PaxStore* store = stores_[scan.table_idx()];
-        const size_t group_count = store->group_count();
+        const size_t group_count =
+            write_counter_snapshots_[scan.table_idx()].size();
         output->tables = {scan.table_idx()};
         output->refs.assign(1, {});
         if (group_count == 0) return true;
@@ -1208,6 +1217,10 @@ class Executor {
     bool TablesAreStillQuiet() const {
         for (size_t table_idx = 0; table_idx < stores_.size(); ++table_idx) {
             PaxStore* store = stores_[table_idx];
+            if (store->slots_allocated() != slot_snapshots_[table_idx] ||
+                store->overflow_count() != overflow_snapshots_[table_idx]) {
+                return false;
+            }
             const std::vector<uint64_t>& snapshot =
                 write_counter_snapshots_[table_idx];
             for (size_t group_idx = 0; group_idx < snapshot.size();
@@ -1217,7 +1230,9 @@ class Executor {
                     group == nullptr
                         ? 0
                         : group->write_counter.load(std::memory_order_acquire);
-                if (current != snapshot[group_idx]) return false;
+                if ((current & 1u) != 0 || current != snapshot[group_idx]) {
+                    return false;
+                }
             }
         }
         return true;
@@ -1234,6 +1249,8 @@ class Executor {
     std::string error_;
     std::vector<PaxStore*> stores_;
     std::vector<std::vector<uint64_t>> write_counter_snapshots_;
+    std::vector<uint64_t> slot_snapshots_;
+    std::vector<uint64_t> overflow_snapshots_;
     std::vector<NodeResult> results_;
 };
 

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -1,15 +1,146 @@
 #include "query_block_executor.hh"
 
+#include <atomic>
+#include <cstdint>
 #include <exception>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <lineairdb/database.h>
+#include <lineairdb/pax_store.h>
 
 namespace query_block {
 namespace {
 
-void fail(LineairDB::Protocol::TxExecuteQueryBlock::Response* response,
-          const char* message) {
+namespace pb = LineairDB::Protocol;
+using LineairDB::Pax::PaxGroup;
+using LineairDB::Pax::PaxStore;
+
+void set_failure(pb::TxExecuteQueryBlock::Response* response,
+                 const std::string& message) {
     if (response == nullptr) return;
     response->set_ok(false);
     response->set_error(message);
+    response->clear_rows();
+}
+
+class Executor {
+ public:
+    Executor(LineairDB::Database* db,
+             const pb::TxExecuteQueryBlock::Request& request)
+        : db_(db), request_(request) {}
+
+    bool Run() {
+        if (!PrepareTables()) return false;
+        if (!ValidateNodeOrder()) return false;
+        if (!TablesAreStillQuiet()) return fail("concurrent modification");
+        return fail("query-block operators are not implemented");
+    }
+
+    const std::string& error() const { return error_; }
+
+ private:
+    bool fail(std::string message) {
+        if (error_.empty()) error_ = std::move(message);
+        return false;
+    }
+
+    bool PrepareTables() {
+        if (db_ == nullptr) return fail("database is unavailable");
+        if (request_.tables_size() == 0) {
+            return fail("query block has no tables");
+        }
+
+        stores_.assign(request_.tables_size(), nullptr);
+        write_counter_snapshots_.assign(request_.tables_size(), {});
+        for (int table_idx = 0; table_idx < request_.tables_size();
+             ++table_idx) {
+            PaxStore* store =
+                db_->GetPaxStore(request_.tables(table_idx).table_name());
+            if (store == nullptr) return fail("table has no PAX store");
+            if (store->overflow_count() > 0) {
+                return fail("table has heap fallback rows");
+            }
+
+            stores_[table_idx] = store;
+
+            // Capture each allocated group's writer counter before operators
+            // read strip cells. A changed counter rejects the whole request.
+            std::vector<uint64_t>& snapshot =
+                write_counter_snapshots_[table_idx];
+            snapshot.resize(store->group_count());
+            for (size_t group_idx = 0; group_idx < snapshot.size();
+                 ++group_idx) {
+                PaxGroup* group = store->group(group_idx);
+                snapshot[group_idx] =
+                    group == nullptr
+                        ? 0
+                        : group->write_counter.load(std::memory_order_acquire);
+            }
+        }
+        return true;
+    }
+
+    bool ValidateNodeOrder() {
+        if (request_.nodes_size() == 0) return fail("empty query block");
+
+        for (int node_idx = 0; node_idx < request_.nodes_size(); ++node_idx) {
+            const pb::QueryBlockNode& node = request_.nodes(node_idx);
+            if (node.has_scan()) {
+                if (node.scan().table_idx() >=
+                    static_cast<uint32_t>(request_.tables_size())) {
+                    return fail("scan table out of range");
+                }
+                continue;
+            }
+            if (node.has_join()) {
+                if (node.join().build() >= static_cast<uint32_t>(node_idx) ||
+                    node.join().probe() >= static_cast<uint32_t>(node_idx)) {
+                    return fail("join child order");
+                }
+                continue;
+            }
+            if (node.has_aggregate()) {
+                if (node.aggregate().input() >=
+                    static_cast<uint32_t>(node_idx)) {
+                    return fail("aggregate child order");
+                }
+                continue;
+            }
+            return fail("unknown query-block node");
+        }
+        return true;
+    }
+
+    bool TablesAreStillQuiet() const {
+        for (size_t table_idx = 0; table_idx < stores_.size(); ++table_idx) {
+            PaxStore* store = stores_[table_idx];
+            const std::vector<uint64_t>& snapshot =
+                write_counter_snapshots_[table_idx];
+            for (size_t group_idx = 0; group_idx < snapshot.size();
+                 ++group_idx) {
+                PaxGroup* group = store->group(group_idx);
+                const uint64_t current =
+                    group == nullptr
+                        ? 0
+                        : group->write_counter.load(std::memory_order_acquire);
+                if (current != snapshot[group_idx]) return false;
+            }
+        }
+        return true;
+    }
+
+    LineairDB::Database* db_;
+    const pb::TxExecuteQueryBlock::Request& request_;
+    std::string error_;
+    std::vector<PaxStore*> stores_;
+    std::vector<std::vector<uint64_t>> write_counter_snapshots_;
+};
+
+const std::string& default_error(const Executor& executor) {
+    static const std::string kDefaultError = "query-block execution failed";
+    return executor.error().empty() ? kDefaultError : executor.error();
 }
 
 }  // namespace
@@ -18,15 +149,20 @@ void ExecuteQueryBlock(
     LineairDB::Database* db,
     const LineairDB::Protocol::TxExecuteQueryBlock::Request& request,
     LineairDB::Protocol::TxExecuteQueryBlock::Response* response) {
-    (void)db;
-    (void)request;
+    if (response == nullptr) return;
+    response->Clear();
 
     try {
-        fail(response, "query-block execution is not implemented");
+        Executor executor(db, request);
+        if (!executor.Run()) {
+            set_failure(response, default_error(executor));
+            return;
+        }
+        response->set_ok(true);
     } catch (const std::exception& e) {
-        fail(response, e.what());
+        set_failure(response, e.what());
     } catch (...) {
-        fail(response, "query-block execution failed");
+        set_failure(response, "query-block execution failed");
     }
 }
 

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -1,0 +1,33 @@
+#include "query_block_executor.hh"
+
+#include <exception>
+
+namespace query_block {
+namespace {
+
+void fail(LineairDB::Protocol::TxExecuteQueryBlock::Response* response,
+          const char* message) {
+    if (response == nullptr) return;
+    response->set_ok(false);
+    response->set_error(message);
+}
+
+}  // namespace
+
+void ExecuteQueryBlock(
+    LineairDB::Database* db,
+    const LineairDB::Protocol::TxExecuteQueryBlock::Request& request,
+    LineairDB::Protocol::TxExecuteQueryBlock::Response* response) {
+    (void)db;
+    (void)request;
+
+    try {
+        fail(response, "query-block execution is not implemented");
+    } catch (const std::exception& e) {
+        fail(response, e.what());
+    } catch (...) {
+        fail(response, "query-block execution failed");
+    }
+}
+
+}  // namespace query_block

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -1,14 +1,18 @@
 #include "query_block_executor.hh"
 
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <exception>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
 #include <lineairdb/database.h>
 #include <lineairdb/pax_store.h>
+
+#include "predicate_evaluator.hh"
 
 namespace query_block {
 namespace {
@@ -25,6 +29,22 @@ void set_failure(pb::TxExecuteQueryBlock::Response* response,
     response->clear_rows();
 }
 
+// Materialized operator output. Each logical tuple is represented as one PAX row
+// reference per participating table.
+struct NodeResult {
+    std::vector<uint32_t> tables;
+    std::vector<std::vector<uint64_t>> refs;
+
+    size_t rows() const { return refs.empty() ? 0 : refs[0].size(); }
+
+    int table_pos(uint32_t table_idx) const {
+        for (size_t idx = 0; idx < tables.size(); ++idx) {
+            if (tables[idx] == table_idx) return static_cast<int>(idx);
+        }
+        return -1;
+    }
+};
+
 class Executor {
  public:
     Executor(LineairDB::Database* db,
@@ -34,8 +54,9 @@ class Executor {
     bool Run() {
         if (!PrepareTables()) return false;
         if (!ValidateNodeOrder()) return false;
+        if (!RunNodes()) return false;
         if (!TablesAreStillQuiet()) return fail("concurrent modification");
-        return fail("query-block operators are not implemented");
+        return fail("query-block output is not implemented");
     }
 
     const std::string& error() const { return error_; }
@@ -113,6 +134,104 @@ class Executor {
         return true;
     }
 
+    bool RunScan(const pb::QueryBlockScan& scan, NodeResult* output) {
+        if (scan.table_idx() >= static_cast<uint32_t>(request_.tables_size())) {
+            return fail("scan table out of range");
+        }
+
+        PaxStore* store = stores_[scan.table_idx()];
+        const size_t group_count = store->group_count();
+        output->tables = {scan.table_idx()};
+        output->refs.assign(1, {});
+        if (group_count == 0) return true;
+
+        const bool has_filter = scan.has_filter() && scan.filter().has_expr();
+        const unsigned worker_count = static_cast<unsigned>(
+            std::min<size_t>(WorkerCount(), group_count));
+        std::vector<std::vector<uint64_t>> local_refs(worker_count);
+        std::vector<char> worker_failed(worker_count, 0);
+        std::vector<std::thread> workers;
+        workers.reserve(worker_count);
+
+        for (unsigned worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+            workers.emplace_back([&, worker_idx] {
+                PredicateEvaluator evaluator;
+                std::vector<uint64_t>& refs = local_refs[worker_idx];
+                for (size_t group_idx = worker_idx; group_idx < group_count;
+                     group_idx += worker_count) {
+                    PaxGroup* group = store->group(group_idx);
+                    if (group == nullptr) continue;
+
+                    // Turn one 64-slot visibility word into row references for
+                    // the live slots that survive the optional predicate.
+                    for (uint32_t base = 0; base < PaxGroup::kRows;
+                         base += 64) {
+                        uint64_t visible_bits = 0;
+                        for (uint32_t bit = 0; bit < 64; ++bit) {
+                            if (group->IsVisible(base + bit)) {
+                                visible_bits |= uint64_t{1} << bit;
+                            }
+                        }
+
+                        while (visible_bits != 0) {
+                            const uint32_t bit = static_cast<uint32_t>(
+                                __builtin_ctzll(visible_bits));
+                            visible_bits &= visible_bits - 1;
+                            const uint32_t slot = base + bit;
+                            if (has_filter) {
+                                if (!evaluator.set_row_from_pax(
+                                        *group, slot,
+                                        scan.filter().num_columns())) {
+                                    worker_failed[worker_idx] = 1;
+                                    return;
+                                }
+                                if (!evaluator.evaluate(scan.filter().expr())) {
+                                    continue;
+                                }
+                            }
+                            refs.push_back(group_idx * PaxGroup::kRows + slot);
+                        }
+                    }
+                }
+            });
+        }
+
+        for (std::thread& worker : workers) worker.join();
+        for (char failed : worker_failed) {
+            if (failed) return fail("scan filter cannot read PAX columns");
+        }
+
+        size_t total_refs = 0;
+        for (const std::vector<uint64_t>& refs : local_refs) {
+            total_refs += refs.size();
+        }
+        output->refs[0].reserve(total_refs);
+        for (const std::vector<uint64_t>& refs : local_refs) {
+            output->refs[0].insert(output->refs[0].end(), refs.begin(),
+                                   refs.end());
+        }
+        return true;
+    }
+
+    bool RunNodes() {
+        results_.resize(request_.nodes_size());
+        for (int node_idx = 0; node_idx < request_.nodes_size(); ++node_idx) {
+            const pb::QueryBlockNode& node = request_.nodes(node_idx);
+            if (node.has_scan()) {
+                if (!RunScan(node.scan(), &results_[node_idx])) return false;
+                continue;
+            }
+            if (node.has_join()) {
+                return fail("query-block join is not implemented");
+            }
+            if (node.has_aggregate()) {
+                return fail("query-block aggregate is not implemented");
+            }
+            return fail("unknown query-block node");
+        }
+        return true;
+    }
+
     bool TablesAreStillQuiet() const {
         for (size_t table_idx = 0; table_idx < stores_.size(); ++table_idx) {
             PaxStore* store = stores_[table_idx];
@@ -131,11 +250,18 @@ class Executor {
         return true;
     }
 
+    unsigned WorkerCount() const {
+        const unsigned hardware_threads = std::thread::hardware_concurrency();
+        return std::min<unsigned>(hardware_threads == 0 ? 8 : hardware_threads,
+                                  32);
+    }
+
     LineairDB::Database* db_;
     const pb::TxExecuteQueryBlock::Request& request_;
     std::string error_;
     std::vector<PaxStore*> stores_;
     std::vector<std::vector<uint64_t>> write_counter_snapshots_;
+    std::vector<NodeResult> results_;
 };
 
 const std::string& default_error(const Executor& executor) {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <cstdint>
 #include <exception>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -24,6 +25,8 @@ namespace {
 namespace pb = LineairDB::Protocol;
 using LineairDB::Pax::PaxGroup;
 using LineairDB::Pax::PaxStore;
+
+constexpr uint64_t kNullRowRef = std::numeric_limits<uint64_t>::max();
 
 void set_failure(pb::TxExecuteQueryBlock::Response* response,
                  const std::string& message) {
@@ -192,6 +195,7 @@ class Executor {
     }
 
     PaxRowRef ToRowRef(uint32_t table_idx, uint64_t ref) const {
+        if (ref == kNullRowRef) return PaxRowRef{};
         PaxStore* store = stores_[table_idx];
         return PaxRowRef{
             store->group(ref / PaxGroup::kRows),
@@ -305,20 +309,24 @@ class Executor {
         return true;
     }
 
-    void BuildJoinKey(const NodeResult& input,
+    bool BuildJoinKey(const NodeResult& input,
                       const std::vector<JoinKeyColumn>& key_columns,
                       size_t row_idx, std::string* key) const {
         key->clear();
         for (const JoinKeyColumn& column : key_columns) {
             const uint64_t ref = input.refs[column.ref_position][row_idx];
+            if (ref == kNullRowRef) return false;
             AppendJoinKeyPart(
                 key, extract_value_column(ToRowRef(column.table_idx, ref),
                                           column.column));
         }
+        return true;
     }
 
     bool RunJoin(const pb::QueryBlockJoin& join, NodeResult* output) {
-        if (join.type() != pb::QueryBlockJoin::INNER) {
+        const bool is_inner = join.type() == pb::QueryBlockJoin::INNER;
+        const bool is_left = join.type() == pb::QueryBlockJoin::LEFT;
+        if (!is_inner && !is_left) {
             return fail("unsupported query-block join type");
         }
         if (join.build_keys_size() != join.probe_keys_size() ||
@@ -329,9 +337,11 @@ class Executor {
             return fail("join child out of range");
         }
 
-        // INNER joins are symmetric; hash the smaller child at runtime even if
-        // the request named the larger child as build.
+        // INNER joins are symmetric; hash the smaller child at runtime. LEFT
+        // joins keep the request's build/probe sides because probe rows must be
+        // preserved when the build side has no match.
         const bool swap =
+            is_inner &&
             results_[join.build()].rows() > results_[join.probe()].rows();
         const NodeResult& build = results_[swap ? join.probe() : join.build()];
         const NodeResult& probe = results_[swap ? join.build() : join.probe()];
@@ -352,7 +362,9 @@ class Executor {
         hash_table.reserve(build.rows());
         std::string key;
         for (size_t row_idx = 0; row_idx < build.rows(); ++row_idx) {
-            BuildJoinKey(build, build_key_columns, row_idx, &key);
+            if (!BuildJoinKey(build, build_key_columns, row_idx, &key)) {
+                continue;
+            }
             hash_table[key].push_back(row_idx);
         }
 
@@ -385,10 +397,25 @@ class Executor {
                 const size_t end =
                     probe_rows * (worker_idx + 1) / worker_count;
                 for (size_t probe_idx = begin; probe_idx < end; ++probe_idx) {
-                    BuildJoinKey(probe, probe_key_columns, probe_idx,
-                                 &probe_key);
-                    const auto match = hash_table.find(probe_key);
-                    if (match == hash_table.end()) continue;
+                    const bool has_probe_key = BuildJoinKey(
+                        probe, probe_key_columns, probe_idx, &probe_key);
+                    const auto match = has_probe_key
+                                           ? hash_table.find(probe_key)
+                                           : hash_table.end();
+                    if (match == hash_table.end()) {
+                        if (!is_left) continue;
+                        for (size_t column_idx = 0;
+                             column_idx < probe.tables.size(); ++column_idx) {
+                            local.refs[column_idx].push_back(
+                                probe.refs[column_idx][probe_idx]);
+                        }
+                        for (size_t column_idx = 0;
+                             column_idx < build.tables.size(); ++column_idx) {
+                            local.refs[probe.tables.size() + column_idx]
+                                .push_back(kNullRowRef);
+                        }
+                        continue;
+                    }
 
                     for (const size_t build_idx : match->second) {
                         for (size_t column_idx = 0;
@@ -525,8 +552,11 @@ class Executor {
                 const int input_pos = aggregate_positions[aggregate_idx];
                 const uint64_t ref =
                     input_pos >= 0 ? input.refs[input_pos][row_idx] : 0;
+                const bool has_arg_row =
+                    input_pos < 0 || ref != kNullRowRef;
 
                 if (function.has_filter() && function.filter().has_expr()) {
+                    if (!has_arg_row) continue;
                     PaxRowRef row = ToRowRef(function.arg_table(), ref);
                     if (row.group == nullptr ||
                         !evaluator.set_row_from_pax(
@@ -541,6 +571,7 @@ class Executor {
 
                 switch (function.kind()) {
                     case pb::QueryBlockAggFunc::COUNT:
+                        if (function.has_arg() && !has_arg_row) break;
                         state->counts[aggregate_idx] += 1;
                         break;
                     case pb::QueryBlockAggFunc::SUM:

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -278,6 +278,160 @@ class Executor {
         return true;
     }
 
+    static void AppendJoinKeyPart(std::string* key, std::string_view value) {
+        const uint32_t length = static_cast<uint32_t>(value.size());
+        key->append(reinterpret_cast<const char*>(&length), sizeof(length));
+        key->append(value.data(), value.size());
+    }
+
+    struct JoinKeyColumn {
+        int ref_position = -1;
+        uint32_t table_idx = 0;
+        uint32_t column = 0;
+    };
+
+    bool ResolveJoinKeys(
+        const NodeResult& input,
+        const google::protobuf::RepeatedPtrField<pb::QueryBlockColumnRef>& keys,
+        std::vector<JoinKeyColumn>* resolved) const {
+        resolved->clear();
+        resolved->reserve(keys.size());
+        for (const pb::QueryBlockColumnRef& key : keys) {
+            const int position = input.table_pos(key.table_idx());
+            if (position < 0) return false;
+            resolved->push_back(
+                JoinKeyColumn{position, key.table_idx(), key.column()});
+        }
+        return true;
+    }
+
+    void BuildJoinKey(const NodeResult& input,
+                      const std::vector<JoinKeyColumn>& key_columns,
+                      size_t row_idx, std::string* key) const {
+        key->clear();
+        for (const JoinKeyColumn& column : key_columns) {
+            const uint64_t ref = input.refs[column.ref_position][row_idx];
+            AppendJoinKeyPart(
+                key, extract_value_column(ToRowRef(column.table_idx, ref),
+                                          column.column));
+        }
+    }
+
+    bool RunJoin(const pb::QueryBlockJoin& join, NodeResult* output) {
+        if (join.type() != pb::QueryBlockJoin::INNER) {
+            return fail("unsupported query-block join type");
+        }
+        if (join.build_keys_size() != join.probe_keys_size() ||
+            join.build_keys_size() == 0) {
+            return fail("join key arity");
+        }
+        if (join.build() >= results_.size() || join.probe() >= results_.size()) {
+            return fail("join child out of range");
+        }
+
+        // INNER joins are symmetric; hash the smaller child at runtime even if
+        // the request named the larger child as build.
+        const bool swap =
+            results_[join.build()].rows() > results_[join.probe()].rows();
+        const NodeResult& build = results_[swap ? join.probe() : join.build()];
+        const NodeResult& probe = results_[swap ? join.build() : join.probe()];
+        const auto& build_keys = swap ? join.probe_keys() : join.build_keys();
+        const auto& probe_keys = swap ? join.build_keys() : join.probe_keys();
+
+        std::vector<JoinKeyColumn> build_key_columns;
+        std::vector<JoinKeyColumn> probe_key_columns;
+        if (!ResolveJoinKeys(build, build_keys, &build_key_columns)) {
+            return fail("build key table is not in join input");
+        }
+        if (!ResolveJoinKeys(probe, probe_keys, &probe_key_columns)) {
+            return fail("probe key table is not in join input");
+        }
+
+        // Build a composite byte-key hash table from the chosen build child.
+        std::unordered_map<std::string, std::vector<size_t>> hash_table;
+        hash_table.reserve(build.rows());
+        std::string key;
+        for (size_t row_idx = 0; row_idx < build.rows(); ++row_idx) {
+            BuildJoinKey(build, build_key_columns, row_idx, &key);
+            hash_table[key].push_back(row_idx);
+        }
+
+        // Keep only row references in the joined tuple; later operators read
+        // column values directly from each table's PAX strips.
+        output->tables = probe.tables;
+        output->tables.insert(output->tables.end(), build.tables.begin(),
+                              build.tables.end());
+        output->refs.assign(output->tables.size(), {});
+
+        struct WorkerOutput {
+            std::vector<std::vector<uint64_t>> refs;
+        };
+
+        // Probe in independent row chunks and merge per-worker ref columns at
+        // the end to avoid synchronized appends on every match.
+        const size_t probe_rows = probe.rows();
+        const unsigned worker_count = static_cast<unsigned>(std::min<size_t>(
+            WorkerCount(), std::max<size_t>(probe_rows / 16384, 1)));
+        std::vector<WorkerOutput> local_outputs(worker_count);
+        std::vector<std::thread> workers;
+        workers.reserve(worker_count);
+
+        for (unsigned worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+            workers.emplace_back([&, worker_idx] {
+                WorkerOutput& local = local_outputs[worker_idx];
+                local.refs.assign(output->tables.size(), {});
+                std::string probe_key;
+                const size_t begin = probe_rows * worker_idx / worker_count;
+                const size_t end =
+                    probe_rows * (worker_idx + 1) / worker_count;
+                for (size_t probe_idx = begin; probe_idx < end; ++probe_idx) {
+                    BuildJoinKey(probe, probe_key_columns, probe_idx,
+                                 &probe_key);
+                    const auto match = hash_table.find(probe_key);
+                    if (match == hash_table.end()) continue;
+
+                    for (const size_t build_idx : match->second) {
+                        for (size_t column_idx = 0;
+                             column_idx < probe.tables.size(); ++column_idx) {
+                            local.refs[column_idx].push_back(
+                                probe.refs[column_idx][probe_idx]);
+                        }
+                        for (size_t column_idx = 0;
+                             column_idx < build.tables.size(); ++column_idx) {
+                            local.refs[probe.tables.size() + column_idx]
+                                .push_back(build.refs[column_idx][build_idx]);
+                        }
+                    }
+                }
+            });
+        }
+
+        for (std::thread& worker : workers) worker.join();
+
+        size_t total_rows = 0;
+        for (const WorkerOutput& local : local_outputs) {
+            total_rows += local.refs.empty() ? 0 : local.refs[0].size();
+        }
+        // Fan-out safety valve: reject the offload before materializing an
+        // unbounded intermediate and let the primary path run the query.
+        if (total_rows > (size_t{64} << 20)) {
+            return fail("join intermediate too large");
+        }
+
+        for (size_t column_idx = 0; column_idx < output->refs.size();
+             ++column_idx) {
+            output->refs[column_idx].reserve(total_rows);
+            for (const WorkerOutput& local : local_outputs) {
+                if (local.refs.empty()) continue;
+                output->refs[column_idx].insert(
+                    output->refs[column_idx].end(),
+                    local.refs[column_idx].begin(),
+                    local.refs[column_idx].end());
+            }
+        }
+        return true;
+    }
+
     struct GroupState {
         std::vector<std::string> keys;
         std::vector<uint64_t> counts;
@@ -730,7 +884,8 @@ class Executor {
                 continue;
             }
             if (node.has_join()) {
-                return fail("query-block join is not implemented");
+                if (!RunJoin(node.join(), &results_[node_idx])) return false;
+                continue;
             }
             if (node.has_aggregate()) {
                 if (node_idx != request_.nodes_size() - 1) {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -27,6 +27,8 @@ using LineairDB::Pax::PaxGroup;
 using LineairDB::Pax::PaxStore;
 
 constexpr uint64_t kNullRowRef = std::numeric_limits<uint64_t>::max();
+constexpr uint32_t kTaggedColumnShift = 16;
+constexpr uint32_t kTaggedColumnMask = (uint32_t{1} << kTaggedColumnShift) - 1;
 
 void set_failure(pb::TxExecuteQueryBlock::Response* response,
                  const std::string& message) {
@@ -103,6 +105,11 @@ struct NodeResult {
         }
         return -1;
     }
+};
+
+struct DecodedColumnRef {
+    uint32_t table_idx = 0;
+    uint32_t column = 0;
 };
 
 class Executor {
@@ -201,6 +208,149 @@ class Executor {
             store->group(ref / PaxGroup::kRows),
             static_cast<uint32_t>(ref % PaxGroup::kRows),
         };
+    }
+
+    PaxRowRef RowRefForTable(const NodeResult& input, size_t row_idx,
+                             uint32_t table_idx) const {
+        const int position = input.table_pos(table_idx);
+        if (position < 0) return PaxRowRef{};
+        return ToRowRef(table_idx, input.refs[position][row_idx]);
+    }
+
+    static DecodedColumnRef DecodeAggregateColumnRef(
+        uint32_t default_table_idx, uint32_t encoded_column) {
+        if ((encoded_column >> kTaggedColumnShift) == 0) {
+            return DecodedColumnRef{default_table_idx, encoded_column};
+        }
+        return DecodedColumnRef{
+            encoded_column >> kTaggedColumnShift,
+            encoded_column & kTaggedColumnMask,
+        };
+    }
+
+    bool ValidateAggregateExpressionTables(
+        const pb::FilterExpr& expression, const NodeResult& input,
+        uint32_t default_table_idx) {
+        if (expression.op() == pb::FilterExpr::COLUMN_REF) {
+            const DecodedColumnRef column = DecodeAggregateColumnRef(
+                default_table_idx, expression.column_index());
+            if (input.table_pos(column.table_idx) < 0) {
+                return fail("aggregate expression table is not in input");
+            }
+        }
+        for (const pb::FilterExpr& child : expression.children()) {
+            if (!ValidateAggregateExpressionTables(child, input,
+                                                   default_table_idx)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    std::string_view GroupColumnValue(
+        const pb::QueryBlockColumnRef& column, uint64_t ref) const {
+        std::string_view value = extract_value_column(
+            ToRowRef(column.table_idx(), ref), column.column());
+        if (column.prefix_len() > 0 && value.size() > column.prefix_len()) {
+            value = value.substr(0, column.prefix_len());
+        }
+        return value;
+    }
+
+    bool ReadAggregateColumn(const pb::FilterExpr& expression,
+                             const NodeResult& input, size_t row_idx,
+                             uint32_t default_table_idx,
+                             std::string_view* value) const {
+        if (expression.op() != pb::FilterExpr::COLUMN_REF) return false;
+        const DecodedColumnRef column = DecodeAggregateColumnRef(
+            default_table_idx, expression.column_index());
+        PaxRowRef row = RowRefForTable(input, row_idx, column.table_idx);
+        if (row.group == nullptr) return false;
+        *value = extract_value_column(row, column.column);
+        return true;
+    }
+
+    DecimalValue EvaluateAggregateExpression(
+        const pb::FilterExpr& expression, const NodeResult& input,
+        size_t row_idx, uint32_t default_table_idx) const {
+        using FE = pb::FilterExpr;
+        switch (expression.op()) {
+            case FE::COLUMN_REF: {
+                std::string_view value;
+                if (!ReadAggregateColumn(expression, input, row_idx,
+                                         default_table_idx, &value)) {
+                    DecimalValue result;
+                    result.is_null = true;
+                    return result;
+                }
+                return parse_decimal_value(value);
+            }
+            case FE::CONST_INT: {
+                DecimalValue result;
+                result.mantissa = expression.int_val();
+                return result;
+            }
+            case FE::CONST_UINT: {
+                DecimalValue result;
+                result.mantissa =
+                    static_cast<__int128>(expression.uint_val());
+                return result;
+            }
+            case FE::OP_ADD:
+            case FE::OP_SUB: {
+                if (expression.children_size() != 2) {
+                    DecimalValue result;
+                    result.is_null = true;
+                    return result;
+                }
+                DecimalValue lhs = EvaluateAggregateExpression(
+                    expression.children(0), input, row_idx,
+                    default_table_idx);
+                DecimalValue rhs = EvaluateAggregateExpression(
+                    expression.children(1), input, row_idx,
+                    default_table_idx);
+                if (expression.op() == FE::OP_SUB) {
+                    rhs.mantissa = -rhs.mantissa;
+                }
+                add_decimal_value(lhs, rhs);
+                return lhs;
+            }
+            case FE::OP_MUL: {
+                if (expression.children_size() != 2) {
+                    DecimalValue result;
+                    result.is_null = true;
+                    return result;
+                }
+                DecimalValue lhs = EvaluateAggregateExpression(
+                    expression.children(0), input, row_idx,
+                    default_table_idx);
+                DecimalValue rhs = EvaluateAggregateExpression(
+                    expression.children(1), input, row_idx,
+                    default_table_idx);
+                DecimalValue result;
+                result.mantissa = lhs.mantissa * rhs.mantissa;
+                result.scale = lhs.scale + rhs.scale;
+                result.is_null = lhs.is_null || rhs.is_null;
+                return result;
+            }
+            case FE::OP_NEG: {
+                if (expression.children_size() != 1) {
+                    DecimalValue result;
+                    result.is_null = true;
+                    return result;
+                }
+                DecimalValue result = EvaluateAggregateExpression(
+                    expression.children(0), input, row_idx,
+                    default_table_idx);
+                result.mantissa = -result.mantissa;
+                return result;
+            }
+            default: {
+                DecimalValue result;
+                result.is_null = true;
+                return result;
+            }
+        }
     }
 
     bool RunScan(const pb::QueryBlockScan& scan, NodeResult* output) {
@@ -501,6 +651,11 @@ class Executor {
                     return fail("aggregate table is not in aggregate input");
                 }
             }
+            if (function.has_arg() &&
+                !ValidateAggregateExpressionTables(
+                    function.arg(), input, function.arg_table())) {
+                return false;
+            }
         }
 
         PredicateEvaluator evaluator;
@@ -513,9 +668,7 @@ class Executor {
                     aggregate.group_columns(group_idx);
                 const uint64_t ref =
                     input.refs[group_positions[group_idx]][row_idx];
-                group_values[group_idx] =
-                    extract_value_column(ToRowRef(column.table_idx(), ref),
-                                         column.column());
+                group_values[group_idx] = GroupColumnValue(column, ref);
                 const uint32_t length =
                     static_cast<uint32_t>(group_values[group_idx].size());
                 key_buffer.append(reinterpret_cast<const char*>(&length),
@@ -576,9 +729,9 @@ class Executor {
                         break;
                     case pb::QueryBlockAggFunc::SUM:
                     case pb::QueryBlockAggFunc::AVG: {
-                        DecimalValue value = evaluate_decimal_expression(
-                            function.arg(),
-                            ToRowRef(function.arg_table(), ref));
+                        DecimalValue value = EvaluateAggregateExpression(
+                            function.arg(), input, row_idx,
+                            function.arg_table());
                         if (value.is_null) break;
                         add_decimal_value(state->decimals[aggregate_idx],
                                           value);
@@ -590,9 +743,13 @@ class Executor {
                         const bool wants_max =
                             function.kind() == pb::QueryBlockAggFunc::MAX;
                         if (function.cmp_kind() == 1) {
-                            std::string_view value = extract_value_column(
-                                ToRowRef(function.arg_table(), ref),
-                                function.arg().column_index());
+                            std::string_view value;
+                            if (!ReadAggregateColumn(function.arg(), input,
+                                                     row_idx,
+                                                     function.arg_table(),
+                                                     &value)) {
+                                break;
+                            }
                             if (!state->has_value[aggregate_idx] ||
                                 (wants_max
                                      ? value >
@@ -605,9 +762,9 @@ class Executor {
                                     std::string(value);
                             }
                         } else {
-                            DecimalValue value = evaluate_decimal_expression(
-                                function.arg(),
-                                ToRowRef(function.arg_table(), ref));
+                            DecimalValue value = EvaluateAggregateExpression(
+                                function.arg(), input, row_idx,
+                                function.arg_table());
                             if (value.is_null) break;
                             if (!state->has_value[aggregate_idx] ||
                                 (wants_max

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <exception>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -32,6 +33,59 @@ void set_failure(pb::TxExecuteQueryBlock::Response* response,
     response->clear_rows();
 }
 
+__int128 decimal_power_of_ten(int exponent) {
+    __int128 value = 1;
+    while (exponent-- > 0) value *= 10;
+    return value;
+}
+
+// MySQL AVG uses the argument scale plus div_precision_increment, which is 4 in
+// the default configuration used by this build.
+DecimalValue divide_decimal_value(const DecimalValue& sum, uint64_t count,
+                                  int output_scale) {
+    DecimalValue result;
+    result.is_null = true;
+    if (sum.is_null || count == 0) return result;
+
+    __int128 numerator = sum.mantissa;
+    const bool negative = numerator < 0;
+    if (negative) numerator = -numerator;
+
+    // Keep one extra decimal digit for round-half-up after the divide.
+    const int extra_scale = output_scale - sum.scale + 1;
+    if (extra_scale > 0) {
+        numerator *= decimal_power_of_ten(extra_scale);
+    } else if (extra_scale < 0) {
+        numerator /= decimal_power_of_ten(-extra_scale);
+    }
+
+    __int128 quotient = numerator / static_cast<__int128>(count);
+    quotient = (quotient + 5) / 10;
+    result.mantissa = negative ? -quotient : quotient;
+    result.scale = output_scale;
+    result.is_null = false;
+    return result;
+}
+
+void append_result_field(std::string& row, std::string_view payload,
+                         bool is_null) {
+    if (is_null) {
+        row.push_back(static_cast<char>(0xFF));
+        return;
+    }
+
+    const size_t length = payload.size();
+    size_t byte_size = 1;
+    for (size_t value = length >> 8; value != 0; value >>= 8) {
+        ++byte_size;
+    }
+    row.push_back(static_cast<char>(byte_size));
+    for (size_t idx = 0; idx < byte_size; ++idx) {
+        row.push_back(static_cast<char>((length >> (8 * idx)) & 0xFF));
+    }
+    row.append(payload.data(), payload.size());
+}
+
 // Materialized operator output. Each logical tuple is represented as one PAX row
 // reference per participating table.
 struct NodeResult {
@@ -54,12 +108,12 @@ class Executor {
              const pb::TxExecuteQueryBlock::Request& request)
         : db_(db), request_(request) {}
 
-    bool Run() {
+    bool Run(pb::TxExecuteQueryBlock::Response* response) {
         if (!PrepareTables()) return false;
         if (!ValidateNodeOrder()) return false;
-        if (!RunNodes()) return false;
+        if (!RunNodes(response)) return false;
         if (!TablesAreStillQuiet()) return fail("concurrent modification");
-        return fail("query-block output is not implemented");
+        return true;
     }
 
     const std::string& error() const { return error_; }
@@ -230,6 +284,11 @@ class Executor {
         std::vector<DecimalValue> decimals;
         std::vector<std::string> strings;
         std::vector<bool> has_value;
+    };
+
+    struct OutputRow {
+        std::vector<std::string> values;
+        std::vector<bool> nulls;
     };
 
     using GroupMap = std::unordered_map<std::string, GroupState>;
@@ -463,7 +522,206 @@ class Executor {
             }
         }
     }
-    bool RunNodes() {
+
+    std::string AggregateValue(const pb::QueryBlockAggFunc& function,
+                               const GroupState& state, int aggregate_idx,
+                               bool* is_null) const {
+        *is_null = false;
+        switch (function.kind()) {
+            case pb::QueryBlockAggFunc::COUNT:
+                return std::to_string(state.counts[aggregate_idx]);
+            case pb::QueryBlockAggFunc::SUM:
+                if (state.counts[aggregate_idx] == 0) {
+                    *is_null = true;
+                    return {};
+                }
+                return format_decimal_value(state.decimals[aggregate_idx]);
+            case pb::QueryBlockAggFunc::AVG: {
+                if (state.counts[aggregate_idx] == 0) {
+                    *is_null = true;
+                    return {};
+                }
+                const int output_scale =
+                    static_cast<int>(function.arg_scale()) + 4;
+                return format_decimal_value(divide_decimal_value(
+                    state.decimals[aggregate_idx],
+                    state.counts[aggregate_idx], output_scale));
+            }
+            case pb::QueryBlockAggFunc::MIN:
+            case pb::QueryBlockAggFunc::MAX:
+                if (!state.has_value[aggregate_idx]) {
+                    *is_null = true;
+                    return {};
+                }
+                return function.cmp_kind() == 1
+                           ? state.strings[aggregate_idx]
+                           : format_decimal_value(
+                                 state.decimals[aggregate_idx]);
+            default:
+                *is_null = true;
+                return {};
+        }
+    }
+
+    bool SortOutputRows(std::vector<OutputRow>* output_rows) {
+        for (const pb::QueryBlockSortKey& key : request_.order_by()) {
+            if (key.output_ordinal() >=
+                static_cast<uint32_t>(request_.output_size())) {
+                return fail("order-by output ordinal out of range");
+            }
+        }
+
+        std::sort(output_rows->begin(), output_rows->end(),
+                  [&](const OutputRow& lhs, const OutputRow& rhs) {
+                      for (const pb::QueryBlockSortKey& key :
+                           request_.order_by()) {
+                          const uint32_t ordinal = key.output_ordinal();
+                          const bool lhs_null = lhs.nulls[ordinal];
+                          const bool rhs_null = rhs.nulls[ordinal];
+                          if (lhs_null != rhs_null) {
+                              return key.descending() ? rhs_null : lhs_null;
+                          }
+                          if (lhs_null) continue;
+
+                          int comparison = 0;
+                          if (key.cmp_kind() == 1) {
+                              comparison =
+                                  lhs.values[ordinal].compare(
+                                      rhs.values[ordinal]);
+                          } else {
+                              comparison = compare_decimal_values(
+                                  parse_decimal_value(lhs.values[ordinal]),
+                                  parse_decimal_value(rhs.values[ordinal]));
+                          }
+                          if (comparison != 0) {
+                              return key.descending() ? comparison > 0
+                                                      : comparison < 0;
+                          }
+                      }
+                      return false;
+                  });
+        return true;
+    }
+
+    void EmitOutputRows(
+        const std::vector<OutputRow>& output_rows,
+        pb::TxExecuteQueryBlock::Response* response) const {
+        const size_t begin =
+            std::min<size_t>(request_.offset(), output_rows.size());
+        const size_t end =
+            request_.limit() > 0
+                ? std::min<size_t>(begin + request_.limit(),
+                                   output_rows.size())
+                : output_rows.size();
+
+        std::string row_buffer;
+        for (size_t row_idx = begin; row_idx < end; ++row_idx) {
+            row_buffer.clear();
+            append_result_field(row_buffer, {}, false);
+            const OutputRow& row = output_rows[row_idx];
+            for (size_t column_idx = 0; column_idx < row.values.size();
+                 ++column_idx) {
+                append_result_field(row_buffer, row.values[column_idx],
+                                    row.nulls[column_idx]);
+            }
+            response->add_rows(row_buffer);
+        }
+    }
+
+    bool RunAggregateAndEmit(
+        const pb::QueryBlockAggregate& aggregate,
+        pb::TxExecuteQueryBlock::Response* response) {
+        const NodeResult& input = results_[aggregate.input()];
+        const size_t input_rows = input.rows();
+
+        GroupMap groups;
+        const unsigned worker_count = static_cast<unsigned>(std::min<size_t>(
+            WorkerCount(), std::max<size_t>(input_rows / 65536, 1)));
+        if (worker_count <= 1) {
+            if (!AccumulateRange(aggregate, input, 0, input_rows, &groups)) {
+                return false;
+            }
+        } else {
+            std::vector<GroupMap> local_groups(worker_count);
+            std::vector<char> worker_failed(worker_count, 0);
+            std::vector<std::thread> workers;
+            workers.reserve(worker_count);
+            for (unsigned worker_idx = 0; worker_idx < worker_count;
+                 ++worker_idx) {
+                workers.emplace_back([&, worker_idx] {
+                    const size_t begin =
+                        input_rows * worker_idx / worker_count;
+                    const size_t end =
+                        input_rows * (worker_idx + 1) / worker_count;
+                    if (!AccumulateRange(aggregate, input, begin, end,
+                                         &local_groups[worker_idx])) {
+                        worker_failed[worker_idx] = 1;
+                    }
+                });
+            }
+            for (std::thread& worker : workers) worker.join();
+            for (char failed : worker_failed) {
+                if (failed) return false;
+            }
+            for (GroupMap& local : local_groups) {
+                MergeGroups(&groups, &local, aggregate);
+            }
+        }
+
+        const int group_count = aggregate.group_columns_size();
+        if (group_count == 0 && groups.empty()) {
+            GroupState state;
+            state.counts.assign(aggregate.aggs_size(), 0);
+            state.decimals.assign(aggregate.aggs_size(), DecimalValue{});
+            state.strings.assign(aggregate.aggs_size(), {});
+            state.has_value.assign(aggregate.aggs_size(), false);
+            groups.emplace(std::string(), std::move(state));
+        }
+
+        std::vector<OutputRow> output_rows;
+        output_rows.reserve(groups.size());
+        for (auto& entry : groups) {
+            GroupState& state = entry.second;
+            OutputRow row;
+            row.values.reserve(request_.output_size());
+            row.nulls.reserve(request_.output_size());
+            for (const pb::QueryBlockOutputExpr& expression :
+                 request_.output()) {
+                switch (expression.source()) {
+                    case pb::QueryBlockOutputExpr::GROUP:
+                        if (expression.ordinal() >=
+                            static_cast<uint32_t>(group_count)) {
+                            return fail("group output ordinal out of range");
+                        }
+                        row.values.push_back(
+                            state.keys[expression.ordinal()]);
+                        row.nulls.push_back(false);
+                        break;
+                    case pb::QueryBlockOutputExpr::AGG: {
+                        if (expression.ordinal() >=
+                            static_cast<uint32_t>(aggregate.aggs_size())) {
+                            return fail("aggregate output ordinal out of range");
+                        }
+                        bool is_null = false;
+                        row.values.push_back(AggregateValue(
+                            aggregate.aggs(expression.ordinal()), state,
+                            static_cast<int>(expression.ordinal()), &is_null));
+                        row.nulls.push_back(is_null);
+                        break;
+                    }
+                    default:
+                        return fail("unsupported query-block output source");
+                }
+            }
+            output_rows.push_back(std::move(row));
+        }
+
+        if (!SortOutputRows(&output_rows)) return false;
+        EmitOutputRows(output_rows, response);
+        return true;
+    }
+
+    bool RunNodes(pb::TxExecuteQueryBlock::Response* response) {
         results_.resize(request_.nodes_size());
         for (int node_idx = 0; node_idx < request_.nodes_size(); ++node_idx) {
             const pb::QueryBlockNode& node = request_.nodes(node_idx);
@@ -475,11 +733,14 @@ class Executor {
                 return fail("query-block join is not implemented");
             }
             if (node.has_aggregate()) {
-                return fail("query-block aggregate is not implemented");
+                if (node_idx != request_.nodes_size() - 1) {
+                    return fail("aggregate must be the root node");
+                }
+                return RunAggregateAndEmit(node.aggregate(), response);
             }
             return fail("unknown query-block node");
         }
-        return true;
+        return fail("root must be an aggregate node");
     }
 
     bool TablesAreStillQuiet() const {
@@ -530,7 +791,7 @@ void ExecuteQueryBlock(
 
     try {
         Executor executor(db, request);
-        if (!executor.Run()) {
+        if (!executor.Run(response)) {
             set_failure(response, default_error(executor));
             return;
         }

--- a/server/rpc/query_block_executor.hh
+++ b/server/rpc/query_block_executor.hh
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "lineairdb.pb.h"
+
+namespace LineairDB {
+class Database;
+}
+
+namespace query_block {
+
+/**
+ * @brief Execute a LineairDB query-block request on the server.
+ *
+ * The request is the protobuf operator tree built by the proxy from supported
+ * SELECT shapes. It is not SQL text and it is not MySQL's AccessPath or Query
+ * Execution Plan object. The executor runs accepted operators over LineairDB's
+ * PAX storage and returns final rows in the proxy row format.
+ */
+void ExecuteQueryBlock(
+    LineairDB::Database* db,
+    const LineairDB::Protocol::TxExecuteQueryBlock::Request& request,
+    LineairDB::Protocol::TxExecuteQueryBlock::Response* response);
+
+}  // namespace query_block


### PR DESCRIPTION
## Summary

- Add a `TxExecuteQueryBlock` RPC for supported scan, join, aggregate, ordering, and limit work over LineairDB tables.
- Add a LineairDB server executor that evaluates recognized query blocks directly over PAX-backed table data.
- Extend `LINEAIRDB_COLUMNAR` planning to build query-block requests for supported joined aggregate SELECTs.
- Support inner joins, left joins, grouped aggregation, aggregate regrouping, prefix grouping over canonical date cells, exact decimal SUM/AVG handling, final ordering, and limit application.
- Keep unsupported SQL shapes outside the offload path so they remain handled by the primary MySQL execution path.

## Why

The existing columnar secondary path could offload only narrow single-table aggregate plans. Queries that needed joins, derived aggregate regrouping, outer-join counting, grouped date-prefix expressions, or multi-table aggregate arguments still left most of the analytical work on the MySQL/proxy side.

This branch moves the supported analytical work into LineairDB as a compact query-block request. The server can keep intermediate tuples as table row references, read PAX cells only when an operator needs a column value, and return only the final result rows to MySQL. That reduces row materialization, avoids moving large intermediate join inputs through the proxy, and keeps the secondary engine path explicit about which SQL shapes it can execute.

## Details

`TxExecuteQueryBlock` introduces a tree-shaped request format for secondary-engine execution. A request declares the participating tables, scan nodes, join nodes, aggregate nodes, output expressions, ordering, and limit. The proxy sends this request through the existing LineairDB RPC path, and the server dispatches it to the query-block executor.

The server executor prepares the referenced PAX stores, snapshots writer counters before reading, scans visible PAX slots, applies table-local filters, builds hash joins, accumulates grouped aggregate state, applies regrouping when a derived aggregate must be aggregated again, sorts the final result when requested, and encodes the output rows in the existing proxy row framing.

The executor keeps intermediate rows as row references instead of decoded full records. Column values are decoded from PAX cells only for predicates, join keys, grouping keys, aggregate arguments, ordering keys, and final output values. This keeps the execution path column-oriented while preserving the row identity needed for joined operators.

`ha_lineairdb_columnar` now recognizes supported analytical SELECT blocks and installs the secondary override executor with a prepared query-block request. The recognizer separates table-local predicates from join predicates, builds connected join trees, maps grouped output columns and aggregate outputs back to the original SELECT list, and lowers supported derived aggregate shapes into one server-side request.

Aggregate handling covers COUNT, SUM, AVG, MIN, and MAX over supported integer, decimal, and binary-safe string values. Decimal SUM and AVG use exact fixed-point server arithmetic with MySQL-compatible AVG rounding. COUNT over nullable outer-join rows carries the counted column so rows introduced by the outer join are skipped correctly.

The request format also supports table-tagged aggregate arguments for expressions that read more than one joined table, prefix grouping for canonical date values, and aggregate regrouping over first-stage aggregate output rows.

The offload recognizer is intentionally conservative. It rejects nullable join keys, nullable MIN/MAX arguments, non-binary string MIN/MAX, unsupported predicate shapes, unsupported HAVING/DISTINCT/window/ROLLUP forms, and query shapes that cannot be represented safely in the server executor. Those rejected plans stay outside the columnar offload path rather than returning approximate results.