### PR TITLE
feat(proxy): expand LineairDB columnar TPC-H coverage

### DIFF
--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -714,6 +714,8 @@ message QueryBlockAggFunc {
     // arg_table when the filter and aggregate argument come from different
     // joined tables.
     uint32 filter_table = 8;
+    // COUNT(DISTINCT col): count distinct non-NULL cell values per group.
+    bool distinct = 9;
 }
 
 message QueryBlockColumnRef {

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -707,6 +707,13 @@ message QueryBlockAggFunc {
     uint32 arg_scale = 5;
     // MIN/MAX comparison semantics: 0=numeric decimal, 1=binary string.
     uint32 cmp_kind = 6;
+    // Conditional SUM over an ELSE 0 branch returns 0 for a group with no
+    // matching rows instead of SQL NULL.
+    bool zero_if_empty = 7;
+    // Table read by the optional per-row predicate. It may differ from
+    // arg_table when the filter and aggregate argument come from different
+    // joined tables.
+    uint32 filter_table = 8;
 }
 
 message QueryBlockColumnRef {
@@ -723,6 +730,13 @@ message QueryBlockScan {
     PushedPredicate filter = 2;
 }
 
+message QueryBlockTupleFilter {
+    // Predicate over a joined tuple. FilterExpr COLUMN_REF ordinals address
+    // the columns registry below rather than one physical table.
+    PushedPredicate predicate = 1;
+    repeated QueryBlockColumnRef columns = 2;
+}
+
 message QueryBlockJoin {
     uint32 build = 1;  // Node index into TxExecuteQueryBlock.Request.nodes.
     uint32 probe = 2;
@@ -731,6 +745,13 @@ message QueryBlockJoin {
     repeated QueryBlockColumnRef probe_keys = 4;
     enum Type { INNER = 0; LEFT = 1; SEMI = 2; ANTI = 3; }
     Type type = 5;
+    // Optional per-match predicate over the combined probe/build tuple.
+    QueryBlockTupleFilter residual = 6;
+}
+
+message QueryBlockTupleFilterNode {
+    uint32 input = 1;
+    QueryBlockTupleFilter filter = 2;
 }
 
 message QueryBlockAggregate {
@@ -764,14 +785,19 @@ message QueryBlockNode {
         QueryBlockScan scan = 1;
         QueryBlockJoin join = 2;
         QueryBlockAggregate aggregate = 3;
+        QueryBlockTupleFilterNode filter = 4;
     }
 }
 
 message QueryBlockOutputExpr {
-    enum Source { GROUP = 0; AGG = 1; COLUMN = 2; }
+    enum Source { GROUP = 0; AGG = 1; COLUMN = 2; EXPR = 3; }
     Source source = 1;
     uint32 ordinal = 2;      // GROUP: group key index; AGG: aggregate index.
     QueryBlockColumnRef column = 3;  // Used when source is COLUMN.
+    // Arithmetic expression over emitted aggregate-row values. COLUMN_REF
+    // ordinals address [group columns..., aggregate values...].
+    FilterExpr expr = 4;
+    uint32 result_scale = 5;
 }
 
 message TxExecuteQueryBlock {

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -780,12 +780,21 @@ message QueryBlockSortKey {
     uint32 cmp_kind = 3;  // 0=int64 numeric, 1=binary string, 2=decimal numeric.
 }
 
+// A nested query block for a derived table. The server executes it recursively
+// and exposes its output rows as a virtual table. Virtual table indexes start at
+// tables_size and follow sub_block node order; virtual column refs address the
+// sub-block output ordinals, and refs are row numbers.
+message QueryBlockSubBlock {
+    TxExecuteQueryBlock.Request block = 1;
+}
+
 message QueryBlockNode {
     oneof op {
         QueryBlockScan scan = 1;
         QueryBlockJoin join = 2;
         QueryBlockAggregate aggregate = 3;
         QueryBlockTupleFilterNode filter = 4;
+        QueryBlockSubBlock sub_block = 5;
     }
 }
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1232,42 +1232,34 @@ bool RecognizeFlattenedAggregate(JOIN *join, ColumnarExecutionContext *ctx,
 }
 
 /**
- * @brief Recognize aggregate query blocks supported by LINEAIRDB_COLUMNAR.
+ * @brief Build a query-block request for aggregate shapes.
  *
- * Unsupported shapes return false and set `why`; callers convert that into a
- * secondary-engine reject that may fall back to the primary engine when the
- * session allows it.
+ * Unsupported shapes return false and set `why`; callers decide whether the
+ * primary engine may run instead.
  */
-bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
-                         const char **why) {
+bool BuildQueryBlockRequest(
+    JOIN *join, Query_block *qb,
+    LineairDB::Protocol::TxExecuteQueryBlock::Request *request_out,
+    const char **why) {
 #define LDB_COL_REJECT(reason) \
   do {                         \
     *why = (reason);           \
     return false;              \
   } while (0)
 
-  ctx->query_block_request.Clear();
-  ctx->query_block_ready = false;
-
-  Query_block *qb = join->query_block;
-  if (qb == nullptr || qb->outer_query_block() != nullptr)
-    LDB_COL_REJECT("not top-level");
+  if (qb == nullptr || request_out == nullptr) LDB_COL_REJECT("missing block");
 
   Query_expression *unit = qb->master_query_expression();
   if (unit == nullptr || !unit->is_simple())
     LDB_COL_REJECT("not simple unit");
 
-  if (qb->leaf_tables != nullptr && qb->leaf_tables->next_leaf == nullptr &&
-      qb->leaf_tables->is_view_or_derived()) {
-    if (RecognizeDerivedRegroup(join, ctx, why)) return true;
-    return RecognizeFlattenedAggregate(join, ctx, why);
-  }
-
   if (qb->having_cond() != nullptr) LDB_COL_REJECT("has HAVING");
   if (qb->is_distinct()) LDB_COL_REJECT("has DISTINCT");
   if (qb->has_windows()) LDB_COL_REJECT("has windows");
   if (qb->olap != UNSPECIFIED_OLAP_TYPE) LDB_COL_REJECT("has ROLLUP");
-  if (!join->implicit_grouping && qb->group_list.elements == 0)
+  const bool implicit_grouping =
+      join != nullptr ? join->implicit_grouping : qb->is_implicitly_grouped();
+  if (!implicit_grouping && qb->group_list.elements == 0)
     LDB_COL_REJECT("no aggregation");
 
   struct SemijoinNest {
@@ -1338,7 +1330,9 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
   std::vector<JoinEdge> join_edges;
   std::vector<Item *> tuple_predicates;
   Item *where_cond =
-      qb->where_cond() != nullptr ? qb->where_cond() : join->where_cond;
+      qb->where_cond() != nullptr
+          ? qb->where_cond()
+          : (join != nullptr ? join->where_cond : nullptr);
   std::vector<Item *> predicates;
   FlattenAnd(where_cond, &predicates);
 
@@ -1492,7 +1486,8 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
     LDB_COL_REJECT("cross join");
 
   // Scan every table once, attaching only predicates that read that table.
-  auto &request = ctx->query_block_request;
+  auto &request = *request_out;
+  request.Clear();
   std::vector<int> scan_nodes(tables.size(), -1);
   for (size_t table_idx = 0; table_idx < tables.size(); table_idx++) {
     TABLE *table = tables[table_idx].table;
@@ -2165,12 +2160,47 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
     }
   }
 
-  ctx->query_block_ready = true;
-
   *why = nullptr;
   return true;
 
 #undef LDB_COL_REJECT
+}
+
+/**
+ * @brief Recognize aggregate query blocks supported by LINEAIRDB_COLUMNAR.
+ *
+ * Unsupported shapes return false and set `why`; callers convert that into a
+ * secondary-engine reject that may fall back to the primary engine when the
+ * session allows it.
+ */
+bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
+                         const char **why) {
+  ctx->query_block_request.Clear();
+  ctx->query_block_ready = false;
+
+  Query_block *qb = join == nullptr ? nullptr : join->query_block;
+  if (qb == nullptr || qb->outer_query_block() != nullptr) {
+    *why = "not top-level";
+    return false;
+  }
+
+  Query_expression *unit = qb->master_query_expression();
+  if (unit == nullptr || !unit->is_simple()) {
+    *why = "not simple unit";
+    return false;
+  }
+
+  if (qb->leaf_tables != nullptr && qb->leaf_tables->next_leaf == nullptr &&
+      qb->leaf_tables->is_view_or_derived()) {
+    if (RecognizeDerivedRegroup(join, ctx, why)) return true;
+    return RecognizeFlattenedAggregate(join, ctx, why);
+  }
+
+  if (!BuildQueryBlockRequest(join, qb, &ctx->query_block_request, why)) {
+    return false;
+  }
+  ctx->query_block_ready = true;
+  return true;
 }
 
 /**

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -338,6 +338,26 @@ Item *CaseToCountFilter(Item *argument) {
   return predicate;
 }
 
+/**
+ * @brief Split SUM(CASE WHEN predicate THEN expression ELSE 0 END).
+ */
+bool CaseToFilteredSum(Item *argument, Item **predicate, Item **then_expr) {
+  if (argument->type() != Item::FUNC_ITEM) return false;
+  auto *function = down_cast<Item_func *>(argument);
+  if (function->functype() != Item_func::CASE_FUNC) return false;
+  if (function->argument_count() != 3) return false;
+
+  Item *condition = function->arguments()[0];
+  Item *value = function->arguments()[1];
+  Item *else_value = function->arguments()[2];
+  if (!IsBooleanFilterShape(condition)) return false;
+  if (!else_value->const_item() || else_value->val_int() != 0) return false;
+
+  *predicate = condition;
+  *then_expr = value;
+  return true;
+}
+
 struct QueryBlockTable {
   TABLE *table = nullptr;
   table_map map = 0;
@@ -1507,6 +1527,59 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
               LDB_COL_REJECT("CASE filter not pushable");
             function->set_arg_table(static_cast<uint32_t>(filter_table));
             function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
+            break;
+          }
+
+          Item *filter = nullptr;
+          Item *then_expr = nullptr;
+          if (CaseToFilteredSum(arg, &filter, &then_expr)) {
+            if (then_expr->result_type() != DECIMAL_RESULT &&
+                then_expr->result_type() != INT_RESULT) {
+              LDB_COL_REJECT("CASE expression type");
+            }
+
+            const int filter_table = SingleTableOf(
+                filter->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+            if (filter_table < 0) LDB_COL_REJECT("CASE filter tables");
+            auto *predicate = function->mutable_filter();
+            predicate->set_num_columns(tables[filter_table].table->s->fields);
+            if (!serialize_item(filter, predicate->mutable_expr()))
+              LDB_COL_REJECT("CASE filter not pushable");
+
+            int argument_table = SingleTableOf(
+                then_expr->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+            if (argument_table >= 0 &&
+                then_expr->real_item()->type() == Item::FIELD_ITEM) {
+              const Field *raw_argument_field =
+                  down_cast<Item_field *>(then_expr->real_item())->field;
+              const Field *argument_field = ResolveBaseField(
+                  raw_argument_field, tables[argument_table].table);
+              if (argument_field == nullptr)
+                LDB_COL_REJECT("CASE expression unresolvable");
+
+              auto *ref = function->mutable_arg();
+              ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+              ref->set_column_index(argument_field->field_index());
+            } else if (argument_table >= 0) {
+              if (!lineairdb::serialize_aggregate_expression(
+                      then_expr->real_item(), function->mutable_arg())) {
+                LDB_COL_REJECT("CASE expression not pushable");
+              }
+            } else {
+              argument_table = 0;
+              if (!SerializeAggregateExpressionForTables(
+                      then_expr->real_item(), tables,
+                      static_cast<uint32_t>(argument_table),
+                      function->mutable_arg())) {
+                LDB_COL_REJECT("CASE expression not pushable");
+              }
+            }
+
+            function->set_arg_table(static_cast<uint32_t>(argument_table));
+            function->set_filter_table(static_cast<uint32_t>(filter_table));
+            function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::SUM);
+            function->set_arg_scale(then_expr->decimals);
+            function->set_zero_if_empty(true);
             break;
           }
         }

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1490,6 +1490,18 @@ bool BuildQueryBlockRequest(
     return ResolveBaseField(field, tables[table_idx].table);
   };
 
+  auto is_scalar_virtual_table = [&](int table_idx) {
+    if (table_idx < static_cast<int>(real_table_count) ||
+        table_idx >= static_cast<int>(table_is_virtual.size()) ||
+        !table_is_virtual[table_idx]) {
+      return false;
+    }
+    const size_t virtual_idx =
+        static_cast<size_t>(table_idx) - real_table_count;
+    return virtual_idx < virtual_block_is_scalar_aggregate.size() &&
+           virtual_block_is_scalar_aggregate[virtual_idx];
+  };
+
   struct JoinEdge {
     int left_table = -1;
     int right_table = -1;
@@ -1755,8 +1767,14 @@ bool BuildQueryBlockRequest(
     }
     join_edges.push_back({left_table, right_table, left_field, right_field});
   }
-  if (main_tables.size() > 1 && join_edges.empty())
+  size_t main_non_scalar_tables = 0;
+  for (int table_idx : main_tables) {
+    if (!is_scalar_virtual_table(table_idx)) main_non_scalar_tables++;
+  }
+  if (main_tables.size() > 1 && join_edges.empty() &&
+      main_non_scalar_tables > 1) {
     LDB_COL_REJECT("cross join");
+  }
 
   // Scan every table once, attaching only predicates that read that table.
   auto &request = *request_out;
@@ -1789,16 +1807,23 @@ bool BuildQueryBlockRequest(
 
   // Build a left-deep INNER join tree by walking FROM order and retrying tables
   // whose equality edges are not connected yet.
-  int current_node = scan_nodes[main_tables[0]];
+  auto first_input =
+      std::find_if(main_tables.begin(), main_tables.end(), [&](int table_idx) {
+        return !is_scalar_virtual_table(table_idx);
+      });
+  const int first_table =
+      first_input != main_tables.end() ? *first_input : main_tables[0];
+  int current_node = scan_nodes[first_table];
   std::vector<bool> joined(tables.size(), false);
-  joined[main_tables[0]] = true;
+  joined[first_table] = true;
   std::vector<int> pending_tables;
-  for (size_t table_idx = 1; table_idx < main_tables.size(); table_idx++) {
-    pending_tables.push_back(main_tables[table_idx]);
+  for (int table_idx : main_tables) {
+    if (table_idx != first_table) pending_tables.push_back(table_idx);
   }
   while (!pending_tables.empty()) {
     int table_idx = -1;
     size_t pending_idx = 0;
+    bool keyless_one_row_join = false;
     for (size_t idx = 0; idx < pending_tables.size(); idx++) {
       for (const JoinEdge &edge : join_edges) {
         if ((edge.left_table == pending_tables[idx] &&
@@ -1812,10 +1837,22 @@ bool BuildQueryBlockRequest(
       }
       if (table_idx >= 0) break;
     }
+    if (table_idx < 0) {
+      // Scalar aggregate sub-blocks produce at most one row, so they are the
+      // only virtual inputs that can use a keyless INNER join.
+      for (size_t idx = 0; idx < pending_tables.size(); idx++) {
+        if (is_scalar_virtual_table(pending_tables[idx])) {
+          table_idx = pending_tables[idx];
+          pending_idx = idx;
+          keyless_one_row_join = true;
+          break;
+        }
+      }
+    }
     if (table_idx < 0) LDB_COL_REJECT("disconnected join graph");
     pending_tables.erase(pending_tables.begin() + pending_idx);
 
-    bool connected = false;
+    bool connected = keyless_one_row_join;
     auto *join_node = request.add_nodes()->mutable_join();
     join_node->set_type(LineairDB::Protocol::QueryBlockJoin::INNER);
     join_node->set_build(scan_nodes[table_idx]);
@@ -1906,8 +1943,20 @@ bool BuildQueryBlockRequest(
       return false;
     };
 
+    int first_inner_table = semijoin.inner_tables[0];
+    if (semijoin.inner_tables.size() > 1) {
+      auto first_inner_input =
+          std::find_if(semijoin.inner_tables.begin(),
+                       semijoin.inner_tables.end(), [&](int table_idx) {
+                         return !is_scalar_virtual_table(table_idx);
+                       });
+      if (first_inner_input != semijoin.inner_tables.end()) {
+        first_inner_table = *first_inner_input;
+      }
+    }
+
     // Multi-table semijoin nests become a build-side INNER-join mini tree.
-    int build_node = scan_nodes[semijoin.inner_tables[0]];
+    int build_node = scan_nodes[first_inner_table];
     if (semijoin.inner_tables.size() > 1) {
       struct InnerJoinEdge {
         int left_table = -1;
@@ -1955,14 +2004,18 @@ bool BuildQueryBlockRequest(
       semijoin.residual_predicates = std::move(remaining_residuals);
 
       std::vector<bool> inner_joined(tables.size(), false);
-      inner_joined[semijoin.inner_tables[0]] = true;
-      std::vector<int> pending_inner_tables(
-          semijoin.inner_tables.begin() + 1,
-          semijoin.inner_tables.end());
+      inner_joined[first_inner_table] = true;
+      std::vector<int> pending_inner_tables;
+      for (int table_idx : semijoin.inner_tables) {
+        if (table_idx != first_inner_table) {
+          pending_inner_tables.push_back(table_idx);
+        }
+      }
 
       while (!pending_inner_tables.empty()) {
         int picked_table = -1;
         size_t picked_idx = 0;
+        bool keyless_one_row_join = false;
         for (size_t idx = 0; idx < pending_inner_tables.size(); idx++) {
           for (const InnerJoinEdge &edge : inner_edges) {
             if ((edge.left_table == pending_inner_tables[idx] &&
@@ -1976,10 +2029,21 @@ bool BuildQueryBlockRequest(
           }
           if (picked_table >= 0) break;
         }
+        if (picked_table < 0) {
+          // Keep keyless INNER joins limited to one-row virtual inputs.
+          for (size_t idx = 0; idx < pending_inner_tables.size(); idx++) {
+            if (is_scalar_virtual_table(pending_inner_tables[idx])) {
+              picked_table = pending_inner_tables[idx];
+              picked_idx = idx;
+              keyless_one_row_join = true;
+              break;
+            }
+          }
+        }
         if (picked_table < 0) LDB_COL_REJECT("semijoin disconnected");
         pending_inner_tables.erase(pending_inner_tables.begin() + picked_idx);
 
-        bool connected = false;
+        bool connected = keyless_one_row_join;
         auto *inner_join = request.add_nodes()->mutable_join();
         inner_join->set_type(LineairDB::Protocol::QueryBlockJoin::INNER);
         inner_join->set_build(static_cast<uint32_t>(scan_nodes[picked_table]));

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -576,11 +576,13 @@ const Field *SubstringPrefixField(Item *item, uint32_t *prefix_len) {
   Item *from = function->arguments()[1];
   Item *length = function->arguments()[2];
   if (column->type() != Item::FIELD_ITEM) return nullptr;
+  const Field *field = down_cast<Item_field *>(column)->field;
+  if (field->result_type() != STRING_RESULT) return nullptr;
   if (!from->const_item() || from->val_int() != 1) return nullptr;
   if (!length->const_item() || length->val_int() <= 0) return nullptr;
 
   *prefix_len = static_cast<uint32_t>(length->val_int());
-  return down_cast<Item_field *>(column)->field;
+  return field;
 }
 
 /**
@@ -2186,6 +2188,28 @@ bool BuildQueryBlockRequest(
       group_column->set_column(group_field->field_index());
       group_column->set_prefix_len(4);
       group_column->set_cmp_kind(0);
+      group_fields.push_back({group_table, nullptr});
+      continue;
+    }
+
+    uint32_t substring_prefix_len = 0;
+    if (const Field *substring_field =
+            SubstringPrefixField(group_item, &substring_prefix_len)) {
+      const int group_table = TableIndexOfField(substring_field, tables);
+      const Field *group_field =
+          group_table >= 0
+              ? resolve_query_field(substring_field, group_table)
+              : nullptr;
+      if (group_field == nullptr ||
+          (!table_is_virtual[group_table] && group_field->is_nullable())) {
+        LDB_COL_REJECT("group substring column");
+      }
+
+      auto *group_column = aggregate->add_group_columns();
+      group_column->set_table_idx(static_cast<uint32_t>(group_table));
+      group_column->set_column(group_field->field_index());
+      group_column->set_prefix_len(substring_prefix_len);
+      group_column->set_cmp_kind(1);
       group_fields.push_back({group_table, nullptr});
       continue;
     }

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -400,6 +400,7 @@ bool CaseToFilteredSum(Item *argument, Item **predicate, Item **then_expr) {
 }
 
 struct QueryBlockTable {
+  Table_ref *table_ref = nullptr;
   TABLE *table = nullptr;
   table_map map = 0;
 };
@@ -1076,7 +1077,7 @@ bool RecognizeFlattenedAggregate(JOIN *join, ColumnarExecutionContext *ctx,
     if (table_ref->outer_join) LDB_COL_REJECT("inner outer join");
     if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
       LDB_COL_REJECT("inner not SECONDARY_LOADed");
-    tables.push_back({table, table_ref->map()});
+    tables.push_back({table_ref, table, table_ref->map()});
   }
   if (tables.size() < 2) LDB_COL_REJECT("inner too few tables");
 
@@ -1428,6 +1429,7 @@ bool BuildQueryBlockRequest(
   std::vector<bool> table_is_virtual;
   std::vector<Query_block *> virtual_blocks;
   std::vector<bool> virtual_block_is_scalar_aggregate;
+  std::vector<int> outer_derived_tables;
   for (Table_ref *table_ref = qb->leaf_tables; table_ref != nullptr;
        table_ref = table_ref->next_leaf) {
     if (table_ref->is_view_or_derived()) continue;
@@ -1438,7 +1440,7 @@ bool BuildQueryBlockRequest(
       LDB_COL_REJECT("outer join");
     if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
       LDB_COL_REJECT("not SECONDARY_LOADed");
-    tables.push_back({table, table_ref->map()});
+    tables.push_back({table_ref, table, table_ref->map()});
     table_semijoin_nest.push_back(semijoin_nest);
     table_is_virtual.push_back(false);
     if (semijoin_nest < 0) {
@@ -1454,8 +1456,6 @@ bool BuildQueryBlockRequest(
        table_ref = table_ref->next_leaf) {
     if (!table_ref->is_view_or_derived()) continue;
     const int semijoin_nest = semijoin_nest_of(table_ref);
-    if (semijoin_nest < 0 && table_ref->outer_join)
-      LDB_COL_REJECT("outer derived table");
     if (table_ref->table == nullptr) LDB_COL_REJECT("derived no TABLE");
 
     Query_expression *derived_unit = table_ref->derived_query_expression();
@@ -1464,7 +1464,7 @@ bool BuildQueryBlockRequest(
     Query_block *derived_qb = derived_unit->first_query_block();
     if (derived_qb == nullptr) LDB_COL_REJECT("derived no query block");
 
-    tables.push_back({table_ref->table, table_ref->map()});
+    tables.push_back({table_ref, table_ref->table, table_ref->map()});
     table_semijoin_nest.push_back(semijoin_nest);
     table_is_virtual.push_back(true);
     virtual_blocks.push_back(derived_qb);
@@ -1474,6 +1474,8 @@ bool BuildQueryBlockRequest(
     if (semijoin_nest >= 0) {
       semijoin_nests[semijoin_nest].inner_tables.push_back(
           static_cast<int>(tables.size()) - 1);
+    } else if (table_ref->outer_join) {
+      outer_derived_tables.push_back(static_cast<int>(tables.size()) - 1);
     } else {
       main_tables.push_back(static_cast<int>(tables.size()) - 1);
     }
@@ -1887,6 +1889,109 @@ bool BuildQueryBlockRequest(
 
     if (!connected) LDB_COL_REJECT("disconnected join graph");
     joined[table_idx] = true;
+    current_node = request.nodes_size() - 1;
+  }
+
+  // MySQL may rewrite correlated subqueries into derived tables on the
+  // nullable side of a LEFT join. Execute the derived block as a virtual table,
+  // then split the ON condition into equality keys and residual predicates.
+  for (int table_idx : outer_derived_tables) {
+    Table_ref *table_ref = tables[table_idx].table_ref;
+    Item *join_condition =
+        table_ref == nullptr ? nullptr : table_ref->join_cond();
+    if (join_condition == nullptr) LDB_COL_REJECT("derived LEFT without ON");
+
+    std::vector<Item *> join_predicates;
+    FlattenAnd(join_condition, &join_predicates);
+    std::vector<Item *> residual_predicates;
+
+    auto *join_node = request.add_nodes()->mutable_join();
+    join_node->set_type(LineairDB::Protocol::QueryBlockJoin::LEFT);
+    join_node->set_build(static_cast<uint32_t>(scan_nodes[table_idx]));
+    join_node->set_probe(static_cast<uint32_t>(current_node));
+
+    for (Item *predicate : join_predicates) {
+      bool is_join_key = false;
+      if (predicate->type() == Item::FUNC_ITEM &&
+          down_cast<Item_func *>(predicate)->functype() ==
+              Item_func::EQ_FUNC) {
+        auto *equals = down_cast<Item_func *>(predicate);
+        Item *left = equals->arguments()[0]->real_item();
+        Item *right = equals->arguments()[1]->real_item();
+        if (left->type() == Item::FIELD_ITEM &&
+            right->type() == Item::FIELD_ITEM) {
+          const Field *left_raw = semijoin_outer_equivalent(
+              down_cast<Item_field *>(left)->field);
+          const Field *right_raw = semijoin_outer_equivalent(
+              down_cast<Item_field *>(right)->field);
+          int left_table = TableIndexOfField(left_raw, tables);
+          int right_table = TableIndexOfField(right_raw, tables);
+          if (left_table == table_idx || right_table == table_idx) {
+            if (left_table != table_idx) {
+              std::swap(left_table, right_table);
+              std::swap(left_raw, right_raw);
+            }
+            if (right_table >= 0 &&
+                JoinColumnsUseByteEquality(left_raw, right_raw)) {
+              const Field *build_field =
+                  resolve_query_field(left_raw, left_table);
+              const Field *probe_field =
+                  resolve_query_field(right_raw, right_table);
+              if (build_field != nullptr && probe_field != nullptr) {
+                auto *build_key = join_node->add_build_keys();
+                build_key->set_table_idx(static_cast<uint32_t>(table_idx));
+                build_key->set_column(build_field->field_index());
+                auto *probe_key = join_node->add_probe_keys();
+                probe_key->set_table_idx(static_cast<uint32_t>(right_table));
+                probe_key->set_column(probe_field->field_index());
+                is_join_key = true;
+              }
+            }
+          }
+        }
+      }
+      if (!is_join_key) residual_predicates.push_back(predicate);
+    }
+
+    if (join_node->build_keys_size() == 0)
+      LDB_COL_REJECT("derived LEFT keyless");
+
+    if (!residual_predicates.empty()) {
+      TupleColumnRegistry registry;
+      registry.table_of = [&](const Field *field) {
+        return TableIndexOfField(field, tables);
+      };
+      registry.resolve = [&](const Field *field, int table_idx) {
+        return resolve_query_field(field, table_idx);
+      };
+
+      auto *residual = join_node->mutable_residual();
+      auto *predicate = residual->mutable_predicate();
+      auto *expression = predicate->mutable_expr();
+      if (residual_predicates.size() == 1) {
+        if (!SerializeTuplePredicate(residual_predicates[0], expression,
+                                     &registry)) {
+          LDB_COL_REJECT("derived ON residual not pushable");
+        }
+      } else {
+        expression->set_op(LineairDB::Protocol::FilterExpr::OP_AND);
+        for (Item *residual_predicate : residual_predicates) {
+          if (!SerializeTuplePredicate(residual_predicate,
+                                       expression->add_children(),
+                                       &registry)) {
+            LDB_COL_REJECT("derived ON residual not pushable");
+          }
+        }
+      }
+
+      predicate->set_num_columns(registry.columns.size());
+      for (const auto &column_ref : registry.columns) {
+        auto *column = residual->add_columns();
+        column->set_table_idx(static_cast<uint32_t>(column_ref.first));
+        column->set_column(column_ref.second->field_index());
+      }
+    }
+
     current_node = request.nodes_size() - 1;
   }
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -277,6 +277,19 @@ bool GroupColumnIsBinarySafe(const Field *field) {
 }
 
 /**
+ * @brief Return true when a join key can use byte equality on stored cells.
+ *
+ * Integer cells and canonical DECIMAL text cells compare correctly with byte
+ * equality when both sides use the same MySQL result type.
+ */
+bool JoinColumnsUseByteEquality(const Field *left, const Field *right) {
+  if (left == nullptr || right == nullptr) return false;
+  if (left->result_type() != right->result_type()) return false;
+  return left->result_type() == INT_RESULT ||
+         left->result_type() == DECIMAL_RESULT;
+}
+
+/**
  * @brief Return the visible output ordinal used by an ORDER BY item.
  */
 int OrderOutputOrdinal(Item *order_item,
@@ -815,8 +828,7 @@ bool RecognizeDerivedRegroup(JOIN *join, ColumnarExecutionContext *ctx,
     } else {
       LDB_COL_REJECT("inner join key tables");
     }
-    if (preserved_key->result_type() != INT_RESULT ||
-        nullable_key->result_type() != INT_RESULT) {
+    if (!JoinColumnsUseByteEquality(preserved_key, nullable_key)) {
       LDB_COL_REJECT("inner join key type");
     }
     if (preserved_key->is_nullable() || nullable_key->is_nullable()) {
@@ -1123,8 +1135,7 @@ bool RecognizeFlattenedAggregate(JOIN *join, ColumnarExecutionContext *ctx,
     if (left_table < 0 || right_table < 0 || left_table == right_table) {
       LDB_COL_REJECT("inner join key tables");
     }
-    if (left_raw->result_type() != INT_RESULT ||
-        right_raw->result_type() != INT_RESULT) {
+    if (!JoinColumnsUseByteEquality(left_raw, right_raw)) {
       LDB_COL_REJECT("inner join key type");
     }
 
@@ -1516,8 +1527,7 @@ bool BuildQueryBlockRequest(
         table_semijoin_nest[right_table] >= 0) {
       return false;
     }
-    if (left_raw->result_type() != INT_RESULT ||
-        right_raw->result_type() != INT_RESULT) {
+    if (!JoinColumnsUseByteEquality(left_raw, right_raw)) {
       return false;
     }
 
@@ -1684,8 +1694,7 @@ bool BuildQueryBlockRequest(
               left_table == right_table) {
             continue;
           }
-          if (candidate.first->result_type() != INT_RESULT ||
-              candidate.second->result_type() != INT_RESULT) {
+          if (!JoinColumnsUseByteEquality(candidate.first, candidate.second)) {
             continue;
           }
 
@@ -1723,9 +1732,8 @@ bool BuildQueryBlockRequest(
     if (left_table < 0 || right_table < 0 || left_table == right_table) {
       LDB_COL_REJECT("join key tables");
     }
-    if (left_raw->result_type() != INT_RESULT ||
-        right_raw->result_type() != INT_RESULT) {
-      LDB_COL_REJECT("non-integer join key");
+    if (!JoinColumnsUseByteEquality(left_raw, right_raw)) {
+      LDB_COL_REJECT("join key type");
     }
 
     const Field *left_field = resolve_query_field(left_raw, left_table);
@@ -1916,8 +1924,7 @@ bool BuildQueryBlockRequest(
       if (outer_table < 0 || inner_key_table != inner_table) {
         LDB_COL_REJECT("semijoin key tables");
       }
-      if (raw_outer_field->result_type() != INT_RESULT ||
-          raw_inner_field->result_type() != INT_RESULT) {
+      if (!JoinColumnsUseByteEquality(raw_outer_field, raw_inner_field)) {
         LDB_COL_REJECT("semijoin key type");
       }
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -18,6 +18,7 @@
 #include "mysqld_error.h"
 #include "sql/handler.h"
 #include "sql/item.h"
+#include "sql/item_cmpfunc.h"
 #include "sql/item_sum.h"
 #include "sql/item_timefunc.h"
 #include "sql/mem_root_array.h"
@@ -1301,6 +1302,7 @@ bool BuildQueryBlockRequest(
   std::vector<int> table_semijoin_nest;
   std::vector<bool> table_is_virtual;
   std::vector<Query_block *> virtual_blocks;
+  std::vector<bool> virtual_block_is_scalar_aggregate;
   for (Table_ref *table_ref = qb->leaf_tables; table_ref != nullptr;
        table_ref = table_ref->next_leaf) {
     if (table_ref->is_view_or_derived()) continue;
@@ -1340,6 +1342,9 @@ bool BuildQueryBlockRequest(
     table_semijoin_nest.push_back(-1);
     table_is_virtual.push_back(true);
     virtual_blocks.push_back(derived_qb);
+    virtual_block_is_scalar_aggregate.push_back(
+        derived_qb->is_implicitly_grouped() &&
+        derived_qb->group_list.elements == 0);
     main_tables.push_back(static_cast<int>(tables.size()) - 1);
   }
   if (main_tables.empty()) LDB_COL_REJECT("no tables");
@@ -1361,8 +1366,60 @@ bool BuildQueryBlockRequest(
     const Field *right_field = nullptr;
   };
 
+  auto semijoin_outer_equivalent = [&](const Field *field) -> const Field * {
+    for (const SemijoinNest &semijoin : semijoin_nests) {
+      if (semijoin.nest == nullptr ||
+          semijoin.nest->nested_join == nullptr) {
+        continue;
+      }
+      const auto &outer_exprs =
+          semijoin.nest->nested_join->sj_outer_exprs;
+      const auto &inner_exprs =
+          semijoin.nest->nested_join->sj_inner_exprs;
+      for (size_t expr_idx = 0;
+           expr_idx < outer_exprs.size() && expr_idx < inner_exprs.size();
+           expr_idx++) {
+        Item *outer_item = outer_exprs[expr_idx]->real_item();
+        Item *inner_item = inner_exprs[expr_idx]->real_item();
+        if (outer_item->type() == Item::FIELD_ITEM &&
+            inner_item->type() == Item::FIELD_ITEM &&
+            down_cast<Item_field *>(inner_item)->field == field) {
+          return down_cast<Item_field *>(outer_item)->field;
+        }
+      }
+    }
+    return field;
+  };
+
   std::vector<std::vector<Item *>> table_filters(tables.size());
   std::vector<JoinEdge> join_edges;
+  auto add_join_edge_if_supported = [&](const Field *left_raw,
+                                        const Field *right_raw) -> bool {
+    const int left_table = TableIndexOfField(left_raw, tables);
+    const int right_table = TableIndexOfField(right_raw, tables);
+    if (left_table < 0 || right_table < 0 || left_table == right_table) {
+      return false;
+    }
+    if (table_semijoin_nest[left_table] >= 0 ||
+        table_semijoin_nest[right_table] >= 0) {
+      return false;
+    }
+    if (left_raw->result_type() != INT_RESULT ||
+        right_raw->result_type() != INT_RESULT) {
+      return false;
+    }
+
+    const Field *left_field = resolve_query_field(left_raw, left_table);
+    const Field *right_field = resolve_query_field(right_raw, right_table);
+    if (left_field == nullptr || right_field == nullptr) return false;
+    if ((!table_is_virtual[left_table] && left_field->is_nullable()) ||
+        (!table_is_virtual[right_table] && right_field->is_nullable())) {
+      return false;
+    }
+    join_edges.push_back({left_table, right_table, left_field, right_field});
+    return true;
+  };
+
   std::vector<Item *> tuple_predicates;
   Item *where_cond =
       qb->where_cond() != nullptr
@@ -1411,7 +1468,48 @@ bool BuildQueryBlockRequest(
       predicate_nest = table_nest;
     }
     if (spans_multiple_nests) LDB_COL_REJECT("predicate spans semijoins");
+    if (predicate->type() == Item::FUNC_ITEM &&
+        down_cast<Item_func *>(predicate)->functype() ==
+            Item_func::MULT_EQUAL_FUNC) {
+      auto *multiple_equal = down_cast<Item_equal *>(predicate);
+      if (multiple_equal->const_arg() != nullptr) {
+        LDB_COL_REJECT("multiple equality with constant");
+      }
+      std::vector<const Field *> equal_fields;
+      for (Item_field &field_item : multiple_equal->get_fields()) {
+        equal_fields.push_back(field_item.field);
+      }
+      for (size_t left_idx = 0; left_idx < equal_fields.size(); left_idx++) {
+        for (size_t right_idx = left_idx + 1; right_idx < equal_fields.size();
+             right_idx++) {
+          add_join_edge_if_supported(equal_fields[left_idx],
+                                     equal_fields[right_idx]);
+        }
+      }
+      continue;
+    }
     if (predicate_nest >= 0) {
+      if (predicate->type() == Item::FUNC_ITEM &&
+          down_cast<Item_func *>(predicate)->functype() ==
+              Item_func::EQ_FUNC) {
+        auto *equals = down_cast<Item_func *>(predicate);
+        Item *left = equals->arguments()[0]->real_item();
+        Item *right = equals->arguments()[1]->real_item();
+        if (left->type() == Item::FIELD_ITEM &&
+            right->type() == Item::FIELD_ITEM) {
+          const Field *left_raw = semijoin_outer_equivalent(
+              down_cast<Item_field *>(left)->field);
+          const Field *right_raw = semijoin_outer_equivalent(
+              down_cast<Item_field *>(right)->field);
+          const int left_table = TableIndexOfField(left_raw, tables);
+          const int right_table = TableIndexOfField(right_raw, tables);
+          if (left_table >= 0 && right_table >= 0 &&
+              left_table == right_table) {
+            continue;
+          }
+          if (add_join_edge_if_supported(left_raw, right_raw)) continue;
+        }
+      }
       semijoin_nests[predicate_nest].residual_predicates.push_back(predicate);
       continue;
     }
@@ -2103,6 +2201,36 @@ bool BuildQueryBlockRequest(
       expr->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
       expr->set_column_index(aggregate_output_base +
                              static_cast<uint32_t>(ordinal));
+      return true;
+    }
+    if (item->type() == Item::FIELD_ITEM) {
+      const Field *raw_field = down_cast<Item_field *>(item)->field;
+      const int table_idx = TableIndexOfField(raw_field, tables);
+      if (table_idx < static_cast<int>(real_table_count) ||
+          table_idx >= static_cast<int>(tables.size()) ||
+          !table_is_virtual[table_idx]) {
+        return false;
+      }
+      const size_t virtual_idx =
+          static_cast<size_t>(table_idx) - real_table_count;
+      if (virtual_idx >= virtual_block_is_scalar_aggregate.size() ||
+          !virtual_block_is_scalar_aggregate[virtual_idx]) {
+        return false;
+      }
+
+      auto *function = aggregate->add_aggs();
+      function->set_arg_table(static_cast<uint32_t>(table_idx));
+      auto *ref = function->mutable_arg();
+      ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+      ref->set_column_index(raw_field->field_index());
+      function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::MIN);
+      function->set_cmp_kind(raw_field->result_type() == STRING_RESULT ? 1
+                                                                       : 0);
+
+      expr->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+      expr->set_column_index(aggregate_output_base +
+                             static_cast<uint32_t>(
+                                 aggregate->aggs_size() - 1));
       return true;
     }
     if (item->type() == Item::INT_ITEM) {

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1253,7 +1253,6 @@ bool BuildQueryBlockRequest(
   if (unit == nullptr || !unit->is_simple())
     LDB_COL_REJECT("not simple unit");
 
-  if (qb->having_cond() != nullptr) LDB_COL_REJECT("has HAVING");
   if (qb->is_distinct()) LDB_COL_REJECT("has DISTINCT");
   if (qb->has_windows()) LDB_COL_REJECT("has windows");
   if (qb->olap != UNSPECIFIED_OLAP_TYPE) LDB_COL_REJECT("has ROLLUP");
@@ -1835,6 +1834,36 @@ bool BuildQueryBlockRequest(
 
     auto *function = aggregate->add_aggs();
     switch (sum->sum_func()) {
+      case Item_sum::COUNT_DISTINCT_FUNC: {
+        if (sum->argument_count() != 1) {
+          aggregate_error = "COUNT DISTINCT arg count";
+          return -1;
+        }
+        Item *arg = sum->get_arg(0)->real_item();
+        if (arg->type() != Item::FIELD_ITEM) {
+          aggregate_error = "COUNT DISTINCT arg shape";
+          return -1;
+        }
+        const Field *raw_count_field = down_cast<Item_field *>(arg)->field;
+        const int count_table = TableIndexOfField(raw_count_field, tables);
+        const Field *count_field =
+            count_table >= 0
+                ? resolve_query_field(raw_count_field, count_table)
+                : nullptr;
+        if (count_field == nullptr) {
+          aggregate_error = "COUNT DISTINCT arg unresolvable";
+          return -1;
+        }
+
+        function->set_arg_table(static_cast<uint32_t>(count_table));
+        auto *ref = function->mutable_arg();
+        ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+        ref->set_column_index(count_field->field_index());
+        function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
+        function->set_distinct(true);
+        return aggregate->aggs_size() - 1;
+      }
+
       case Item_sum::COUNT_FUNC: {
         function->set_arg_table(0);
         if (sum->argument_count() > 0) {
@@ -2195,7 +2224,73 @@ bool BuildQueryBlockRequest(
     output->set_result_scale(real->decimals);
   }
 
-  if (aggregate->aggs_size() == 0) LDB_COL_REJECT("no aggregates");
+  if (qb->having_cond() != nullptr) {
+    std::function<bool(Item *, LineairDB::Protocol::FilterExpr *)>
+        serialize_having;
+    serialize_having =
+        [&](Item *item, LineairDB::Protocol::FilterExpr *expr) -> bool {
+      item = item->real_item();
+      if (item->type() == Item::COND_ITEM) {
+        auto *condition = down_cast<Item_cond *>(item);
+        expr->set_op(condition->functype() == Item_func::COND_AND_FUNC
+                         ? LineairDB::Protocol::FilterExpr::OP_AND
+                         : LineairDB::Protocol::FilterExpr::OP_OR);
+        List_iterator<Item> iterator(*condition->argument_list());
+        for (Item *part = iterator++; part != nullptr; part = iterator++) {
+          if (!serialize_having(part, expr->add_children())) return false;
+        }
+        return true;
+      }
+      if (item->type() != Item::FUNC_ITEM) return false;
+
+      auto *function = down_cast<Item_func *>(item);
+      LineairDB::Protocol::FilterExpr::Op op;
+      switch (function->functype()) {
+        case Item_func::EQ_FUNC:
+          op = LineairDB::Protocol::FilterExpr::OP_EQ;
+          break;
+        case Item_func::NE_FUNC:
+          op = LineairDB::Protocol::FilterExpr::OP_NE;
+          break;
+        case Item_func::LT_FUNC:
+          op = LineairDB::Protocol::FilterExpr::OP_LT;
+          break;
+        case Item_func::LE_FUNC:
+          op = LineairDB::Protocol::FilterExpr::OP_LE;
+          break;
+        case Item_func::GT_FUNC:
+          op = LineairDB::Protocol::FilterExpr::OP_GT;
+          break;
+        case Item_func::GE_FUNC:
+          op = LineairDB::Protocol::FilterExpr::OP_GE;
+          break;
+        default:
+          return false;
+      }
+      if (function->argument_count() != 2) return false;
+
+      expr->set_op(op);
+      for (uint arg_idx = 0; arg_idx < 2; arg_idx++) {
+        auto *child = expr->add_children();
+        if (!serialize_output_expression(function->arguments()[arg_idx],
+                                         child)) {
+          return false;
+        }
+        child->set_compare_type(2);
+      }
+      return true;
+    };
+
+    auto *having = aggregate->mutable_having();
+    if (!serialize_having(qb->having_cond(), having->mutable_expr())) {
+      LDB_COL_REJECT("HAVING not pushable");
+    }
+    having->set_num_columns(aggregate->group_columns_size() +
+                            aggregate->aggs_size());
+  }
+
+  if (aggregate->aggs_size() == 0 && aggregate->group_columns_size() == 0)
+    LDB_COL_REJECT("no aggregates");
 
   for (ORDER *order = qb->order_list.first; order != nullptr;
        order = order->next) {

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <map>
 #include <memory>
@@ -546,6 +547,117 @@ bool SerializeTuplePredicate(Item *item,
 }
 
 /**
+ * @brief Return the column and width for SUBSTRING(column, 1, width).
+ */
+const Field *SubstringPrefixField(Item *item, uint32_t *prefix_len) {
+  Item *real = item->real_item();
+  if (real->type() != Item::FUNC_ITEM) return nullptr;
+
+  auto *function = down_cast<Item_func *>(real);
+  if (std::strcmp(function->func_name(), "substr") != 0 ||
+      function->argument_count() != 3) {
+    return nullptr;
+  }
+
+  Item *column = function->arguments()[0]->real_item();
+  Item *from = function->arguments()[1];
+  Item *length = function->arguments()[2];
+  if (column->type() != Item::FIELD_ITEM) return nullptr;
+  if (!from->const_item() || from->val_int() != 1) return nullptr;
+  if (!length->const_item() || length->val_int() <= 0) return nullptr;
+
+  *prefix_len = static_cast<uint32_t>(length->val_int());
+  return down_cast<Item_field *>(column)->field;
+}
+
+/**
+ * @brief Serialize a scan predicate, including safe string-prefix rewrites.
+ *
+ * The shared predicate serializer does not model SUBSTRING. For the prefix form
+ * SUBSTRING(column, 1, N) = 'value' or IN (...), rewrite the predicate to
+ * column LIKE 'value%' when every constant has exactly N bytes and does not
+ * contain LIKE wildcards.
+ */
+bool SerializeScanPredicate(Item *condition,
+                            LineairDB::Protocol::FilterExpr *expression) {
+  if (serialize_item(condition, expression)) return true;
+  expression->Clear();
+
+  Item *real = condition->real_item();
+  if (real->type() != Item::FUNC_ITEM) return false;
+
+  auto *function = down_cast<Item_func *>(real);
+  uint32_t prefix_len = 0;
+  const Field *field = nullptr;
+  std::vector<std::string> values;
+  bool negated = false;
+
+  if (function->functype() == Item_func::IN_FUNC) {
+    auto *in_function = down_cast<Item_func_in *>(function);
+    negated = in_function->negated;
+    field = SubstringPrefixField(function->arguments()[0], &prefix_len);
+    if (field == nullptr) return false;
+
+    for (uint arg_idx = 1; arg_idx < function->argument_count(); arg_idx++) {
+      Item *value_item = function->arguments()[arg_idx];
+      if (!value_item->const_item()) return false;
+
+      String value_buffer;
+      String *value = value_item->val_str(&value_buffer);
+      if (value == nullptr) return false;
+      values.emplace_back(value->ptr(), value->length());
+    }
+  } else if (function->functype() == Item_func::EQ_FUNC) {
+    field = SubstringPrefixField(function->arguments()[0], &prefix_len);
+    Item *value_item = function->arguments()[1];
+    if (field == nullptr || !value_item->const_item()) return false;
+
+    String value_buffer;
+    String *value = value_item->val_str(&value_buffer);
+    if (value == nullptr) return false;
+    values.emplace_back(value->ptr(), value->length());
+  } else {
+    return false;
+  }
+
+  // Keep negated forms on the fallback path so NULL behavior remains SQL-like.
+  if (negated) return false;
+
+  for (const std::string &value : values) {
+    if (value.size() != prefix_len) return false;
+    if (value.find('%') != std::string::npos ||
+        value.find('_') != std::string::npos) {
+      return false;
+    }
+  }
+
+  auto emit_like = [&](LineairDB::Protocol::FilterExpr *target,
+                       const std::string &value) {
+    target->set_op(LineairDB::Protocol::FilterExpr::OP_LIKE);
+
+    auto *column = target->add_children();
+    column->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+    column->set_column_index(field->field_index());
+    column->set_compare_type(3);
+
+    auto *pattern = target->add_children();
+    pattern->set_op(LineairDB::Protocol::FilterExpr::CONST_STRING);
+    pattern->set_string_val(value + "%");
+    pattern->set_compare_type(3);
+  };
+
+  if (values.size() == 1) {
+    emit_like(expression, values[0]);
+  } else {
+    expression->set_op(LineairDB::Protocol::FilterExpr::OP_OR);
+    for (const std::string &value : values) {
+      emit_like(expression->add_children(), value);
+    }
+  }
+  return true;
+}
+
+/**
  * @brief Return the date field inside EXTRACT(YEAR FROM field), if supported.
  */
 const Field *ExtractYearField(Item *item) {
@@ -576,13 +688,13 @@ bool SerializeTableFilters(const std::vector<Item *> &filters, TABLE *table,
   if (filters.empty()) return true;
   predicate->set_num_columns(table->s->fields);
   if (filters.size() == 1) {
-    return serialize_item(filters[0], predicate->mutable_expr());
+    return SerializeScanPredicate(filters[0], predicate->mutable_expr());
   }
 
   auto *root = predicate->mutable_expr();
   root->set_op(LineairDB::Protocol::FilterExpr::OP_AND);
   for (Item *filter : filters) {
-    if (!serialize_item(filter, root->add_children())) return false;
+    if (!SerializeScanPredicate(filter, root->add_children())) return false;
   }
   return true;
 }

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1953,8 +1953,10 @@ bool BuildQueryBlockRequest(
       if (!is_join_key) residual_predicates.push_back(predicate);
     }
 
-    if (join_node->build_keys_size() == 0)
+    if (join_node->build_keys_size() == 0 &&
+        !is_scalar_virtual_table(table_idx)) {
       LDB_COL_REJECT("derived LEFT keyless");
+    }
 
     if (!residual_predicates.empty()) {
       TupleColumnRegistry registry;

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1886,17 +1886,135 @@ bool BuildQueryBlockRequest(
   }
 
   for (SemijoinNest &semijoin : semijoin_nests) {
-    if (semijoin.inner_tables.size() != 1)
-      LDB_COL_REJECT("multi-table semijoin");
+    if (semijoin.inner_tables.empty())
+      LDB_COL_REJECT("empty semijoin");
     if (semijoin.nest == nullptr || semijoin.nest->nested_join == nullptr)
       LDB_COL_REJECT("semijoin missing key metadata");
 
-    const int inner_table = semijoin.inner_tables[0];
+    auto semijoin_has_table = [&](int table_idx) {
+      for (int inner_table : semijoin.inner_tables) {
+        if (inner_table == table_idx) return true;
+      }
+      return false;
+    };
+
+    // Multi-table semijoin nests become a build-side INNER-join mini tree.
+    int build_node = scan_nodes[semijoin.inner_tables[0]];
+    if (semijoin.inner_tables.size() > 1) {
+      struct InnerJoinEdge {
+        int left_table = -1;
+        int right_table = -1;
+        const Field *left_field = nullptr;
+        const Field *right_field = nullptr;
+      };
+
+      std::vector<InnerJoinEdge> inner_edges;
+      std::vector<Item *> remaining_residuals;
+      for (Item *predicate : semijoin.residual_predicates) {
+        bool consumed = false;
+        if (predicate->type() == Item::FUNC_ITEM &&
+            down_cast<Item_func *>(predicate)->functype() ==
+                Item_func::EQ_FUNC) {
+          auto *equals = down_cast<Item_func *>(predicate);
+          Item *left = equals->arguments()[0]->real_item();
+          Item *right = equals->arguments()[1]->real_item();
+          if (left->type() == Item::FIELD_ITEM &&
+              right->type() == Item::FIELD_ITEM) {
+            const Field *left_raw = down_cast<Item_field *>(left)->field;
+            const Field *right_raw = down_cast<Item_field *>(right)->field;
+            const int left_table = TableIndexOfField(left_raw, tables);
+            const int right_table = TableIndexOfField(right_raw, tables);
+            const Field *left_field =
+                left_table >= 0 ? resolve_query_field(left_raw, left_table)
+                                : nullptr;
+            const Field *right_field =
+                right_table >= 0 ? resolve_query_field(right_raw, right_table)
+                                 : nullptr;
+            if (left_table >= 0 && right_table >= 0 &&
+                left_table != right_table && semijoin_has_table(left_table) &&
+                semijoin_has_table(right_table) &&
+                JoinColumnsUseByteEquality(left_raw, right_raw) &&
+                left_field != nullptr && right_field != nullptr &&
+                !left_field->is_nullable() && !right_field->is_nullable()) {
+              inner_edges.push_back(
+                  {left_table, right_table, left_field, right_field});
+              consumed = true;
+            }
+          }
+        }
+        if (!consumed) remaining_residuals.push_back(predicate);
+      }
+      semijoin.residual_predicates = std::move(remaining_residuals);
+
+      std::vector<bool> inner_joined(tables.size(), false);
+      inner_joined[semijoin.inner_tables[0]] = true;
+      std::vector<int> pending_inner_tables(
+          semijoin.inner_tables.begin() + 1,
+          semijoin.inner_tables.end());
+
+      while (!pending_inner_tables.empty()) {
+        int picked_table = -1;
+        size_t picked_idx = 0;
+        for (size_t idx = 0; idx < pending_inner_tables.size(); idx++) {
+          for (const InnerJoinEdge &edge : inner_edges) {
+            if ((edge.left_table == pending_inner_tables[idx] &&
+                 inner_joined[edge.right_table]) ||
+                (edge.right_table == pending_inner_tables[idx] &&
+                 inner_joined[edge.left_table])) {
+              picked_table = pending_inner_tables[idx];
+              picked_idx = idx;
+              break;
+            }
+          }
+          if (picked_table >= 0) break;
+        }
+        if (picked_table < 0) LDB_COL_REJECT("semijoin disconnected");
+        pending_inner_tables.erase(pending_inner_tables.begin() + picked_idx);
+
+        bool connected = false;
+        auto *inner_join = request.add_nodes()->mutable_join();
+        inner_join->set_type(LineairDB::Protocol::QueryBlockJoin::INNER);
+        inner_join->set_build(static_cast<uint32_t>(scan_nodes[picked_table]));
+        inner_join->set_probe(static_cast<uint32_t>(build_node));
+
+        for (const InnerJoinEdge &edge : inner_edges) {
+          const Field *build_field = nullptr;
+          const Field *probe_field = nullptr;
+          int probe_table = -1;
+          if (edge.left_table == picked_table &&
+              inner_joined[edge.right_table]) {
+            build_field = edge.left_field;
+            probe_field = edge.right_field;
+            probe_table = edge.right_table;
+          } else if (edge.right_table == picked_table &&
+                     inner_joined[edge.left_table]) {
+            build_field = edge.right_field;
+            probe_field = edge.left_field;
+            probe_table = edge.left_table;
+          } else {
+            continue;
+          }
+
+          auto *build_key = inner_join->add_build_keys();
+          build_key->set_table_idx(static_cast<uint32_t>(picked_table));
+          build_key->set_column(build_field->field_index());
+          auto *probe_key = inner_join->add_probe_keys();
+          probe_key->set_table_idx(static_cast<uint32_t>(probe_table));
+          probe_key->set_column(probe_field->field_index());
+          connected = true;
+        }
+
+        if (!connected) LDB_COL_REJECT("semijoin disconnected");
+        inner_joined[picked_table] = true;
+        build_node = request.nodes_size() - 1;
+      }
+    }
+
     auto *join_node = request.add_nodes()->mutable_join();
     join_node->set_type(semijoin.anti
                             ? LineairDB::Protocol::QueryBlockJoin::ANTI
                             : LineairDB::Protocol::QueryBlockJoin::SEMI);
-    join_node->set_build(static_cast<uint32_t>(scan_nodes[inner_table]));
+    join_node->set_build(static_cast<uint32_t>(build_node));
     join_node->set_probe(static_cast<uint32_t>(current_node));
 
     const auto &outer_exprs =
@@ -1921,7 +2039,7 @@ bool BuildQueryBlockRequest(
           down_cast<Item_field *>(inner_item)->field;
       const int outer_table = TableIndexOfField(raw_outer_field, tables);
       const int inner_key_table = TableIndexOfField(raw_inner_field, tables);
-      if (outer_table < 0 || inner_key_table != inner_table) {
+      if (outer_table < 0 || !semijoin_has_table(inner_key_table)) {
         LDB_COL_REJECT("semijoin key tables");
       }
       if (!JoinColumnsUseByteEquality(raw_outer_field, raw_inner_field)) {
@@ -1937,7 +2055,7 @@ bool BuildQueryBlockRequest(
       }
 
       auto *build_key = join_node->add_build_keys();
-      build_key->set_table_idx(static_cast<uint32_t>(inner_table));
+      build_key->set_table_idx(static_cast<uint32_t>(inner_key_table));
       build_key->set_column(inner_field->field_index());
       auto *probe_key = join_node->add_probe_keys();
       probe_key->set_table_idx(static_cast<uint32_t>(outer_table));

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -141,6 +141,30 @@ class ItemColumnarValue final : public Item_string {
   }
 
   void set_null_value() { null_value = true; }
+
+  String *val_str(String *str) override {
+    return null_value ? nullptr : Item_string::val_str(str);
+  }
+
+  double val_real() override {
+    return null_value ? 0.0 : Item_string::val_real();
+  }
+
+  longlong val_int() override {
+    return null_value ? 0 : Item_string::val_int();
+  }
+
+  my_decimal *val_decimal(my_decimal *decimal_value) override {
+    return null_value ? nullptr : Item_string::val_decimal(decimal_value);
+  }
+
+  bool get_date(MYSQL_TIME *time, my_time_flags_t flags) override {
+    return null_value ? true : Item_string::get_date(time, flags);
+  }
+
+  bool get_time(MYSQL_TIME *time) override {
+    return null_value ? true : Item_string::get_time(time);
+  }
 };
 
 // Statement-local state owned by LEX::secondary_engine_execution_context.

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -1427,8 +1428,306 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
   std::vector<Item *> output_items;
   for (Item *item : VisibleFields(qb->fields)) output_items.push_back(item);
 
+  const char *aggregate_error = nullptr;
+  auto register_aggregate = [&](Item_sum *sum) -> int {
+    if (sum->argument_count() > 1) {
+      aggregate_error = "aggregate arg count";
+      return -1;
+    }
+
+    auto *function = aggregate->add_aggs();
+    switch (sum->sum_func()) {
+      case Item_sum::COUNT_FUNC: {
+        function->set_arg_table(0);
+        if (sum->argument_count() > 0) {
+          Item *arg = sum->get_arg(0)->real_item();
+          if (arg->const_item()) {
+            if (arg->is_nullable() || arg->is_null()) {
+              aggregate_error = "COUNT const nullable";
+              return -1;
+            }
+          } else {
+            if (arg->type() != Item::FIELD_ITEM) {
+              aggregate_error = "COUNT arg shape";
+              return -1;
+            }
+            const Field *raw_count_field =
+                down_cast<Item_field *>(arg)->field;
+            const int count_table = TableIndexOfField(raw_count_field, tables);
+            const Field *count_field =
+                count_table >= 0
+                    ? ResolveBaseField(raw_count_field,
+                                       tables[count_table].table)
+                    : nullptr;
+            if (count_field == nullptr || count_field->is_nullable()) {
+              aggregate_error = "COUNT arg nullable";
+              return -1;
+            }
+            function->set_arg_table(static_cast<uint32_t>(count_table));
+            auto *ref = function->mutable_arg();
+            ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+            ref->set_column_index(count_field->field_index());
+          }
+        }
+
+        function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
+        return aggregate->aggs_size() - 1;
+      }
+
+      case Item_sum::SUM_FUNC:
+      case Item_sum::AVG_FUNC: {
+        if (sum->argument_count() != 1) {
+          aggregate_error = "aggregate arg count";
+          return -1;
+        }
+        Item *arg = sum->get_arg(0)->real_item();
+        if (sum->sum_func() == Item_sum::SUM_FUNC) {
+          if (Item *filter = CaseToCountFilter(arg)) {
+            const int filter_table = SingleTableOf(
+                filter->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+            if (filter_table < 0) {
+              aggregate_error = "CASE filter tables";
+              return -1;
+            }
+            auto *predicate = function->mutable_filter();
+            predicate->set_num_columns(tables[filter_table].table->s->fields);
+            if (!serialize_item(filter, predicate->mutable_expr())) {
+              aggregate_error = "CASE filter not pushable";
+              return -1;
+            }
+            function->set_arg_table(static_cast<uint32_t>(filter_table));
+            function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
+            return aggregate->aggs_size() - 1;
+          }
+
+          Item *filter = nullptr;
+          Item *then_expr = nullptr;
+          if (CaseToFilteredSum(arg, &filter, &then_expr)) {
+            if (then_expr->result_type() != DECIMAL_RESULT &&
+                then_expr->result_type() != INT_RESULT) {
+              aggregate_error = "CASE expression type";
+              return -1;
+            }
+
+            const int filter_table = SingleTableOf(
+                filter->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+            if (filter_table < 0) {
+              aggregate_error = "CASE filter tables";
+              return -1;
+            }
+            auto *predicate = function->mutable_filter();
+            predicate->set_num_columns(tables[filter_table].table->s->fields);
+            if (!serialize_item(filter, predicate->mutable_expr())) {
+              aggregate_error = "CASE filter not pushable";
+              return -1;
+            }
+
+            int argument_table = SingleTableOf(
+                then_expr->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+            if (argument_table >= 0 &&
+                then_expr->real_item()->type() == Item::FIELD_ITEM) {
+              const Field *raw_argument_field =
+                  down_cast<Item_field *>(then_expr->real_item())->field;
+              const Field *argument_field = ResolveBaseField(
+                  raw_argument_field, tables[argument_table].table);
+              if (argument_field == nullptr) {
+                aggregate_error = "CASE expression unresolvable";
+                return -1;
+              }
+
+              auto *ref = function->mutable_arg();
+              ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+              ref->set_column_index(argument_field->field_index());
+            } else if (argument_table >= 0) {
+              if (!lineairdb::serialize_aggregate_expression(
+                      then_expr->real_item(), function->mutable_arg())) {
+                aggregate_error = "CASE expression not pushable";
+                return -1;
+              }
+            } else {
+              argument_table = 0;
+              if (!SerializeAggregateExpressionForTables(
+                      then_expr->real_item(), tables,
+                      static_cast<uint32_t>(argument_table),
+                      function->mutable_arg())) {
+                aggregate_error = "CASE expression not pushable";
+                return -1;
+              }
+            }
+
+            function->set_arg_table(static_cast<uint32_t>(argument_table));
+            function->set_filter_table(static_cast<uint32_t>(filter_table));
+            function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::SUM);
+            function->set_arg_scale(then_expr->decimals);
+            function->set_zero_if_empty(true);
+            return aggregate->aggs_size() - 1;
+          }
+        }
+        if (arg->result_type() != DECIMAL_RESULT &&
+            arg->result_type() != INT_RESULT) {
+          aggregate_error = "aggregate arg type";
+          return -1;
+        }
+
+        int argument_table =
+            SingleTableOf(arg->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+        if (argument_table >= 0 && arg->type() == Item::FIELD_ITEM) {
+          const Field *raw_argument_field =
+              down_cast<Item_field *>(arg)->field;
+          const Field *argument_field = ResolveBaseField(
+              raw_argument_field, tables[argument_table].table);
+          if (argument_field == nullptr) {
+            aggregate_error = "aggregate arg unresolvable";
+            return -1;
+          }
+
+          auto *ref = function->mutable_arg();
+          ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+          ref->set_column_index(argument_field->field_index());
+        } else if (argument_table >= 0) {
+          if (!lineairdb::serialize_aggregate_expression(
+                  arg, function->mutable_arg())) {
+            aggregate_error = "aggregate expr not pushable";
+            return -1;
+          }
+        } else {
+          argument_table = 0;
+          if (!SerializeAggregateExpressionForTables(
+                  arg, tables, static_cast<uint32_t>(argument_table),
+                  function->mutable_arg())) {
+            aggregate_error = "aggregate expr not pushable";
+            return -1;
+          }
+        }
+
+        function->set_arg_table(static_cast<uint32_t>(argument_table));
+        function->set_kind(
+            sum->sum_func() == Item_sum::SUM_FUNC
+                ? LineairDB::Protocol::QueryBlockAggFunc::SUM
+                : LineairDB::Protocol::QueryBlockAggFunc::AVG);
+        function->set_arg_scale(arg->decimals);
+        return aggregate->aggs_size() - 1;
+      }
+
+      case Item_sum::MIN_FUNC:
+      case Item_sum::MAX_FUNC: {
+        if (sum->argument_count() != 1) {
+          aggregate_error = "aggregate arg count";
+          return -1;
+        }
+        Item *arg = sum->get_arg(0)->real_item();
+        if (arg->type() != Item::FIELD_ITEM) {
+          aggregate_error = "minmax arg";
+          return -1;
+        }
+        const Field *raw_argument_field =
+            down_cast<Item_field *>(arg)->field;
+        const int argument_table =
+            TableIndexOfField(raw_argument_field, tables);
+        const Field *argument_field =
+            argument_table >= 0
+                ? ResolveBaseField(raw_argument_field,
+                                   tables[argument_table].table)
+                : nullptr;
+        if (argument_field == nullptr) {
+          aggregate_error = "minmax unresolvable";
+          return -1;
+        }
+        if (argument_field->is_nullable()) {
+          aggregate_error = "minmax nullable";
+          return -1;
+        }
+        if (argument_field->result_type() == STRING_RESULT &&
+            !argument_field->binary()) {
+          aggregate_error = "minmax collation";
+          return -1;
+        }
+
+        auto *ref = function->mutable_arg();
+        ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+        ref->set_column_index(argument_field->field_index());
+        function->set_arg_table(static_cast<uint32_t>(argument_table));
+        function->set_kind(
+            sum->sum_func() == Item_sum::MIN_FUNC
+                ? LineairDB::Protocol::QueryBlockAggFunc::MIN
+                : LineairDB::Protocol::QueryBlockAggFunc::MAX);
+        function->set_cmp_kind(argument_field->result_type() == STRING_RESULT
+                                   ? 1
+                                   : 0);
+        return aggregate->aggs_size() - 1;
+      }
+
+      default:
+        aggregate_error = "aggregate kind unsupported";
+        return -1;
+    }
+  };
+
+  const uint32_t aggregate_output_base = aggregate->group_columns_size();
+  std::function<bool(Item *, LineairDB::Protocol::FilterExpr *)>
+      serialize_output_expression =
+          [&](Item *item, LineairDB::Protocol::FilterExpr *expr) -> bool {
+    item = item->real_item();
+    if (item->type() == Item::SUM_FUNC_ITEM) {
+      const int ordinal = register_aggregate(down_cast<Item_sum *>(item));
+      if (ordinal < 0) return false;
+      expr->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+      expr->set_column_index(aggregate_output_base +
+                             static_cast<uint32_t>(ordinal));
+      return true;
+    }
+    if (item->type() == Item::INT_ITEM) {
+      expr->set_op(LineairDB::Protocol::FilterExpr::CONST_INT);
+      expr->set_int_val(item->val_int());
+      return true;
+    }
+    if (item->const_item() && (item->result_type() == DECIMAL_RESULT ||
+                               item->result_type() == REAL_RESULT)) {
+      String buffer;
+      String *value = item->val_str(&buffer);
+      if (value == nullptr) return false;
+      expr->set_op(LineairDB::Protocol::FilterExpr::CONST_STRING);
+      expr->set_string_val(value->ptr(), value->length());
+      return true;
+    }
+    if (item->type() != Item::FUNC_ITEM) return false;
+
+    auto *function = down_cast<Item_func *>(item);
+    using FilterExpr = LineairDB::Protocol::FilterExpr;
+    FilterExpr::Op op;
+    switch (function->functype()) {
+      case Item_func::PLUS_FUNC:
+        op = FilterExpr::OP_ADD;
+        break;
+      case Item_func::MINUS_FUNC:
+        op = FilterExpr::OP_SUB;
+        break;
+      case Item_func::MUL_FUNC:
+        op = FilterExpr::OP_MUL;
+        break;
+      case Item_func::DIV_FUNC:
+        op = FilterExpr::OP_DIV;
+        break;
+      case Item_func::NEG_FUNC:
+        op = FilterExpr::OP_NEG;
+        break;
+      default:
+        return false;
+    }
+
+    expr->set_op(op);
+    for (uint arg_idx = 0; arg_idx < function->argument_count(); arg_idx++) {
+      if (!serialize_output_expression(function->arguments()[arg_idx],
+                                       expr->add_children())) {
+        return false;
+      }
+    }
+    return true;
+  };
+
   // The response must match MySQL's visible SELECT list exactly: grouped
-  // columns refer back to group keys, aggregate items refer to aggregate slots.
+  // columns refer back to group keys, aggregate items refer to aggregate slots,
+  // and arithmetic over aggregate items becomes an output expression.
   for (Item *item : output_items) {
     Item *real = item->real_item();
     auto *output = request.add_output();
@@ -1460,7 +1759,19 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
       continue;
     }
 
-    if (real->type() != Item::SUM_FUNC_ITEM) {
+    if (real->type() == Item::SUM_FUNC_ITEM) {
+      const int aggregate_ordinal =
+          register_aggregate(down_cast<Item_sum *>(real));
+      if (aggregate_ordinal < 0) {
+        LDB_COL_REJECT(aggregate_error != nullptr ? aggregate_error
+                                                  : "aggregate");
+      }
+      output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::AGG);
+      output->set_ordinal(static_cast<uint32_t>(aggregate_ordinal));
+      continue;
+    }
+
+    {
       int group_position = -1;
       for (size_t group_idx = 0; group_idx < group_items.size();
            group_idx++) {
@@ -1470,201 +1781,19 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
           break;
         }
       }
-      if (group_position < 0) LDB_COL_REJECT("output not aggregate");
-      output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::GROUP);
-      output->set_ordinal(group_position);
-      continue;
+      if (group_position >= 0) {
+        output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::GROUP);
+        output->set_ordinal(group_position);
+        continue;
+      }
     }
 
-    Item_sum *sum = down_cast<Item_sum *>(real);
-    if (sum->argument_count() > 1) LDB_COL_REJECT("aggregate arg count");
-
-    auto *function = aggregate->add_aggs();
-    switch (sum->sum_func()) {
-      case Item_sum::COUNT_FUNC: {
-        function->set_arg_table(0);
-        if (sum->argument_count() > 0) {
-          Item *arg = sum->get_arg(0)->real_item();
-          if (arg->const_item()) {
-            if (arg->is_nullable() || arg->is_null())
-              LDB_COL_REJECT("COUNT const nullable");
-          } else {
-            if (arg->type() != Item::FIELD_ITEM)
-              LDB_COL_REJECT("COUNT arg shape");
-            const Field *raw_count_field =
-                down_cast<Item_field *>(arg)->field;
-            const int count_table = TableIndexOfField(raw_count_field, tables);
-            const Field *count_field =
-                count_table >= 0
-                    ? ResolveBaseField(raw_count_field,
-                                       tables[count_table].table)
-                    : nullptr;
-            if (count_field == nullptr || count_field->is_nullable())
-              LDB_COL_REJECT("COUNT arg nullable");
-            function->set_arg_table(static_cast<uint32_t>(count_table));
-            auto *ref = function->mutable_arg();
-            ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
-            ref->set_column_index(count_field->field_index());
-          }
-        }
-
-        function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
-        break;
-      }
-
-      case Item_sum::SUM_FUNC:
-      case Item_sum::AVG_FUNC: {
-        if (sum->argument_count() != 1) LDB_COL_REJECT("aggregate arg count");
-        Item *arg = sum->get_arg(0)->real_item();
-        if (sum->sum_func() == Item_sum::SUM_FUNC) {
-          if (Item *filter = CaseToCountFilter(arg)) {
-            const int filter_table = SingleTableOf(
-                filter->used_tables() & ~PSEUDO_TABLE_BITS, tables);
-            if (filter_table < 0) LDB_COL_REJECT("CASE filter tables");
-            auto *predicate = function->mutable_filter();
-            predicate->set_num_columns(tables[filter_table].table->s->fields);
-            if (!serialize_item(filter, predicate->mutable_expr()))
-              LDB_COL_REJECT("CASE filter not pushable");
-            function->set_arg_table(static_cast<uint32_t>(filter_table));
-            function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
-            break;
-          }
-
-          Item *filter = nullptr;
-          Item *then_expr = nullptr;
-          if (CaseToFilteredSum(arg, &filter, &then_expr)) {
-            if (then_expr->result_type() != DECIMAL_RESULT &&
-                then_expr->result_type() != INT_RESULT) {
-              LDB_COL_REJECT("CASE expression type");
-            }
-
-            const int filter_table = SingleTableOf(
-                filter->used_tables() & ~PSEUDO_TABLE_BITS, tables);
-            if (filter_table < 0) LDB_COL_REJECT("CASE filter tables");
-            auto *predicate = function->mutable_filter();
-            predicate->set_num_columns(tables[filter_table].table->s->fields);
-            if (!serialize_item(filter, predicate->mutable_expr()))
-              LDB_COL_REJECT("CASE filter not pushable");
-
-            int argument_table = SingleTableOf(
-                then_expr->used_tables() & ~PSEUDO_TABLE_BITS, tables);
-            if (argument_table >= 0 &&
-                then_expr->real_item()->type() == Item::FIELD_ITEM) {
-              const Field *raw_argument_field =
-                  down_cast<Item_field *>(then_expr->real_item())->field;
-              const Field *argument_field = ResolveBaseField(
-                  raw_argument_field, tables[argument_table].table);
-              if (argument_field == nullptr)
-                LDB_COL_REJECT("CASE expression unresolvable");
-
-              auto *ref = function->mutable_arg();
-              ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
-              ref->set_column_index(argument_field->field_index());
-            } else if (argument_table >= 0) {
-              if (!lineairdb::serialize_aggregate_expression(
-                      then_expr->real_item(), function->mutable_arg())) {
-                LDB_COL_REJECT("CASE expression not pushable");
-              }
-            } else {
-              argument_table = 0;
-              if (!SerializeAggregateExpressionForTables(
-                      then_expr->real_item(), tables,
-                      static_cast<uint32_t>(argument_table),
-                      function->mutable_arg())) {
-                LDB_COL_REJECT("CASE expression not pushable");
-              }
-            }
-
-            function->set_arg_table(static_cast<uint32_t>(argument_table));
-            function->set_filter_table(static_cast<uint32_t>(filter_table));
-            function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::SUM);
-            function->set_arg_scale(then_expr->decimals);
-            function->set_zero_if_empty(true);
-            break;
-          }
-        }
-        if (arg->result_type() != DECIMAL_RESULT &&
-            arg->result_type() != INT_RESULT) {
-          LDB_COL_REJECT("aggregate arg type");
-        }
-
-        int argument_table =
-            SingleTableOf(arg->used_tables() & ~PSEUDO_TABLE_BITS, tables);
-        if (argument_table >= 0 && arg->type() == Item::FIELD_ITEM) {
-          const Field *raw_argument_field =
-              down_cast<Item_field *>(arg)->field;
-          const Field *argument_field = ResolveBaseField(
-              raw_argument_field, tables[argument_table].table);
-          if (argument_field == nullptr)
-            LDB_COL_REJECT("aggregate arg unresolvable");
-
-          auto *ref = function->mutable_arg();
-          ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
-          ref->set_column_index(argument_field->field_index());
-        } else if (argument_table >= 0) {
-          if (!lineairdb::serialize_aggregate_expression(
-                  arg, function->mutable_arg())) {
-            LDB_COL_REJECT("aggregate expr not pushable");
-          }
-        } else {
-          argument_table = 0;
-          if (!SerializeAggregateExpressionForTables(
-                  arg, tables, static_cast<uint32_t>(argument_table),
-                  function->mutable_arg())) {
-            LDB_COL_REJECT("aggregate expr not pushable");
-          }
-        }
-
-        function->set_arg_table(static_cast<uint32_t>(argument_table));
-        function->set_kind(
-            sum->sum_func() == Item_sum::SUM_FUNC
-                ? LineairDB::Protocol::QueryBlockAggFunc::SUM
-                : LineairDB::Protocol::QueryBlockAggFunc::AVG);
-        function->set_arg_scale(arg->decimals);
-        break;
-      }
-
-      case Item_sum::MIN_FUNC:
-      case Item_sum::MAX_FUNC: {
-        if (sum->argument_count() != 1) LDB_COL_REJECT("aggregate arg count");
-        Item *arg = sum->get_arg(0)->real_item();
-        if (arg->type() != Item::FIELD_ITEM) LDB_COL_REJECT("minmax arg");
-        const Field *raw_argument_field =
-            down_cast<Item_field *>(arg)->field;
-        const int argument_table =
-            TableIndexOfField(raw_argument_field, tables);
-        const Field *argument_field =
-            argument_table >= 0
-                ? ResolveBaseField(raw_argument_field,
-                                   tables[argument_table].table)
-                : nullptr;
-        if (argument_field == nullptr) LDB_COL_REJECT("minmax unresolvable");
-        if (argument_field->is_nullable()) LDB_COL_REJECT("minmax nullable");
-        if (argument_field->result_type() == STRING_RESULT &&
-            !argument_field->binary()) {
-          LDB_COL_REJECT("minmax collation");
-        }
-
-        auto *ref = function->mutable_arg();
-        ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
-        ref->set_column_index(argument_field->field_index());
-        function->set_arg_table(static_cast<uint32_t>(argument_table));
-        function->set_kind(
-            sum->sum_func() == Item_sum::MIN_FUNC
-                ? LineairDB::Protocol::QueryBlockAggFunc::MIN
-                : LineairDB::Protocol::QueryBlockAggFunc::MAX);
-        function->set_cmp_kind(argument_field->result_type() == STRING_RESULT
-                                   ? 1
-                                   : 0);
-        break;
-      }
-
-      default:
-        LDB_COL_REJECT("aggregate kind unsupported");
+    if (!serialize_output_expression(real, output->mutable_expr())) {
+      LDB_COL_REJECT(aggregate_error != nullptr ? aggregate_error
+                                                : "output expression");
     }
-
-    output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::AGG);
-    output->set_ordinal(aggregate->aggs_size() - 1);
+    output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::EXPR);
+    output->set_result_scale(real->decimals);
   }
 
   if (aggregate->aggs_size() == 0) LDB_COL_REJECT("no aggregates");

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -481,6 +481,44 @@ bool SerializeAggregateExpressionForTables(
   }
 }
 
+struct TupleColumnRegistry {
+  std::vector<std::pair<int, const Field *>> columns;
+  std::function<int(const Field *)> table_of;
+  std::function<const Field *(const Field *, int)> resolve;
+
+  int ordinal_of(const Field *raw_field) {
+    const int table_idx = table_of(raw_field);
+    if (table_idx < 0) return -1;
+
+    const Field *field = resolve(raw_field, table_idx);
+    if (field == nullptr) return -1;
+
+    for (size_t column_idx = 0; column_idx < columns.size(); column_idx++) {
+      if (columns[column_idx].first == table_idx &&
+          columns[column_idx].second == field) {
+        return static_cast<int>(column_idx);
+      }
+    }
+    columns.push_back({table_idx, field});
+    return static_cast<int>(columns.size()) - 1;
+  }
+};
+
+/**
+ * @brief Serialize a predicate over an already joined tuple.
+ */
+bool SerializeTuplePredicate(Item *item,
+                             LineairDB::Protocol::FilterExpr *expression,
+                             TupleColumnRegistry *registry) {
+  SerializeColumnEncoder encoder = [registry](const Field *field) {
+    return registry->ordinal_of(field);
+  };
+  set_serialize_column_encoder(&encoder);
+  const bool ok = serialize_item(item, expression);
+  set_serialize_column_encoder(nullptr);
+  return ok;
+}
+
 /**
  * @brief Return the date field inside EXTRACT(YEAR FROM field), if supported.
  */
@@ -1230,13 +1268,15 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
 
   std::vector<std::vector<Item *>> table_filters(tables.size());
   std::vector<JoinEdge> join_edges;
+  std::vector<Item *> tuple_predicates;
   Item *where_cond =
       qb->where_cond() != nullptr ? qb->where_cond() : join->where_cond;
   std::vector<Item *> predicates;
   FlattenAnd(where_cond, &predicates);
 
   // Local predicates become scan filters. Cross-table integer equalities become
-  // join edges; other cross-table shapes stay on the primary engine path.
+  // join edges. Other cross-table predicates are evaluated after the join as
+  // tuple filters.
   for (Item *predicate : predicates) {
     const table_map used = predicate->used_tables() & ~PSEUDO_TABLE_BITS;
     const int table_idx = SingleTableOf(used, tables);
@@ -1249,9 +1289,87 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
       continue;
     }
 
+    if (predicate->type() == Item::COND_ITEM &&
+        down_cast<Item_cond *>(predicate)->functype() ==
+            Item_func::COND_OR_FUNC) {
+      auto *condition = down_cast<Item_cond *>(predicate);
+      std::vector<std::vector<std::pair<const Field *, const Field *>>>
+          branch_equalities;
+      List_iterator<Item> branch_it(*condition->argument_list());
+      for (Item *branch = branch_it++; branch != nullptr;
+           branch = branch_it++) {
+        std::vector<Item *> branch_parts;
+        FlattenAnd(branch, &branch_parts);
+        branch_equalities.emplace_back();
+        for (Item *part : branch_parts) {
+          if (part->type() != Item::FUNC_ITEM ||
+              down_cast<Item_func *>(part)->functype() !=
+                  Item_func::EQ_FUNC) {
+            continue;
+          }
+          auto *equals = down_cast<Item_func *>(part);
+          Item *left = equals->arguments()[0]->real_item();
+          Item *right = equals->arguments()[1]->real_item();
+          if (left->type() != Item::FIELD_ITEM ||
+              right->type() != Item::FIELD_ITEM) {
+            continue;
+          }
+          branch_equalities.back().push_back(
+              {down_cast<Item_field *>(left)->field,
+               down_cast<Item_field *>(right)->field});
+        }
+      }
+
+      if (!branch_equalities.empty()) {
+        for (const auto &candidate : branch_equalities[0]) {
+          bool appears_in_all_branches = true;
+          for (size_t branch_idx = 1;
+               branch_idx < branch_equalities.size() &&
+               appears_in_all_branches;
+               branch_idx++) {
+            bool found = false;
+            for (const auto &other : branch_equalities[branch_idx]) {
+              if ((other.first == candidate.first &&
+                   other.second == candidate.second) ||
+                  (other.first == candidate.second &&
+                   other.second == candidate.first)) {
+                found = true;
+                break;
+              }
+            }
+            appears_in_all_branches = found;
+          }
+          if (!appears_in_all_branches) continue;
+
+          const int left_table = TableIndexOfField(candidate.first, tables);
+          const int right_table = TableIndexOfField(candidate.second, tables);
+          if (left_table < 0 || right_table < 0 ||
+              left_table == right_table) {
+            continue;
+          }
+          if (candidate.first->result_type() != INT_RESULT ||
+              candidate.second->result_type() != INT_RESULT) {
+            continue;
+          }
+
+          const Field *left_field =
+              ResolveBaseField(candidate.first, tables[left_table].table);
+          const Field *right_field =
+              ResolveBaseField(candidate.second, tables[right_table].table);
+          if (left_field == nullptr || right_field == nullptr) continue;
+          join_edges.push_back(
+              {left_table, right_table, left_field, right_field});
+        }
+      }
+
+      tuple_predicates.push_back(predicate);
+      continue;
+    }
+
     if (predicate->type() != Item::FUNC_ITEM ||
         down_cast<Item_func *>(predicate)->functype() != Item_func::EQ_FUNC) {
-      LDB_COL_REJECT("non-equi join predicate");
+      tuple_predicates.push_back(predicate);
+      continue;
     }
     auto *equals = down_cast<Item_func *>(predicate);
     Item *left = equals->arguments()[0]->real_item();
@@ -1367,6 +1485,46 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
 
     if (!connected) LDB_COL_REJECT("disconnected join graph");
     joined[table_idx] = true;
+    current_node = request.nodes_size() - 1;
+  }
+
+  if (!tuple_predicates.empty()) {
+    auto *filter_node = request.add_nodes()->mutable_filter();
+    filter_node->set_input(static_cast<uint32_t>(current_node));
+    auto *tuple_filter = filter_node->mutable_filter();
+
+    TupleColumnRegistry registry;
+    registry.table_of = [&](const Field *field) {
+      return TableIndexOfField(field, tables);
+    };
+    registry.resolve = [&](const Field *field, int table_idx) {
+      return ResolveBaseField(field, tables[table_idx].table);
+    };
+
+    auto *predicate = tuple_filter->mutable_predicate();
+    auto *expression = predicate->mutable_expr();
+    if (tuple_predicates.size() == 1) {
+      if (!SerializeTuplePredicate(tuple_predicates[0], expression,
+                                   &registry)) {
+        LDB_COL_REJECT("tuple predicate not pushable");
+      }
+    } else {
+      expression->set_op(LineairDB::Protocol::FilterExpr::OP_AND);
+      for (Item *tuple_predicate : tuple_predicates) {
+        if (!SerializeTuplePredicate(tuple_predicate,
+                                     expression->add_children(),
+                                     &registry)) {
+          LDB_COL_REJECT("tuple predicate not pushable");
+        }
+      }
+    }
+
+    predicate->set_num_columns(registry.columns.size());
+    for (const auto &column_ref : registry.columns) {
+      auto *column = tuple_filter->add_columns();
+      column->set_table_idx(static_cast<uint32_t>(column_ref.first));
+      column->set_column(column_ref.second->field_index());
+    }
     current_node = request.nodes_size() - 1;
   }
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1259,8 +1259,8 @@ bool BuildQueryBlockRequest(
   if (qb->olap != UNSPECIFIED_OLAP_TYPE) LDB_COL_REJECT("has ROLLUP");
   const bool implicit_grouping =
       join != nullptr ? join->implicit_grouping : qb->is_implicitly_grouped();
-  if (!implicit_grouping && qb->group_list.elements == 0)
-    LDB_COL_REJECT("no aggregation");
+  const bool plain_rows =
+      !implicit_grouping && qb->group_list.elements == 0;
 
   struct SemijoinNest {
     Table_ref *nest = nullptr;
@@ -1864,6 +1864,63 @@ bool BuildQueryBlockRequest(
     current_node = request.nodes_size() - 1;
   }
 
+  std::vector<Item *> output_items;
+  for (Item *item : VisibleFields(qb->fields)) output_items.push_back(item);
+
+  if (plain_rows) {
+    if (qb->having_cond() != nullptr) LDB_COL_REJECT("row block has HAVING");
+    for (Item *item : output_items) {
+      Item *real = item->real_item();
+      if (real->type() != Item::FIELD_ITEM)
+        LDB_COL_REJECT("row output not a column");
+
+      const Field *raw_output_field = down_cast<Item_field *>(real)->field;
+      const int output_table = TableIndexOfField(raw_output_field, tables);
+      const Field *output_field =
+          output_table >= 0
+              ? resolve_query_field(raw_output_field, output_table)
+              : nullptr;
+      if (output_field == nullptr)
+        LDB_COL_REJECT("row output column unresolvable");
+
+      auto *output = request.add_output();
+      output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::COLUMN);
+      auto *column = output->mutable_column();
+      column->set_table_idx(static_cast<uint32_t>(output_table));
+      column->set_column(output_field->field_index());
+      column->set_cmp_kind(output_field->result_type() == STRING_RESULT ? 1
+                                                                        : 2);
+    }
+
+    for (ORDER *order = qb->order_list.first; order != nullptr;
+         order = order->next) {
+      const int output_ordinal =
+          OrderOutputOrdinal(*order->item, output_items);
+      if (output_ordinal < 0)
+        LDB_COL_REJECT("row ORDER BY not an output column");
+
+      auto *sort_key = request.add_order_by();
+      sort_key->set_output_ordinal(output_ordinal);
+      sort_key->set_descending(order->direction == ORDER_DESC);
+      Item *output_item = output_items[output_ordinal]->real_item();
+      sort_key->set_cmp_kind(output_item->result_type() == STRING_RESULT ? 1
+                                                                         : 2);
+    }
+
+    if (qb->has_limit()) {
+      if (unit->select_limit_cnt != HA_POS_ERROR)
+        request.set_limit(unit->select_limit_cnt);
+      if (unit->offset_limit_cnt > 0) {
+        request.set_offset(unit->offset_limit_cnt);
+        if (request.limit() > 0)
+          request.set_limit(request.limit() - unit->offset_limit_cnt);
+      }
+    }
+
+    *why = nullptr;
+    return true;
+  }
+
   auto *aggregate_node = request.add_nodes();
   auto *aggregate = aggregate_node->mutable_aggregate();
   aggregate->set_input(current_node);
@@ -1919,9 +1976,6 @@ bool BuildQueryBlockRequest(
                                                                            : 0);
     group_fields.push_back({group_table, group_field});
   }
-
-  std::vector<Item *> output_items;
-  for (Item *item : VisibleFields(qb->fields)) output_items.push_back(item);
 
   const char *aggregate_error = nullptr;
   auto register_aggregate = [&](Item_sum *sum) -> int {

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1453,8 +1453,9 @@ bool BuildQueryBlockRequest(
   for (Table_ref *table_ref = qb->leaf_tables; table_ref != nullptr;
        table_ref = table_ref->next_leaf) {
     if (!table_ref->is_view_or_derived()) continue;
-    if (table_ref->outer_join) LDB_COL_REJECT("outer derived table");
-    if (semijoin_nest_of(table_ref) >= 0) LDB_COL_REJECT("derived semijoin");
+    const int semijoin_nest = semijoin_nest_of(table_ref);
+    if (semijoin_nest < 0 && table_ref->outer_join)
+      LDB_COL_REJECT("outer derived table");
     if (table_ref->table == nullptr) LDB_COL_REJECT("derived no TABLE");
 
     Query_expression *derived_unit = table_ref->derived_query_expression();
@@ -1464,13 +1465,18 @@ bool BuildQueryBlockRequest(
     if (derived_qb == nullptr) LDB_COL_REJECT("derived no query block");
 
     tables.push_back({table_ref->table, table_ref->map()});
-    table_semijoin_nest.push_back(-1);
+    table_semijoin_nest.push_back(semijoin_nest);
     table_is_virtual.push_back(true);
     virtual_blocks.push_back(derived_qb);
     virtual_block_is_scalar_aggregate.push_back(
         derived_qb->is_implicitly_grouped() &&
         derived_qb->group_list.elements == 0);
-    main_tables.push_back(static_cast<int>(tables.size()) - 1);
+    if (semijoin_nest >= 0) {
+      semijoin_nests[semijoin_nest].inner_tables.push_back(
+          static_cast<int>(tables.size()) - 1);
+    } else {
+      main_tables.push_back(static_cast<int>(tables.size()) - 1);
+    }
   }
   if (main_tables.empty()) LDB_COL_REJECT("no tables");
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -21,6 +21,7 @@
 #include "sql/item_sum.h"
 #include "sql/item_timefunc.h"
 #include "sql/mem_root_array.h"
+#include "sql/nested_join.h"
 #include "sql/query_result.h"
 #include "sql/sql_const.h"
 #include "sql/sql_class.h"
@@ -1245,19 +1246,62 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
   if (!join->implicit_grouping && qb->group_list.elements == 0)
     LDB_COL_REJECT("no aggregation");
 
+  struct SemijoinNest {
+    Table_ref *nest = nullptr;
+    bool anti = false;
+    std::vector<int> inner_tables;
+    std::vector<Item *> residual_predicates;
+  };
+
+  std::vector<SemijoinNest> semijoin_nests;
+  for (Table_ref *nest : qb->sj_nests) {
+    semijoin_nests.push_back(
+        {nest, nest->is_aj_nest(), {}, {}});
+  }
+
+  auto semijoin_nest_of = [&](Table_ref *table_ref) -> int {
+    for (Table_ref *embedding = table_ref->embedding; embedding != nullptr;
+         embedding = embedding->embedding) {
+      for (size_t nest_idx = 0; nest_idx < semijoin_nests.size();
+           nest_idx++) {
+        if (embedding == semijoin_nests[nest_idx].nest) {
+          return static_cast<int>(nest_idx);
+        }
+      }
+
+      if (embedding->is_sj_nest() || embedding->is_aj_nest()) {
+        semijoin_nests.push_back(
+            {embedding, embedding->is_aj_nest(), {}, {}});
+        return static_cast<int>(semijoin_nests.size()) - 1;
+      }
+    }
+    return -1;
+  };
+
   // The request table order is the stable numbering used by scan, join,
   // grouping, and aggregate argument references.
   std::vector<QueryBlockTable> tables;
+  std::vector<int> main_tables;
+  std::vector<int> table_semijoin_nest;
   for (Table_ref *table_ref = qb->leaf_tables; table_ref != nullptr;
        table_ref = table_ref->next_leaf) {
     TABLE *table = table_ref->table;
     if (table == nullptr || table->s == nullptr) LDB_COL_REJECT("no TABLE");
-    if (table_ref->outer_join) LDB_COL_REJECT("outer join");
+    const int semijoin_nest = semijoin_nest_of(table_ref);
+    if (semijoin_nest < 0 && table_ref->outer_join)
+      LDB_COL_REJECT("outer join");
     if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
       LDB_COL_REJECT("not SECONDARY_LOADed");
     tables.push_back({table, table_ref->map()});
+    table_semijoin_nest.push_back(semijoin_nest);
+    if (semijoin_nest < 0) {
+      main_tables.push_back(static_cast<int>(tables.size()) - 1);
+    } else {
+      semijoin_nests[semijoin_nest].inner_tables.push_back(
+          static_cast<int>(tables.size()) - 1);
+    }
   }
-  if (tables.empty()) LDB_COL_REJECT("no tables");
+  if (main_tables.empty()) LDB_COL_REJECT("no tables");
 
   struct JoinEdge {
     int left_table = -1;
@@ -1285,7 +1329,24 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
       continue;
     }
     if (used == 0) {
-      table_filters[0].push_back(predicate);
+      table_filters[main_tables[0]].push_back(predicate);
+      continue;
+    }
+
+    int predicate_nest = -1;
+    bool spans_multiple_nests = false;
+    for (size_t table_idx = 0; table_idx < tables.size(); table_idx++) {
+      if ((used & tables[table_idx].map) == 0) continue;
+      const int table_nest = table_semijoin_nest[table_idx];
+      if (table_nest < 0) continue;
+      if (predicate_nest >= 0 && predicate_nest != table_nest) {
+        spans_multiple_nests = true;
+      }
+      predicate_nest = table_nest;
+    }
+    if (spans_multiple_nests) LDB_COL_REJECT("predicate spans semijoins");
+    if (predicate_nest >= 0) {
+      semijoin_nests[predicate_nest].residual_predicates.push_back(predicate);
       continue;
     }
 
@@ -1403,7 +1464,8 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
     }
     join_edges.push_back({left_table, right_table, left_field, right_field});
   }
-  if (tables.size() > 1 && join_edges.empty()) LDB_COL_REJECT("cross join");
+  if (main_tables.size() > 1 && join_edges.empty())
+    LDB_COL_REJECT("cross join");
 
   // Scan every table once, attaching only predicates that read that table.
   auto &request = ctx->query_block_request;
@@ -1424,12 +1486,12 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
 
   // Build a left-deep INNER join tree by walking FROM order and retrying tables
   // whose equality edges are not connected yet.
-  int current_node = scan_nodes[0];
+  int current_node = scan_nodes[main_tables[0]];
   std::vector<bool> joined(tables.size(), false);
-  joined[0] = true;
+  joined[main_tables[0]] = true;
   std::vector<int> pending_tables;
-  for (size_t table_idx = 1; table_idx < tables.size(); table_idx++) {
-    pending_tables.push_back(static_cast<int>(table_idx));
+  for (size_t table_idx = 1; table_idx < main_tables.size(); table_idx++) {
+    pending_tables.push_back(main_tables[table_idx]);
   }
   while (!pending_tables.empty()) {
     int table_idx = -1;
@@ -1525,6 +1587,105 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
       column->set_table_idx(static_cast<uint32_t>(column_ref.first));
       column->set_column(column_ref.second->field_index());
     }
+    current_node = request.nodes_size() - 1;
+  }
+
+  for (SemijoinNest &semijoin : semijoin_nests) {
+    if (semijoin.inner_tables.size() != 1)
+      LDB_COL_REJECT("multi-table semijoin");
+    if (semijoin.nest == nullptr || semijoin.nest->nested_join == nullptr)
+      LDB_COL_REJECT("semijoin missing key metadata");
+
+    const int inner_table = semijoin.inner_tables[0];
+    auto *join_node = request.add_nodes()->mutable_join();
+    join_node->set_type(semijoin.anti
+                            ? LineairDB::Protocol::QueryBlockJoin::ANTI
+                            : LineairDB::Protocol::QueryBlockJoin::SEMI);
+    join_node->set_build(static_cast<uint32_t>(scan_nodes[inner_table]));
+    join_node->set_probe(static_cast<uint32_t>(current_node));
+
+    const auto &outer_exprs =
+        semijoin.nest->nested_join->sj_outer_exprs;
+    const auto &inner_exprs =
+        semijoin.nest->nested_join->sj_inner_exprs;
+    if (outer_exprs.size() != inner_exprs.size() || outer_exprs.empty()) {
+      LDB_COL_REJECT("semijoin key arity");
+    }
+
+    for (size_t key_idx = 0; key_idx < outer_exprs.size(); key_idx++) {
+      Item *outer_item = outer_exprs[key_idx]->real_item();
+      Item *inner_item = inner_exprs[key_idx]->real_item();
+      if (outer_item->type() != Item::FIELD_ITEM ||
+          inner_item->type() != Item::FIELD_ITEM) {
+        LDB_COL_REJECT("semijoin key shape");
+      }
+
+      const Field *raw_outer_field =
+          down_cast<Item_field *>(outer_item)->field;
+      const Field *raw_inner_field =
+          down_cast<Item_field *>(inner_item)->field;
+      const int outer_table = TableIndexOfField(raw_outer_field, tables);
+      const int inner_key_table = TableIndexOfField(raw_inner_field, tables);
+      if (outer_table < 0 || inner_key_table != inner_table) {
+        LDB_COL_REJECT("semijoin key tables");
+      }
+      if (raw_outer_field->result_type() != INT_RESULT ||
+          raw_inner_field->result_type() != INT_RESULT) {
+        LDB_COL_REJECT("semijoin key type");
+      }
+
+      const Field *outer_field =
+          ResolveBaseField(raw_outer_field, tables[outer_table].table);
+      const Field *inner_field =
+          ResolveBaseField(raw_inner_field, tables[inner_key_table].table);
+      if (outer_field == nullptr || inner_field == nullptr) {
+        LDB_COL_REJECT("semijoin key unresolvable");
+      }
+
+      auto *build_key = join_node->add_build_keys();
+      build_key->set_table_idx(static_cast<uint32_t>(inner_table));
+      build_key->set_column(inner_field->field_index());
+      auto *probe_key = join_node->add_probe_keys();
+      probe_key->set_table_idx(static_cast<uint32_t>(outer_table));
+      probe_key->set_column(outer_field->field_index());
+    }
+
+    if (!semijoin.residual_predicates.empty()) {
+      TupleColumnRegistry registry;
+      registry.table_of = [&](const Field *field) {
+        return TableIndexOfField(field, tables);
+      };
+      registry.resolve = [&](const Field *field, int table_idx) {
+        return ResolveBaseField(field, tables[table_idx].table);
+      };
+
+      auto *residual = join_node->mutable_residual();
+      auto *predicate = residual->mutable_predicate();
+      auto *expression = predicate->mutable_expr();
+      if (semijoin.residual_predicates.size() == 1) {
+        if (!SerializeTuplePredicate(semijoin.residual_predicates[0],
+                                     expression, &registry)) {
+          LDB_COL_REJECT("semijoin residual not pushable");
+        }
+      } else {
+        expression->set_op(LineairDB::Protocol::FilterExpr::OP_AND);
+        for (Item *residual_predicate : semijoin.residual_predicates) {
+          if (!SerializeTuplePredicate(residual_predicate,
+                                       expression->add_children(),
+                                       &registry)) {
+            LDB_COL_REJECT("semijoin residual not pushable");
+          }
+        }
+      }
+
+      predicate->set_num_columns(registry.columns.size());
+      for (const auto &column_ref : registry.columns) {
+        auto *column = residual->add_columns();
+        column->set_table_idx(static_cast<uint32_t>(column_ref.first));
+        column->set_column(column_ref.second->field_index());
+      }
+    }
+
     current_node = request.nodes_size() - 1;
   }
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1295,12 +1295,16 @@ bool BuildQueryBlockRequest(
   };
 
   // The request table order is the stable numbering used by scan, join,
-  // grouping, and aggregate argument references.
+  // grouping, and aggregate argument references. Real loaded tables come
+  // first; derived tables follow them and become server-side virtual tables.
   std::vector<QueryBlockTable> tables;
   std::vector<int> main_tables;
   std::vector<int> table_semijoin_nest;
+  std::vector<bool> table_is_virtual;
+  std::vector<Query_block *> virtual_blocks;
   for (Table_ref *table_ref = qb->leaf_tables; table_ref != nullptr;
        table_ref = table_ref->next_leaf) {
+    if (table_ref->is_view_or_derived()) continue;
     TABLE *table = table_ref->table;
     if (table == nullptr || table->s == nullptr) LDB_COL_REJECT("no TABLE");
     const int semijoin_nest = semijoin_nest_of(table_ref);
@@ -1310,6 +1314,7 @@ bool BuildQueryBlockRequest(
       LDB_COL_REJECT("not SECONDARY_LOADed");
     tables.push_back({table, table_ref->map()});
     table_semijoin_nest.push_back(semijoin_nest);
+    table_is_virtual.push_back(false);
     if (semijoin_nest < 0) {
       main_tables.push_back(static_cast<int>(tables.size()) - 1);
     } else {
@@ -1317,7 +1322,38 @@ bool BuildQueryBlockRequest(
           static_cast<int>(tables.size()) - 1);
     }
   }
+
+  const size_t real_table_count = tables.size();
+  for (Table_ref *table_ref = qb->leaf_tables; table_ref != nullptr;
+       table_ref = table_ref->next_leaf) {
+    if (!table_ref->is_view_or_derived()) continue;
+    if (table_ref->outer_join) LDB_COL_REJECT("outer derived table");
+    if (semijoin_nest_of(table_ref) >= 0) LDB_COL_REJECT("derived semijoin");
+    if (table_ref->table == nullptr) LDB_COL_REJECT("derived no TABLE");
+
+    Query_expression *derived_unit = table_ref->derived_query_expression();
+    if (derived_unit == nullptr || !derived_unit->is_simple())
+      LDB_COL_REJECT("derived not simple");
+    Query_block *derived_qb = derived_unit->first_query_block();
+    if (derived_qb == nullptr) LDB_COL_REJECT("derived no query block");
+
+    tables.push_back({table_ref->table, table_ref->map()});
+    table_semijoin_nest.push_back(-1);
+    table_is_virtual.push_back(true);
+    virtual_blocks.push_back(derived_qb);
+    main_tables.push_back(static_cast<int>(tables.size()) - 1);
+  }
   if (main_tables.empty()) LDB_COL_REJECT("no tables");
+
+  auto resolve_query_field = [&](const Field *field,
+                                 int table_idx) -> const Field * {
+    if (table_idx < 0 ||
+        table_idx >= static_cast<int>(table_is_virtual.size())) {
+      return nullptr;
+    }
+    if (table_is_virtual[table_idx]) return field;
+    return ResolveBaseField(field, tables[table_idx].table);
+  };
 
   struct JoinEdge {
     int left_table = -1;
@@ -1343,11 +1379,24 @@ bool BuildQueryBlockRequest(
     const table_map used = predicate->used_tables() & ~PSEUDO_TABLE_BITS;
     const int table_idx = SingleTableOf(used, tables);
     if (table_idx >= 0) {
+      if (table_is_virtual[table_idx]) {
+        tuple_predicates.push_back(predicate);
+        continue;
+      }
       table_filters[table_idx].push_back(predicate);
       continue;
     }
     if (used == 0) {
-      table_filters[main_tables[0]].push_back(predicate);
+      auto real_filter_table =
+          std::find_if(main_tables.begin(), main_tables.end(),
+                       [&](int candidate) {
+                         return !table_is_virtual[candidate];
+                       });
+      if (real_filter_table != main_tables.end()) {
+        table_filters[*real_filter_table].push_back(predicate);
+      } else {
+        tuple_predicates.push_back(predicate);
+      }
       continue;
     }
 
@@ -1432,9 +1481,9 @@ bool BuildQueryBlockRequest(
           }
 
           const Field *left_field =
-              ResolveBaseField(candidate.first, tables[left_table].table);
+              resolve_query_field(candidate.first, left_table);
           const Field *right_field =
-              ResolveBaseField(candidate.second, tables[right_table].table);
+              resolve_query_field(candidate.second, right_table);
           if (left_field == nullptr || right_field == nullptr) continue;
           join_edges.push_back(
               {left_table, right_table, left_field, right_field});
@@ -1470,14 +1519,13 @@ bool BuildQueryBlockRequest(
       LDB_COL_REJECT("non-integer join key");
     }
 
-    const Field *left_field =
-        ResolveBaseField(left_raw, tables[left_table].table);
-    const Field *right_field =
-        ResolveBaseField(right_raw, tables[right_table].table);
+    const Field *left_field = resolve_query_field(left_raw, left_table);
+    const Field *right_field = resolve_query_field(right_raw, right_table);
     if (left_field == nullptr || right_field == nullptr) {
       LDB_COL_REJECT("join key unresolvable");
     }
-    if (left_field->is_nullable() || right_field->is_nullable()) {
+    if ((!table_is_virtual[left_table] && left_field->is_nullable()) ||
+        (!table_is_virtual[right_table] && right_field->is_nullable())) {
       LDB_COL_REJECT("join key nullable");
     }
     join_edges.push_back({left_table, right_table, left_field, right_field});
@@ -1489,7 +1537,7 @@ bool BuildQueryBlockRequest(
   auto &request = *request_out;
   request.Clear();
   std::vector<int> scan_nodes(tables.size(), -1);
-  for (size_t table_idx = 0; table_idx < tables.size(); table_idx++) {
+  for (size_t table_idx = 0; table_idx < real_table_count; table_idx++) {
     TABLE *table = tables[table_idx].table;
     request.add_tables()->set_table_name(table->s->normalized_path.str);
     auto *scan_node = request.add_nodes();
@@ -1501,6 +1549,17 @@ bool BuildQueryBlockRequest(
                                scan->mutable_filter())) {
       LDB_COL_REJECT("filter not pushable");
     }
+  }
+
+  for (size_t table_idx = real_table_count; table_idx < tables.size();
+       table_idx++) {
+    auto *sub_block = request.add_nodes()->mutable_sub_block();
+    if (!BuildQueryBlockRequest(
+            nullptr, virtual_blocks[table_idx - real_table_count],
+            sub_block->mutable_block(), why)) {
+      return false;
+    }
+    scan_nodes[table_idx] = request.nodes_size() - 1;
   }
 
   // Build a left-deep INNER join tree by walking FROM order and retrying tables
@@ -1579,7 +1638,7 @@ bool BuildQueryBlockRequest(
       return TableIndexOfField(field, tables);
     };
     registry.resolve = [&](const Field *field, int table_idx) {
-      return ResolveBaseField(field, tables[table_idx].table);
+      return resolve_query_field(field, table_idx);
     };
 
     auto *predicate = tuple_filter->mutable_predicate();
@@ -1654,9 +1713,9 @@ bool BuildQueryBlockRequest(
       }
 
       const Field *outer_field =
-          ResolveBaseField(raw_outer_field, tables[outer_table].table);
+          resolve_query_field(raw_outer_field, outer_table);
       const Field *inner_field =
-          ResolveBaseField(raw_inner_field, tables[inner_key_table].table);
+          resolve_query_field(raw_inner_field, inner_key_table);
       if (outer_field == nullptr || inner_field == nullptr) {
         LDB_COL_REJECT("semijoin key unresolvable");
       }
@@ -1675,7 +1734,7 @@ bool BuildQueryBlockRequest(
         return TableIndexOfField(field, tables);
       };
       registry.resolve = [&](const Field *field, int table_idx) {
-        return ResolveBaseField(field, tables[table_idx].table);
+        return resolve_query_field(field, table_idx);
       };
 
       auto *residual = join_node->mutable_residual();
@@ -1724,10 +1783,10 @@ bool BuildQueryBlockRequest(
     if (const Field *year_field = ExtractYearField(group_item)) {
       const int group_table = TableIndexOfField(year_field, tables);
       const Field *group_field =
-          group_table >= 0
-              ? ResolveBaseField(year_field, tables[group_table].table)
-              : nullptr;
-      if (group_field == nullptr || group_field->is_nullable()) {
+          group_table >= 0 ? resolve_query_field(year_field, group_table)
+                           : nullptr;
+      if (group_field == nullptr ||
+          (!table_is_virtual[group_table] && group_field->is_nullable())) {
         LDB_COL_REJECT("group year column");
       }
 
@@ -1748,10 +1807,11 @@ bool BuildQueryBlockRequest(
     const int group_table = TableIndexOfField(raw_group_field, tables);
     if (group_table < 0) LDB_COL_REJECT("group column foreign");
     const Field *group_field =
-        ResolveBaseField(raw_group_field, tables[group_table].table);
+        resolve_query_field(raw_group_field, group_table);
     if (group_field == nullptr) LDB_COL_REJECT("group column foreign");
-    if (group_field->is_nullable() ||
-        !GroupColumnIsBinarySafe(group_field)) {
+    if ((!table_is_virtual[group_table] && group_field->is_nullable()) ||
+        (!table_is_virtual[group_table] &&
+         !GroupColumnIsBinarySafe(group_field))) {
       LDB_COL_REJECT("group column not binary-safe");
     }
 
@@ -1794,10 +1854,11 @@ bool BuildQueryBlockRequest(
             const int count_table = TableIndexOfField(raw_count_field, tables);
             const Field *count_field =
                 count_table >= 0
-                    ? ResolveBaseField(raw_count_field,
-                                       tables[count_table].table)
+                    ? resolve_query_field(raw_count_field, count_table)
                     : nullptr;
-            if (count_field == nullptr || count_field->is_nullable()) {
+            if (count_field == nullptr ||
+                (!table_is_virtual[count_table] &&
+                 count_field->is_nullable())) {
               aggregate_error = "COUNT arg nullable";
               return -1;
             }
@@ -1866,8 +1927,8 @@ bool BuildQueryBlockRequest(
                 then_expr->real_item()->type() == Item::FIELD_ITEM) {
               const Field *raw_argument_field =
                   down_cast<Item_field *>(then_expr->real_item())->field;
-              const Field *argument_field = ResolveBaseField(
-                  raw_argument_field, tables[argument_table].table);
+              const Field *argument_field =
+                  resolve_query_field(raw_argument_field, argument_table);
               if (argument_field == nullptr) {
                 aggregate_error = "CASE expression unresolvable";
                 return -1;
@@ -1912,8 +1973,8 @@ bool BuildQueryBlockRequest(
         if (argument_table >= 0 && arg->type() == Item::FIELD_ITEM) {
           const Field *raw_argument_field =
               down_cast<Item_field *>(arg)->field;
-          const Field *argument_field = ResolveBaseField(
-              raw_argument_field, tables[argument_table].table);
+          const Field *argument_field =
+              resolve_query_field(raw_argument_field, argument_table);
           if (argument_field == nullptr) {
             aggregate_error = "aggregate arg unresolvable";
             return -1;
@@ -1964,18 +2025,19 @@ bool BuildQueryBlockRequest(
             TableIndexOfField(raw_argument_field, tables);
         const Field *argument_field =
             argument_table >= 0
-                ? ResolveBaseField(raw_argument_field,
-                                   tables[argument_table].table)
+                ? resolve_query_field(raw_argument_field, argument_table)
                 : nullptr;
         if (argument_field == nullptr) {
           aggregate_error = "minmax unresolvable";
           return -1;
         }
-        if (argument_field->is_nullable()) {
+        if (!table_is_virtual[argument_table] &&
+            argument_field->is_nullable()) {
           aggregate_error = "minmax nullable";
           return -1;
         }
-        if (argument_field->result_type() == STRING_RESULT &&
+        if (!table_is_virtual[argument_table] &&
+            argument_field->result_type() == STRING_RESULT &&
             !argument_field->binary()) {
           aggregate_error = "minmax collation";
           return -1;
@@ -2074,8 +2136,7 @@ bool BuildQueryBlockRequest(
       const int output_table = TableIndexOfField(raw_output_field, tables);
       const Field *output_field =
           output_table >= 0
-              ? ResolveBaseField(raw_output_field,
-                                 tables[output_table].table)
+              ? resolve_query_field(raw_output_field, output_table)
               : nullptr;
       if (output_field == nullptr)
         LDB_COL_REJECT("output column unresolvable");
@@ -2193,7 +2254,7 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
   if (qb->leaf_tables != nullptr && qb->leaf_tables->next_leaf == nullptr &&
       qb->leaf_tables->is_view_or_derived()) {
     if (RecognizeDerivedRegroup(join, ctx, why)) return true;
-    return RecognizeFlattenedAggregate(join, ctx, why);
+    if (RecognizeFlattenedAggregate(join, ctx, why)) return true;
   }
 
   if (!BuildQueryBlockRequest(join, qb, &ctx->query_block_request, why)) {

--- a/proxy/lineairdb_pushdown.cc
+++ b/proxy/lineairdb_pushdown.cc
@@ -36,6 +36,12 @@
 // Predicate Pushdown: serialize MySQL Item tree → FilterExpr protobuf
 // ---------------------------------------------------------------------------
 
+static thread_local const SerializeColumnEncoder *g_column_encoder = nullptr;
+
+void set_serialize_column_encoder(const SerializeColumnEncoder *encoder) {
+  g_column_encoder = encoder;
+}
+
 const Item *ha_lineairdb::cond_push(const Item *cond) {
   DBUG_TRACE;
   pushed_filter_serialized_.clear();
@@ -61,6 +67,13 @@ const Item *ha_lineairdb::cond_push(const Item *cond) {
 bool serialize_item(const Item *item,
                     LineairDB::Protocol::FilterExpr *expr) {
   if (!item) return false;
+
+  // View and derived-table references point at the item that should be
+  // serialized.
+  if (item->type() == Item::REF_ITEM) {
+    const Item *real = const_cast<Item *>(item)->real_item();
+    if (real != nullptr && real != item) return serialize_item(real, expr);
+  }
 
   // Unwrap constant-propagation caches before reading their value.
   if (item->type() == Item::CACHE_ITEM) {
@@ -193,7 +206,13 @@ bool serialize_item(const Item *item,
       Field *field = field_item->field;
       if (!field) return false;
       expr->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
-      expr->set_column_index(field->field_index());
+      if (g_column_encoder != nullptr) {
+        const int encoded = (*g_column_encoder)(field);
+        if (encoded < 0) return false;
+        expr->set_column_index(static_cast<uint32_t>(encoded));
+      } else {
+        expr->set_column_index(field->field_index());
+      }
 
       // Set compare_type based on MySQL field type
       switch (field->result_type()) {

--- a/proxy/lineairdb_pushdown.hh
+++ b/proxy/lineairdb_pushdown.hh
@@ -1,17 +1,31 @@
 #ifndef LINEAIRDB_PUSHDOWN_HH
 #define LINEAIRDB_PUSHDOWN_HH
 
+#include <functional>
 #include <string>
 
 #include "lineairdb.pb.h"
 
 class Item;
+class Field;
 class THD;
 struct TABLE;
 class LineairDBTransaction;
 
 bool serialize_item(const Item *item,
                     LineairDB::Protocol::FilterExpr *expr);
+
+using SerializeColumnEncoder = std::function<int(const Field *)>;
+
+/**
+ * @brief Install a statement-local column encoder for predicate serialization.
+ *
+ * @details When unset, `serialize_item()` encodes `Item_field` references as
+ * the field index within one table. Joined tuple predicates can set this hook
+ * while serializing so each field becomes an ordinal in a tuple-wide column
+ * registry.
+ */
+void set_serialize_column_encoder(const SerializeColumnEncoder *encoder);
 
 bool prepare_select_filter_for_tx(THD *thd, TABLE *table,
                                   LineairDBTransaction *tx,

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -19,6 +19,8 @@ else
   echo "WARNING: jemalloc not found, using system malloc (apt install libjemalloc2)" >&2
 fi
 
+export HELIOS_PAX_STORAGE=1
+
 if [ ! -x "$BIN" ]; then
   echo "ERROR: binary not found: $BIN" >&2
   echo "Hint: build it via: bash scripts/build.sh (or build_partial.sh)" >&2
@@ -39,4 +41,3 @@ echo $PID > "$PID_FILE"
 echo "Started lineairdb-server with PID $PID"
 echo "Logs: $LOG_FILE"
 echo "PID file: $PID_FILE"
-

--- a/server/rpc/predicate_evaluator.cc
+++ b/server/rpc/predicate_evaluator.cc
@@ -92,6 +92,20 @@ bool PredicateEvaluator::set_row_from_pax(
   return true;
 }
 
+void PredicateEvaluator::set_row_from_views(
+    const std::vector<std::string_view>& cells,
+    const std::vector<bool>& nulls) {
+  columns_.assign(cells.begin(), cells.end());
+  null_flags_.assign((columns_.size() + 7) / 8, 0);
+  for (size_t idx = 0; idx < nulls.size() && idx < columns_.size(); ++idx) {
+    if (nulls[idx]) {
+      null_flags_[idx / 8] =
+          static_cast<char>(static_cast<unsigned char>(null_flags_[idx / 8]) |
+                            (1u << (idx % 8)));
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Value extraction
 // ---------------------------------------------------------------------------

--- a/server/rpc/predicate_evaluator.hh
+++ b/server/rpc/predicate_evaluator.hh
@@ -39,6 +39,15 @@ class PredicateEvaluator {
   bool set_row_from_pax(const LineairDB::Pax::PaxGroup& group, uint32_t slot,
                         uint32_t num_columns);
 
+  /**
+   * @brief Read predicate inputs from already decoded column views.
+   *
+   * Joined tuple filters build a compact row consisting only of the columns
+   * referenced by the predicate. `nulls[i]` marks SQL NULL for `cells[i]`.
+   */
+  void set_row_from_views(const std::vector<std::string_view>& cells,
+                          const std::vector<bool>& nulls);
+
   // Recursively evaluate a FilterExpr tree against the parsed row.
   // Returns true if the row satisfies the predicate.
   bool evaluate(const LineairDB::Protocol::FilterExpr& expr) const;

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -197,6 +197,13 @@ class Executor {
                 }
                 continue;
             }
+            if (node.has_filter()) {
+                if (node.filter().input() >=
+                    static_cast<uint32_t>(node_idx)) {
+                    return fail("tuple filter child order");
+                }
+                continue;
+            }
             if (node.has_aggregate()) {
                 if (node.aggregate().input() >=
                     static_cast<uint32_t>(node_idx)) {
@@ -223,6 +230,16 @@ class Executor {
         const int position = input.table_pos(table_idx);
         if (position < 0) return PaxRowRef{};
         return ToRowRef(table_idx, input.refs[position][row_idx]);
+    }
+
+    static bool IsNullColumn(const PaxRowRef& row, uint32_t column_idx) {
+        if (row.group == nullptr) return true;
+        const std::string_view null_flags = row.group->cell(0, row.slot);
+        const size_t byte_idx = column_idx / 8;
+        const uint32_t bit_idx = column_idx % 8;
+        return byte_idx < null_flags.size() &&
+               (static_cast<unsigned char>(null_flags[byte_idx]) &
+                (1u << bit_idx)) != 0;
     }
 
     static DecodedColumnRef DecodeAggregateColumnRef(
@@ -437,6 +454,140 @@ class Executor {
         for (const std::vector<uint64_t>& refs : local_refs) {
             output->refs[0].insert(output->refs[0].end(), refs.begin(),
                                    refs.end());
+        }
+        return true;
+    }
+
+    struct TupleFilterColumn {
+        int ref_position = -1;
+        uint32_t table_idx = 0;
+        uint32_t column = 0;
+    };
+
+    bool ResolveTupleFilterColumns(
+        const pb::QueryBlockTupleFilter& filter, const NodeResult& input,
+        std::vector<TupleFilterColumn>* columns) {
+        if (!filter.has_predicate() || !filter.predicate().has_expr()) {
+            return fail("tuple filter predicate missing");
+        }
+        if (filter.predicate().num_columns() !=
+            static_cast<uint32_t>(filter.columns_size())) {
+            return fail("tuple filter column count");
+        }
+
+        columns->clear();
+        columns->reserve(filter.columns_size());
+        for (const pb::QueryBlockColumnRef& column : filter.columns()) {
+            const int position = input.table_pos(column.table_idx());
+            if (position < 0) return fail("tuple filter table");
+            columns->push_back(
+                TupleFilterColumn{position, column.table_idx(),
+                                  column.column()});
+        }
+        return true;
+    }
+
+    bool BuildTupleFilterRow(
+        const NodeResult& input,
+        const std::vector<TupleFilterColumn>& columns, size_t row_idx,
+        std::vector<std::string_view>* cells,
+        std::vector<bool>* nulls) const {
+        cells->resize(columns.size());
+        nulls->resize(columns.size());
+        for (size_t column_idx = 0; column_idx < columns.size();
+             ++column_idx) {
+            const TupleFilterColumn& column = columns[column_idx];
+            const uint64_t ref = input.refs[column.ref_position][row_idx];
+            if (ref == kNullRowRef) {
+                (*cells)[column_idx] = {};
+                (*nulls)[column_idx] = true;
+                continue;
+            }
+
+            const PaxRowRef row = ToRowRef(column.table_idx, ref);
+            if (row.group == nullptr) return false;
+            (*cells)[column_idx] =
+                extract_value_column(row, static_cast<int>(column.column));
+            (*nulls)[column_idx] = IsNullColumn(row, column.column);
+        }
+        return true;
+    }
+
+    bool RunTupleFilter(const pb::QueryBlockTupleFilterNode& filter,
+                        NodeResult* output) {
+        if (filter.input() >= results_.size()) {
+            return fail("tuple filter child out of range");
+        }
+        const NodeResult& input = results_[filter.input()];
+
+        std::vector<TupleFilterColumn> columns;
+        if (!ResolveTupleFilterColumns(filter.filter(), input, &columns)) {
+            return false;
+        }
+
+        output->tables = input.tables;
+        output->refs.assign(input.refs.size(), {});
+        const size_t input_rows = input.rows();
+        const unsigned worker_count = static_cast<unsigned>(std::min<size_t>(
+            WorkerCount(), std::max<size_t>(input_rows / 16384, 1)));
+
+        struct WorkerOutput {
+            std::vector<std::vector<uint64_t>> refs;
+        };
+        std::vector<WorkerOutput> local_outputs(worker_count);
+        std::vector<char> worker_failed(worker_count, 0);
+        std::vector<std::thread> workers;
+        workers.reserve(worker_count);
+
+        for (unsigned worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+            workers.emplace_back([&, worker_idx] {
+                PredicateEvaluator evaluator;
+                std::vector<std::string_view> cells;
+                std::vector<bool> nulls;
+                WorkerOutput& local = local_outputs[worker_idx];
+                local.refs.assign(input.refs.size(), {});
+                const size_t begin = input_rows * worker_idx / worker_count;
+                const size_t end =
+                    input_rows * (worker_idx + 1) / worker_count;
+                for (size_t row_idx = begin; row_idx < end; ++row_idx) {
+                    if (!BuildTupleFilterRow(input, columns, row_idx, &cells,
+                                             &nulls)) {
+                        worker_failed[worker_idx] = 1;
+                        return;
+                    }
+                    evaluator.set_row_from_views(cells, nulls);
+                    if (!evaluator.evaluate(filter.filter().predicate()
+                                                .expr())) {
+                        continue;
+                    }
+                    for (size_t column_idx = 0; column_idx < input.refs.size();
+                         ++column_idx) {
+                        local.refs[column_idx].push_back(
+                            input.refs[column_idx][row_idx]);
+                    }
+                }
+            });
+        }
+
+        for (std::thread& worker : workers) worker.join();
+        for (char failed : worker_failed) {
+            if (failed) return fail("tuple filter cannot read PAX columns");
+        }
+
+        size_t total_rows = 0;
+        for (const WorkerOutput& local : local_outputs) {
+            total_rows += local.refs.empty() ? 0 : local.refs[0].size();
+        }
+        for (size_t column_idx = 0; column_idx < output->refs.size();
+             ++column_idx) {
+            output->refs[column_idx].reserve(total_rows);
+            for (const WorkerOutput& local : local_outputs) {
+                if (local.refs.empty()) continue;
+                output->refs[column_idx].insert(
+                    output->refs[column_idx].end(),
+                    local.refs[column_idx].begin(),
+                    local.refs[column_idx].end());
+            }
         }
         return true;
     }
@@ -1201,6 +1352,12 @@ class Executor {
             }
             if (node.has_join()) {
                 if (!RunJoin(node.join(), &results_[node_idx])) return false;
+                continue;
+            }
+            if (node.has_filter()) {
+                if (!RunTupleFilter(node.filter(), &results_[node_idx])) {
+                    return false;
+                }
                 continue;
             }
             if (node.has_aggregate()) {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -686,7 +686,9 @@ class Executor {
     bool RunJoin(const pb::QueryBlockJoin& join, NodeResult* output) {
         const bool is_inner = join.type() == pb::QueryBlockJoin::INNER;
         const bool is_left = join.type() == pb::QueryBlockJoin::LEFT;
-        if (!is_inner && !is_left) {
+        const bool is_semi = join.type() == pb::QueryBlockJoin::SEMI;
+        const bool is_anti = join.type() == pb::QueryBlockJoin::ANTI;
+        if (!is_inner && !is_left && !is_semi && !is_anti) {
             return fail("unsupported query-block join type");
         }
         if (join.build_keys_size() != join.probe_keys_size() ||
@@ -697,9 +699,9 @@ class Executor {
             return fail("join child out of range");
         }
 
-        // INNER joins are symmetric; hash the smaller child at runtime. LEFT
-        // joins keep the request's build/probe sides because probe rows must be
-        // preserved when the build side has no match.
+        // INNER joins are symmetric; hash the smaller child at runtime. LEFT,
+        // SEMI, and ANTI keep the request's build/probe sides because their
+        // output semantics are defined by the probe side.
         const bool swap =
             is_inner &&
             results_[join.build()].rows() > results_[join.probe()].rows();
@@ -729,7 +731,7 @@ class Executor {
             join.has_residual() && join.residual().has_predicate() &&
             join.residual().predicate().has_expr();
         if (has_residual) {
-            if (!is_inner) return fail("residual on non-inner join");
+            if (is_left) return fail("residual on LEFT join");
             if (join.residual().predicate().num_columns() !=
                 static_cast<uint32_t>(join.residual().columns_size())) {
                 return fail("join residual column count");
@@ -765,9 +767,12 @@ class Executor {
 
         // Keep only row references in the joined tuple; later operators read
         // column values directly from each table's PAX strips.
+        const bool keep_build = is_inner || is_left;
         output->tables = probe.tables;
-        output->tables.insert(output->tables.end(), build.tables.begin(),
-                              build.tables.end());
+        if (keep_build) {
+            output->tables.insert(output->tables.end(),
+                                  build.tables.begin(), build.tables.end());
+        }
         output->refs.assign(output->tables.size(), {});
 
         struct WorkerOutput {
@@ -833,7 +838,47 @@ class Executor {
                     const auto match = has_probe_key
                                            ? hash_table.find(probe_key)
                                            : hash_table.end();
+                    bool matched =
+                        match != hash_table.end() && !match->second.empty();
+                    if (matched && has_residual) {
+                        matched = false;
+                        for (const size_t build_idx : match->second) {
+                            if (residual_ok(probe_idx, build_idx)) {
+                                matched = true;
+                                break;
+                            }
+                        }
+                    }
+
                     if (match == hash_table.end()) {
+                        if (!is_left && !is_anti) continue;
+                        for (size_t column_idx = 0;
+                             column_idx < probe.tables.size(); ++column_idx) {
+                            local.refs[column_idx].push_back(
+                                probe.refs[column_idx][probe_idx]);
+                        }
+                        if (is_anti) continue;
+                        for (size_t column_idx = 0;
+                             column_idx < build.tables.size(); ++column_idx) {
+                            local.refs[probe.tables.size() + column_idx]
+                                .push_back(kNullRowRef);
+                        }
+                        continue;
+                    }
+
+                    if (is_semi || is_anti) {
+                        if (matched == is_semi) {
+                            for (size_t column_idx = 0;
+                                 column_idx < probe.tables.size();
+                                 ++column_idx) {
+                                local.refs[column_idx].push_back(
+                                    probe.refs[column_idx][probe_idx]);
+                            }
+                        }
+                        continue;
+                    }
+
+                    if (!matched) {
                         if (!is_left) continue;
                         for (size_t column_idx = 0;
                              column_idx < probe.tables.size(); ++column_idx) {
@@ -849,7 +894,10 @@ class Executor {
                     }
 
                     for (const size_t build_idx : match->second) {
-                        if (!residual_ok(probe_idx, build_idx)) continue;
+                        if (has_residual &&
+                            !residual_ok(probe_idx, build_idx)) {
+                            continue;
+                        }
                         for (size_t column_idx = 0;
                              column_idx < probe.tables.size(); ++column_idx) {
                             local.refs[column_idx].push_back(

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -1750,6 +1750,60 @@ class Executor {
         }
     }
 
+    bool RunEmitRows(
+        const NodeResult& input,
+        pb::TxExecuteQueryBlock::Response* response) {
+        std::vector<int> output_positions(request_.output_size(), -1);
+        for (int output_idx = 0; output_idx < request_.output_size();
+             ++output_idx) {
+            const pb::QueryBlockOutputExpr& expression =
+                request_.output(output_idx);
+            if (expression.source() != pb::QueryBlockOutputExpr::COLUMN) {
+                return fail("row output source");
+            }
+            output_positions[output_idx] =
+                input.table_pos(expression.column().table_idx());
+            if (output_positions[output_idx] < 0) {
+                return fail("row output table is not in input");
+            }
+        }
+
+        std::vector<OutputRow> output_rows;
+        output_rows.reserve(input.rows());
+        for (size_t row_idx = 0; row_idx < input.rows(); ++row_idx) {
+            OutputRow row;
+            row.values.reserve(request_.output_size());
+            row.nulls.reserve(request_.output_size());
+
+            for (int output_idx = 0; output_idx < request_.output_size();
+                 ++output_idx) {
+                const pb::QueryBlockColumnRef& column =
+                    request_.output(output_idx).column();
+                const uint64_t ref =
+                    input.refs[output_positions[output_idx]][row_idx];
+                if (NullOf(column.table_idx(), ref, column.column())) {
+                    row.values.emplace_back();
+                    row.nulls.push_back(true);
+                    continue;
+                }
+
+                std::string_view value =
+                    ValueOf(column.table_idx(), ref, column.column());
+                if (column.prefix_len() > 0 &&
+                    value.size() > column.prefix_len()) {
+                    value = value.substr(0, column.prefix_len());
+                }
+                row.values.emplace_back(value);
+                row.nulls.push_back(false);
+            }
+            output_rows.push_back(std::move(row));
+        }
+
+        if (!SortOutputRows(&output_rows)) return false;
+        EmitOutputRows(output_rows, response);
+        return true;
+    }
+
     bool RunAggregateAndEmit(
         const pb::QueryBlockAggregate& aggregate,
         pb::TxExecuteQueryBlock::Response* response) {
@@ -1947,7 +2001,8 @@ class Executor {
             }
             return fail("unknown query-block node");
         }
-        return fail("root must be an aggregate node");
+        if (request_.nodes_size() == 0) return fail("root node missing");
+        return RunEmitRows(results_.back(), response);
     }
 
     bool TablesAreStillQuiet() const {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <exception>
 #include <limits>
+#include <set>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -1080,6 +1081,7 @@ class Executor {
         std::vector<DecimalValue> decimals;
         std::vector<std::string> strings;
         std::vector<bool> has_value;
+        std::vector<std::set<std::string>> distinct_values;
     };
 
     struct OutputRow {
@@ -1206,6 +1208,7 @@ class Executor {
                 new_state.decimals.assign(aggregate_count, DecimalValue{});
                 new_state.strings.assign(aggregate_count, {});
                 new_state.has_value.assign(aggregate_count, false);
+                new_state.distinct_values.resize(aggregate_count);
                 state = &groups->emplace(std::move(key_buffer),
                                          std::move(new_state))
                              .first->second;
@@ -1246,6 +1249,17 @@ class Executor {
 
                 switch (function.kind()) {
                     case pb::QueryBlockAggFunc::COUNT:
+                        if (function.distinct()) {
+                            if (!function.has_arg() || !has_arg_row) break;
+                            std::string_view value;
+                            if (ReadAggregateColumn(
+                                    function.arg(), input, row_idx,
+                                    function.arg_table(), &value)) {
+                                state->distinct_values[aggregate_idx].emplace(
+                                    value);
+                            }
+                            break;
+                        }
                         if (function.has_arg() && !has_arg_row) break;
                         state->counts[aggregate_idx] += 1;
                         break;
@@ -1332,6 +1346,12 @@ class Executor {
                     aggregate.aggs(aggregate_idx);
                 switch (function.kind()) {
                     case pb::QueryBlockAggFunc::COUNT:
+                        if (function.distinct()) {
+                            destination_state.distinct_values[aggregate_idx]
+                                .merge(source_state
+                                           .distinct_values[aggregate_idx]);
+                            break;
+                        }
                         destination_state.counts[aggregate_idx] +=
                             source_state.counts[aggregate_idx];
                         break;
@@ -1393,7 +1413,10 @@ class Executor {
         *is_null = false;
         switch (function.kind()) {
             case pb::QueryBlockAggFunc::COUNT:
-                return std::to_string(state.counts[aggregate_idx]);
+                return std::to_string(
+                    function.distinct()
+                        ? state.distinct_values[aggregate_idx].size()
+                        : state.counts[aggregate_idx]);
             case pb::QueryBlockAggFunc::SUM:
                 if (state.counts[aggregate_idx] == 0) {
                     if (function.zero_if_empty()) {
@@ -1774,7 +1797,51 @@ class Executor {
             state.decimals.assign(aggregate.aggs_size(), DecimalValue{});
             state.strings.assign(aggregate.aggs_size(), {});
             state.has_value.assign(aggregate.aggs_size(), false);
+            state.distinct_values.resize(aggregate.aggs_size());
             groups.emplace(std::string(), std::move(state));
+        }
+
+        // HAVING predicates read the first-stage aggregate row layout:
+        // group values first, then aggregate values.
+        if (aggregate.has_having() && aggregate.having().has_expr()) {
+            PredicateEvaluator evaluator;
+            std::vector<std::string> values;
+            std::vector<std::string_view> cells;
+            std::vector<bool> nulls;
+            for (auto group_it = groups.begin(); group_it != groups.end();) {
+                const GroupState& state = group_it->second;
+                values.clear();
+                cells.clear();
+                nulls.clear();
+                values.reserve(group_count + aggregate.aggs_size());
+                cells.reserve(group_count + aggregate.aggs_size());
+                nulls.reserve(group_count + aggregate.aggs_size());
+
+                for (int group_idx = 0; group_idx < group_count;
+                     ++group_idx) {
+                    values.push_back(state.keys[group_idx]);
+                    nulls.push_back(false);
+                }
+                for (int aggregate_idx = 0;
+                     aggregate_idx < aggregate.aggs_size();
+                     ++aggregate_idx) {
+                    bool is_null = false;
+                    values.push_back(AggregateValue(
+                        aggregate.aggs(aggregate_idx), state,
+                        aggregate_idx, &is_null));
+                    nulls.push_back(is_null);
+                }
+                for (const std::string& value : values) {
+                    cells.push_back(value);
+                }
+
+                evaluator.set_row_from_views(cells, nulls);
+                if (evaluator.evaluate(aggregate.having().expr())) {
+                    ++group_it;
+                } else {
+                    group_it = groups.erase(group_it);
+                }
+            }
         }
 
         std::vector<OutputRow> output_rows;

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -667,6 +667,41 @@ class Executor {
             return fail("probe key table is not in join input");
         }
 
+        struct ResidualColumn {
+            bool from_build = false;
+            int ref_position = -1;
+            uint32_t table_idx = 0;
+            uint32_t column = 0;
+        };
+
+        std::vector<ResidualColumn> residual_columns;
+        const bool has_residual =
+            join.has_residual() && join.residual().has_predicate() &&
+            join.residual().predicate().has_expr();
+        if (has_residual) {
+            if (!is_inner) return fail("residual on non-inner join");
+            if (join.residual().predicate().num_columns() !=
+                static_cast<uint32_t>(join.residual().columns_size())) {
+                return fail("join residual column count");
+            }
+            residual_columns.reserve(join.residual().columns_size());
+            for (const pb::QueryBlockColumnRef& column :
+                 join.residual().columns()) {
+                int position = probe.table_pos(column.table_idx());
+                if (position >= 0) {
+                    residual_columns.push_back(
+                        ResidualColumn{false, position, column.table_idx(),
+                                       column.column()});
+                    continue;
+                }
+                position = build.table_pos(column.table_idx());
+                if (position < 0) return fail("join residual table");
+                residual_columns.push_back(
+                    ResidualColumn{true, position, column.table_idx(),
+                                   column.column()});
+            }
+        }
+
         // Build a composite byte-key hash table from the chosen build child.
         std::unordered_map<std::string, std::vector<size_t>> hash_table;
         hash_table.reserve(build.rows());
@@ -703,6 +738,42 @@ class Executor {
                 WorkerOutput& local = local_outputs[worker_idx];
                 local.refs.assign(output->tables.size(), {});
                 std::string probe_key;
+                PredicateEvaluator residual_evaluator;
+                std::vector<std::string_view> residual_cells(
+                    residual_columns.size());
+                std::vector<bool> residual_nulls(residual_columns.size());
+                auto residual_ok = [&](size_t probe_idx,
+                                       size_t build_idx) -> bool {
+                    if (!has_residual) return true;
+                    for (size_t column_idx = 0;
+                         column_idx < residual_columns.size();
+                         ++column_idx) {
+                        const ResidualColumn& column =
+                            residual_columns[column_idx];
+                        const NodeResult& source =
+                            column.from_build ? build : probe;
+                        const size_t source_row =
+                            column.from_build ? build_idx : probe_idx;
+                        const uint64_t ref =
+                            source.refs[column.ref_position][source_row];
+                        if (ref == kNullRowRef) {
+                            residual_cells[column_idx] = {};
+                            residual_nulls[column_idx] = true;
+                            continue;
+                        }
+
+                        const PaxRowRef row = ToRowRef(column.table_idx, ref);
+                        if (row.group == nullptr) return false;
+                        residual_cells[column_idx] = extract_value_column(
+                            row, static_cast<int>(column.column));
+                        residual_nulls[column_idx] =
+                            IsNullColumn(row, column.column);
+                    }
+                    residual_evaluator.set_row_from_views(residual_cells,
+                                                          residual_nulls);
+                    return residual_evaluator.evaluate(
+                        join.residual().predicate().expr());
+                };
                 const size_t begin = probe_rows * worker_idx / worker_count;
                 const size_t end =
                     probe_rows * (worker_idx + 1) / worker_count;
@@ -728,6 +799,7 @@ class Executor {
                     }
 
                     for (const size_t build_idx : match->second) {
+                        if (!residual_ok(probe_idx, build_idx)) continue;
                         for (size_t column_idx = 0;
                              column_idx < probe.tables.size(); ++column_idx) {
                             local.refs[column_idx].push_back(

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -873,7 +873,6 @@ class Executor {
             join.has_residual() && join.residual().has_predicate() &&
             join.residual().predicate().has_expr();
         if (has_residual) {
-            if (is_left) return fail("residual on LEFT join");
             if (join.residual().predicate().num_columns() !=
                 static_cast<uint32_t>(join.residual().columns_size())) {
                 return fail("join residual column count");

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -856,6 +856,16 @@ class Executor {
 
     using GroupMap = std::unordered_map<std::string, GroupState>;
 
+    static uint32_t FilterTableForAggregate(
+        const pb::QueryBlockAggFunc& function) {
+        if (!function.has_filter()) return function.arg_table();
+        if (function.kind() == pb::QueryBlockAggFunc::COUNT &&
+            !function.has_arg()) {
+            return function.arg_table();
+        }
+        return function.filter_table();
+    }
+
     bool AccumulateRange(const pb::QueryBlockAggregate& aggregate,
                          const NodeResult& input, size_t begin, size_t end,
                          GroupMap* groups) {
@@ -872,15 +882,24 @@ class Executor {
         }
 
         std::vector<int> aggregate_positions(aggregate_count, -1);
+        std::vector<int> filter_positions(aggregate_count, -1);
         for (int aggregate_idx = 0; aggregate_idx < aggregate_count;
              ++aggregate_idx) {
             const pb::QueryBlockAggFunc& function =
                 aggregate.aggs(aggregate_idx);
-            if (function.has_arg() || function.has_filter()) {
+            if (function.has_arg()) {
                 aggregate_positions[aggregate_idx] =
                     input.table_pos(function.arg_table());
                 if (aggregate_positions[aggregate_idx] < 0) {
                     return fail("aggregate table is not in aggregate input");
+                }
+            }
+            if (function.has_filter()) {
+                filter_positions[aggregate_idx] =
+                    input.table_pos(FilterTableForAggregate(function));
+                if (filter_positions[aggregate_idx] < 0) {
+                    return fail(
+                        "aggregate filter table is not in aggregate input");
                 }
             }
             if (function.has_arg() &&
@@ -941,8 +960,13 @@ class Executor {
                     input_pos < 0 || ref != kNullRowRef;
 
                 if (function.has_filter() && function.filter().has_expr()) {
-                    if (!has_arg_row) continue;
-                    PaxRowRef row = ToRowRef(function.arg_table(), ref);
+                    const int filter_pos = filter_positions[aggregate_idx];
+                    const uint64_t filter_ref =
+                        input.refs[filter_pos][row_idx];
+                    if (filter_ref == kNullRowRef) continue;
+                    const uint32_t filter_table =
+                        FilterTableForAggregate(function);
+                    PaxRowRef row = ToRowRef(filter_table, filter_ref);
                     if (row.group == nullptr ||
                         !evaluator.set_row_from_pax(
                             *row.group, row.slot,
@@ -1106,6 +1130,12 @@ class Executor {
                 return std::to_string(state.counts[aggregate_idx]);
             case pb::QueryBlockAggFunc::SUM:
                 if (state.counts[aggregate_idx] == 0) {
+                    if (function.zero_if_empty()) {
+                        DecimalValue zero;
+                        zero.scale = static_cast<int>(function.arg_scale());
+                        zero.is_null = false;
+                        return format_decimal_value(zero);
+                    }
                     *is_null = true;
                     return {};
                 }

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -72,6 +72,56 @@ DecimalValue divide_decimal_value(const DecimalValue& sum, uint64_t count,
     return result;
 }
 
+DecimalValue divide_decimal_values(const DecimalValue& lhs,
+                                   const DecimalValue& rhs,
+                                   int output_scale) {
+    DecimalValue result;
+    result.is_null = true;
+    if (lhs.is_null || rhs.is_null || rhs.mantissa == 0) return result;
+
+    __int128 numerator = lhs.mantissa;
+    __int128 denominator = rhs.mantissa;
+    bool negative = false;
+    if (numerator < 0) {
+        numerator = -numerator;
+        negative = !negative;
+    }
+    if (denominator < 0) {
+        denominator = -denominator;
+        negative = !negative;
+    }
+
+    // Scale the numerator to keep one extra decimal digit for half-up rounding.
+    const int scale_shift = output_scale + rhs.scale - lhs.scale + 1;
+    if (scale_shift > 0) {
+        numerator *= decimal_power_of_ten(scale_shift);
+    } else if (scale_shift < 0) {
+        numerator /= decimal_power_of_ten(-scale_shift);
+    }
+
+    __int128 quotient = numerator / denominator;
+    quotient = (quotient + 5) / 10;
+    result.mantissa = negative ? -quotient : quotient;
+    result.scale = output_scale;
+    result.is_null = false;
+    return result;
+}
+
+void round_decimal_value(DecimalValue* value, int output_scale) {
+    if (value == nullptr || value->is_null || value->scale <= output_scale) {
+        return;
+    }
+
+    const int drop = value->scale - output_scale;
+    const __int128 divisor = decimal_power_of_ten(drop);
+    __int128 mantissa = value->mantissa;
+    const bool negative = mantissa < 0;
+    if (negative) mantissa = -mantissa;
+    mantissa = (mantissa + divisor / 2) / divisor;
+    value->mantissa = negative ? -mantissa : mantissa;
+    value->scale = output_scale;
+}
+
 void append_result_field(std::string& row, std::string_view payload,
                          bool is_null) {
     if (is_null) {
@@ -1167,6 +1217,128 @@ class Executor {
         }
     }
 
+    bool EvaluateOutputExpression(const pb::FilterExpr& expression,
+                                  const pb::QueryBlockAggregate& aggregate,
+                                  const GroupState& state,
+                                  DecimalValue* result) {
+        if (result == nullptr) return fail("missing output expression result");
+
+        using FE = pb::FilterExpr;
+        switch (expression.op()) {
+            case FE::COLUMN_REF: {
+                const uint32_t ordinal = expression.column_index();
+                const uint32_t group_count =
+                    static_cast<uint32_t>(aggregate.group_columns_size());
+                if (ordinal < group_count) {
+                    *result = parse_decimal_value(state.keys[ordinal]);
+                    return true;
+                }
+
+                const uint32_t aggregate_idx = ordinal - group_count;
+                if (aggregate_idx >=
+                    static_cast<uint32_t>(aggregate.aggs_size())) {
+                    return fail("output expression ordinal out of range");
+                }
+                bool is_null = false;
+                const std::string value = AggregateValue(
+                    aggregate.aggs(aggregate_idx), state,
+                    static_cast<int>(aggregate_idx), &is_null);
+                if (is_null) {
+                    *result = DecimalValue{};
+                    result->is_null = true;
+                    return true;
+                }
+                *result = parse_decimal_value(value);
+                return true;
+            }
+            case FE::CONST_INT:
+                result->mantissa = expression.int_val();
+                result->scale = 0;
+                result->is_null = false;
+                return true;
+            case FE::CONST_UINT:
+                result->mantissa =
+                    static_cast<__int128>(expression.uint_val());
+                result->scale = 0;
+                result->is_null = false;
+                return true;
+            case FE::CONST_STRING:
+                *result = parse_decimal_value(expression.string_val());
+                return true;
+            case FE::CONST_NULL:
+                *result = DecimalValue{};
+                result->is_null = true;
+                return true;
+            case FE::OP_ADD:
+            case FE::OP_SUB: {
+                if (expression.children_size() != 2) {
+                    return fail("output expression arity mismatch");
+                }
+                DecimalValue lhs;
+                DecimalValue rhs;
+                if (!EvaluateOutputExpression(expression.children(0),
+                                              aggregate, state, &lhs) ||
+                    !EvaluateOutputExpression(expression.children(1),
+                                              aggregate, state, &rhs)) {
+                    return false;
+                }
+                if (expression.op() == FE::OP_SUB) {
+                    rhs.mantissa = -rhs.mantissa;
+                }
+                add_decimal_value(lhs, rhs);
+                *result = lhs;
+                return true;
+            }
+            case FE::OP_MUL: {
+                if (expression.children_size() != 2) {
+                    return fail("output expression arity mismatch");
+                }
+                DecimalValue lhs;
+                DecimalValue rhs;
+                if (!EvaluateOutputExpression(expression.children(0),
+                                              aggregate, state, &lhs) ||
+                    !EvaluateOutputExpression(expression.children(1),
+                                              aggregate, state, &rhs)) {
+                    return false;
+                }
+                result->mantissa = lhs.mantissa * rhs.mantissa;
+                result->scale = lhs.scale + rhs.scale;
+                result->is_null = lhs.is_null || rhs.is_null;
+                return true;
+            }
+            case FE::OP_DIV: {
+                if (expression.children_size() != 2) {
+                    return fail("output expression arity mismatch");
+                }
+                DecimalValue lhs;
+                DecimalValue rhs;
+                if (!EvaluateOutputExpression(expression.children(0),
+                                              aggregate, state, &lhs) ||
+                    !EvaluateOutputExpression(expression.children(1),
+                                              aggregate, state, &rhs)) {
+                    return false;
+                }
+                // Match MySQL DECIMAL division: left operand scale plus the
+                // default div_precision_increment, rounded half up.
+                *result = divide_decimal_values(lhs, rhs, lhs.scale + 4);
+                return true;
+            }
+            case FE::OP_NEG: {
+                if (expression.children_size() != 1) {
+                    return fail("output expression arity mismatch");
+                }
+                if (!EvaluateOutputExpression(expression.children(0),
+                                              aggregate, state, result)) {
+                    return false;
+                }
+                result->mantissa = -result->mantissa;
+                return true;
+            }
+            default:
+                return fail("unsupported output expression");
+        }
+    }
+
     bool AggregateRowValue(const pb::QueryBlockAggregate& aggregate,
                            int group_count, const GroupState& state,
                            uint32_t ordinal, std::string* value,
@@ -1428,6 +1600,22 @@ class Executor {
                                 static_cast<int>(expression.ordinal()),
                                 &is_null));
                             row.nulls.push_back(is_null);
+                            break;
+                        }
+                        case pb::QueryBlockOutputExpr::EXPR: {
+                            DecimalValue value;
+                            if (!EvaluateOutputExpression(
+                                    expression.expr(), aggregate, state,
+                                    &value)) {
+                                return false;
+                            }
+                            round_decimal_value(
+                                &value,
+                                static_cast<int>(expression.result_scale()));
+                            row.values.push_back(
+                                value.is_null ? std::string()
+                                              : format_decimal_value(value));
+                            row.nulls.push_back(value.is_null);
                             break;
                         }
                         default:

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -141,8 +141,9 @@ void append_result_field(std::string& row, std::string_view payload,
     row.append(payload.data(), payload.size());
 }
 
-// Materialized operator output. Each logical tuple is represented as one PAX row
-// reference per participating table.
+// Materialized operator output. Each logical tuple is represented as one row
+// reference per participating table. Real tables use PAX row references; virtual
+// tables produced by sub-blocks use result row numbers.
 struct NodeResult {
     std::vector<uint32_t> tables;
     std::vector<std::vector<uint64_t>> refs;
@@ -254,6 +255,9 @@ class Executor {
                 }
                 continue;
             }
+            if (node.has_sub_block()) {
+                continue;
+            }
             if (node.has_aggregate()) {
                 if (node.aggregate().input() >=
                     static_cast<uint32_t>(node_idx)) {
@@ -266,8 +270,56 @@ class Executor {
         return true;
     }
 
+    struct VirtualTable {
+        std::vector<std::vector<std::string>> values;
+        std::vector<std::vector<bool>> nulls;
+    };
+
+    bool IsVirtualTable(uint32_t table_idx) const {
+        return table_idx >= static_cast<uint32_t>(request_.tables_size());
+    }
+
+    const VirtualTable* FindVirtualTable(uint32_t table_idx) const {
+        if (!IsVirtualTable(table_idx)) return nullptr;
+        const uint32_t virtual_idx =
+            table_idx - static_cast<uint32_t>(request_.tables_size());
+        if (virtual_idx >= virtual_tables_.size()) return nullptr;
+        return &virtual_tables_[virtual_idx];
+    }
+
+    std::string_view ValueOf(uint32_t table_idx, uint64_t ref,
+                             uint32_t column) const {
+        if (ref == kNullRowRef) return {};
+        if (!IsVirtualTable(table_idx)) {
+            return extract_value_column(ToRowRef(table_idx, ref),
+                                        static_cast<int>(column));
+        }
+
+        const VirtualTable* table = FindVirtualTable(table_idx);
+        if (table == nullptr || ref >= table->values.size() ||
+            column >= table->values[ref].size()) {
+            return {};
+        }
+        return table->values[ref][column];
+    }
+
+    bool NullOf(uint32_t table_idx, uint64_t ref, uint32_t column) const {
+        if (ref == kNullRowRef) return true;
+        if (!IsVirtualTable(table_idx)) {
+            return IsNullColumn(ToRowRef(table_idx, ref), column);
+        }
+
+        const VirtualTable* table = FindVirtualTable(table_idx);
+        if (table == nullptr || ref >= table->nulls.size() ||
+            column >= table->nulls[ref].size()) {
+            return true;
+        }
+        return table->nulls[ref][column];
+    }
+
     PaxRowRef ToRowRef(uint32_t table_idx, uint64_t ref) const {
         if (ref == kNullRowRef) return PaxRowRef{};
+        if (table_idx >= stores_.size()) return PaxRowRef{};
         PaxStore* store = stores_[table_idx];
         return PaxRowRef{
             store->group(ref / PaxGroup::kRows),
@@ -324,8 +376,8 @@ class Executor {
 
     std::string_view GroupColumnValue(
         const pb::QueryBlockColumnRef& column, uint64_t ref) const {
-        std::string_view value = extract_value_column(
-            ToRowRef(column.table_idx(), ref), column.column());
+        std::string_view value =
+            ValueOf(column.table_idx(), ref, column.column());
         if (column.prefix_len() > 0 && value.size() > column.prefix_len()) {
             value = value.substr(0, column.prefix_len());
         }
@@ -339,9 +391,11 @@ class Executor {
         if (expression.op() != pb::FilterExpr::COLUMN_REF) return false;
         const DecodedColumnRef column = DecodeAggregateColumnRef(
             default_table_idx, expression.column_index());
-        PaxRowRef row = RowRefForTable(input, row_idx, column.table_idx);
-        if (row.group == nullptr) return false;
-        *value = extract_value_column(row, column.column);
+        const int position = input.table_pos(column.table_idx);
+        if (position < 0) return false;
+        const uint64_t ref = input.refs[position][row_idx];
+        if (NullOf(column.table_idx, ref, column.column)) return false;
+        *value = ValueOf(column.table_idx, ref, column.column);
         return true;
     }
 
@@ -508,6 +562,91 @@ class Executor {
         return true;
     }
 
+    bool DecodeSubBlockRow(const std::string& row,
+                           std::vector<std::string>* values,
+                           std::vector<bool>* nulls) {
+        if (values == nullptr || nulls == nullptr) {
+            return fail("sub-block row output missing");
+        }
+
+        values->clear();
+        nulls->clear();
+        size_t offset = 0;
+        bool first_field = true;
+        while (offset < row.size()) {
+            const auto byte_size =
+                static_cast<unsigned char>(row[offset]);
+            ++offset;
+
+            if (byte_size == 0xFF) {
+                if (!first_field) {
+                    values->emplace_back();
+                    nulls->push_back(true);
+                }
+                first_field = false;
+                continue;
+            }
+
+            if (offset + byte_size > row.size()) {
+                return fail("sub-block row is malformed");
+            }
+            size_t value_length = 0;
+            for (unsigned int byte_idx = 0; byte_idx < byte_size;
+                 ++byte_idx) {
+                value_length |=
+                    static_cast<size_t>(
+                        static_cast<unsigned char>(row[offset + byte_idx]))
+                    << (8 * byte_idx);
+            }
+            offset += byte_size;
+            if (offset + value_length > row.size()) {
+                return fail("sub-block row is malformed");
+            }
+
+            if (!first_field) {
+                values->emplace_back(row.data() + offset, value_length);
+                nulls->push_back(false);
+            }
+            first_field = false;
+            offset += value_length;
+        }
+        return true;
+    }
+
+    bool RunSubBlock(const pb::QueryBlockSubBlock& sub_block,
+                     NodeResult* output) {
+        pb::TxExecuteQueryBlock::Response response;
+        ExecuteQueryBlock(db_, sub_block.block(), &response);
+        if (!response.ok()) {
+            return fail(response.error().empty() ? "sub-block failed"
+                                                 : response.error());
+        }
+
+        VirtualTable table;
+        table.values.reserve(response.rows_size());
+        table.nulls.reserve(response.rows_size());
+        for (const std::string& row : response.rows()) {
+            std::vector<std::string> values;
+            std::vector<bool> nulls;
+            if (!DecodeSubBlockRow(row, &values, &nulls)) return false;
+            table.values.push_back(std::move(values));
+            table.nulls.push_back(std::move(nulls));
+        }
+
+        const uint32_t table_idx = static_cast<uint32_t>(
+            request_.tables_size() + virtual_tables_.size());
+        virtual_tables_.push_back(std::move(table));
+
+        output->tables = {table_idx};
+        output->refs.assign(1, {});
+        const size_t row_count = virtual_tables_.back().values.size();
+        output->refs[0].reserve(row_count);
+        for (size_t row_idx = 0; row_idx < row_count; ++row_idx) {
+            output->refs[0].push_back(row_idx);
+        }
+        return true;
+    }
+
     struct TupleFilterColumn {
         int ref_position = -1;
         uint32_t table_idx = 0;
@@ -554,11 +693,10 @@ class Executor {
                 continue;
             }
 
-            const PaxRowRef row = ToRowRef(column.table_idx, ref);
-            if (row.group == nullptr) return false;
             (*cells)[column_idx] =
-                extract_value_column(row, static_cast<int>(column.column));
-            (*nulls)[column_idx] = IsNullColumn(row, column.column);
+                ValueOf(column.table_idx, ref, column.column);
+            (*nulls)[column_idx] =
+                NullOf(column.table_idx, ref, column.column);
         }
         return true;
     }
@@ -675,10 +813,9 @@ class Executor {
         key->clear();
         for (const JoinKeyColumn& column : key_columns) {
             const uint64_t ref = input.refs[column.ref_position][row_idx];
-            if (ref == kNullRowRef) return false;
-            AppendJoinKeyPart(
-                key, extract_value_column(ToRowRef(column.table_idx, ref),
-                                          column.column));
+            if (NullOf(column.table_idx, ref, column.column)) return false;
+            AppendJoinKeyPart(key,
+                              ValueOf(column.table_idx, ref, column.column));
         }
         return true;
     }
@@ -817,12 +954,10 @@ class Executor {
                             continue;
                         }
 
-                        const PaxRowRef row = ToRowRef(column.table_idx, ref);
-                        if (row.group == nullptr) return false;
-                        residual_cells[column_idx] = extract_value_column(
-                            row, static_cast<int>(column.column));
+                        residual_cells[column_idx] =
+                            ValueOf(column.table_idx, ref, column.column);
                         residual_nulls[column_idx] =
-                            IsNullColumn(row, column.column);
+                            NullOf(column.table_idx, ref, column.column);
                     }
                     residual_evaluator.set_row_from_views(residual_cells,
                                                           residual_nulls);
@@ -964,6 +1099,36 @@ class Executor {
         return function.filter_table();
     }
 
+    bool BuildPredicateRowForTable(uint32_t table_idx, uint64_t ref,
+                                   uint32_t column_count,
+                                   std::vector<std::string_view>* cells,
+                                   std::vector<bool>* nulls) const {
+        if (cells == nullptr || nulls == nullptr) return false;
+        if (ref == kNullRowRef) return false;
+        if (!IsVirtualTable(table_idx)) {
+            const PaxRowRef row = ToRowRef(table_idx, ref);
+            if (row.group == nullptr ||
+                row.group->schema().field_count() <
+                    static_cast<size_t>(column_count) + 1) {
+                return false;
+            }
+        } else {
+            const VirtualTable* table = FindVirtualTable(table_idx);
+            if (table == nullptr || ref >= table->values.size()) {
+                return false;
+            }
+        }
+
+        cells->resize(column_count);
+        nulls->resize(column_count);
+        for (uint32_t column_idx = 0; column_idx < column_count;
+             ++column_idx) {
+            (*cells)[column_idx] = ValueOf(table_idx, ref, column_idx);
+            (*nulls)[column_idx] = NullOf(table_idx, ref, column_idx);
+        }
+        return true;
+    }
+
     bool AccumulateRange(const pb::QueryBlockAggregate& aggregate,
                          const NodeResult& input, size_t begin, size_t end,
                          GroupMap* groups) {
@@ -1010,6 +1175,8 @@ class Executor {
         PredicateEvaluator evaluator;
         std::string key_buffer;
         std::vector<std::string_view> group_values(group_count);
+        std::vector<std::string_view> filter_values;
+        std::vector<bool> filter_nulls;
         for (size_t row_idx = begin; row_idx < end; ++row_idx) {
             key_buffer.clear();
             for (int group_idx = 0; group_idx < group_count; ++group_idx) {
@@ -1064,13 +1231,14 @@ class Executor {
                     if (filter_ref == kNullRowRef) continue;
                     const uint32_t filter_table =
                         FilterTableForAggregate(function);
-                    PaxRowRef row = ToRowRef(filter_table, filter_ref);
-                    if (row.group == nullptr ||
-                        !evaluator.set_row_from_pax(
-                            *row.group, row.slot,
-                            function.filter().num_columns())) {
-                        return fail("aggregate filter cannot read PAX columns");
+                    if (!BuildPredicateRowForTable(
+                            filter_table, filter_ref,
+                            function.filter().num_columns(), &filter_values,
+                            &filter_nulls)) {
+                        return fail(
+                            "aggregate filter cannot read table columns");
                     }
+                    evaluator.set_row_from_views(filter_values, filter_nulls);
                     if (!evaluator.evaluate(function.filter().expr())) {
                         continue;
                     }
@@ -1698,6 +1866,12 @@ class Executor {
                 }
                 continue;
             }
+            if (node.has_sub_block()) {
+                if (!RunSubBlock(node.sub_block(), &results_[node_idx])) {
+                    return false;
+                }
+                continue;
+            }
             if (node.has_aggregate()) {
                 if (node_idx != request_.nodes_size() - 1) {
                     return fail("aggregate must be the root node");
@@ -1747,6 +1921,7 @@ class Executor {
     std::vector<uint64_t> slot_snapshots_;
     std::vector<uint64_t> overflow_snapshots_;
     std::vector<NodeResult> results_;
+    std::vector<VirtualTable> virtual_tables_;
 };
 
 const std::string& default_error(const Executor& executor) {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -832,9 +832,9 @@ class Executor {
         if (join.build_keys_size() != join.probe_keys_size()) {
             return fail("join key arity");
         }
-        // A keyless INNER join is a cross product, used for one-row virtual
-        // derived inputs. Other join types need explicit keys for SQL shape.
-        if (join.build_keys_size() == 0 && !is_inner) {
+        // Keyless INNER and LEFT joins are cross products. The proxy only emits
+        // them for one-row virtual inputs, where the SQL shape is explicit.
+        if (join.build_keys_size() == 0 && !is_inner && !is_left) {
             return fail("join key arity");
         }
         if (join.build() >= results_.size() || join.probe() >= results_.size()) {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -829,8 +829,12 @@ class Executor {
         if (!is_inner && !is_left && !is_semi && !is_anti) {
             return fail("unsupported query-block join type");
         }
-        if (join.build_keys_size() != join.probe_keys_size() ||
-            join.build_keys_size() == 0) {
+        if (join.build_keys_size() != join.probe_keys_size()) {
+            return fail("join key arity");
+        }
+        // A keyless INNER join is a cross product, used for one-row virtual
+        // derived inputs. Other join types need explicit keys for SQL shape.
+        if (join.build_keys_size() == 0 && !is_inner) {
             return fail("join key arity");
         }
         if (join.build() >= results_.size() || join.probe() >= results_.size()) {


### PR DESCRIPTION
## Summary

- Extend `LINEAIRDB_COLUMNAR` query-block planning to cover more TPC-H analytical shapes.
- Add server-side query-block execution support for derived inputs, scalar derived values, semijoins, left joins, DISTINCT, HAVING, ordering, limits, string grouping, decimal join keys, and row-shaped outputs.
- Keep the secondary path explicit: unsupported query shapes are rejected from columnar offload instead of being partially executed with ambiguous behavior.
- Enable PAX storage in the server startup script so benchmark loads install PAX schemas by default.

## Why

The previous columnar query-block path could execute joined aggregate plans, but several common TPC-H shapes still stayed outside the secondary engine path. Queries with derived sub-blocks, scalar derived joins, outer joins, semijoin inputs, grouped string prefixes, DISTINCT/HAVING aggregates, row outputs, and decimal join keys needed more proxy lowering and server executor coverage before the columnar path could cover the full benchmark set.

This branch broadens the supported SQL subset while preserving the same safety model: MySQL still owns general SQL planning and result delivery, and LineairDB only receives query blocks that the secondary handler can represent and execute directly over PAX-backed data.

## Details

The proxy-side columnar handler now recognizes more analytical query blocks and lowers them into `TxExecuteQueryBlock` requests. The lowering logic can build derived sub-blocks, connect inner and left joins, pass semijoin inputs, resolve scalar derived equalities, preserve NULL values, emit row-shaped result blocks, map DISTINCT and HAVING aggregates, rewrite supported substring prefix filters, and represent decimal join keys.

The server-side query-block executor now handles the matching execution shapes. It can execute derived and row query blocks, apply residual predicates on joined rows, run keyless inner and left joins, handle scalar keyless derived joins, preserve columnar NULL state, evaluate DISTINCT/HAVING aggregate forms, and return row outputs through the existing result framing.

Predicate and pushdown support is extended where the new query-block forms need it, including row query-block requests, bounded predicate-number parsing, and helper declarations shared with the columnar path.

The startup script exports `HELIOS_PAX_STORAGE=1` before launching `lineairdb-server`, which makes local benchmark/server runs install PAX schemas during table creation instead of requiring the environment variable to be set manually.