### PR TITLE
feat: PAX columnar storage and LINEAIRDB_COLUMNAR secondary engine

### DIFF
--- a/bench/bin/tpch_setup_sf1.sh
+++ b/bench/bin/tpch_setup_sf1.sh
@@ -45,6 +45,8 @@ echo "== [3/4] ANALYZE =="
 "$MYSQL" -u root --socket="$SOCKET" benchbase \
   -e "ANALYZE TABLE customer, lineitem, nation, orders, part, partsupp, region, supplier;" >/dev/null
 
+"$MYSQL" -u root --socket="$SOCKET" -e "SELECT COUNT(*) AS lineitem_rows FROM benchbase.lineitem;"
+
 echo "== [4/4] measurement conditions =="
 "$MYSQL" -u root --socket="$SOCKET" -e "
   SET GLOBAL lineairdb_prefetch_execution=ON;
@@ -52,5 +54,4 @@ echo "== [4/4] measurement conditions =="
   SET GLOBAL optimizer_switch='batched_key_access=on,mrr_cost_based=off,subquery_to_derived=off';
   SET GLOBAL join_buffer_size=1073741824;"
 
-"$MYSQL" -u root --socket="$SOCKET" -e "SELECT COUNT(*) AS lineitem_rows FROM benchbase.lineitem;"
 echo "setup done"

--- a/bench/bin/tpch_setup_sf1.sh
+++ b/bench/bin/tpch_setup_sf1.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Load TPC-H into a running helios stack, then apply the postload indexes,
+# ANALYZE statistics, and session settings used by the wall-clock runner.
+# Usage: tpch_setup_sf1.sh [--sf 1] [--loader-threads 16] [--socket /tmp/mysql.sock]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SF=1
+LOADERS=16
+SOCKET=/tmp/mysql.sock
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --sf)
+      SF=$2
+      shift 2
+      ;;
+    --loader-threads)
+      LOADERS=$2
+      shift 2
+      ;;
+    --socket)
+      SOCKET=$2
+      shift 2
+      ;;
+    *)
+      echo "unknown arg $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+MYSQL="$ROOT/build/runtime_output_directory/mysql"
+[ -x "$MYSQL" ] || MYSQL=$(command -v mysql)
+
+echo "== [1/4] benchbase create+load (SF=$SF) =="
+python3 "$ROOT/bench/bin/benchrun.py" tpch --scalefactor "$SF" --no-exec \
+  --external-server --loader-threads "$LOADERS"
+
+echo "== [2/4] postload 23-index set =="
+time "$MYSQL" -u root --socket="$SOCKET" benchbase \
+  < "$ROOT/third_party/benchbase/src/main/resources/benchmarks/tpch/postload-mysql.sql"
+
+echo "== [3/4] ANALYZE =="
+"$MYSQL" -u root --socket="$SOCKET" benchbase \
+  -e "ANALYZE TABLE customer, lineitem, nation, orders, part, partsupp, region, supplier;" >/dev/null
+
+echo "== [4/4] measurement conditions =="
+"$MYSQL" -u root --socket="$SOCKET" -e "
+  SET GLOBAL lineairdb_prefetch_execution=ON;
+  SET GLOBAL lineairdb_prefetch_ro_novalidate=ON;
+  SET GLOBAL optimizer_switch='batched_key_access=on,mrr_cost_based=off,subquery_to_derived=off';
+  SET GLOBAL join_buffer_size=1073741824;"
+
+"$MYSQL" -u root --socket="$SOCKET" -e "SELECT COUNT(*) AS lineitem_rows FROM benchbase.lineitem;"
+echo "setup done"

--- a/bench/bin/tpch_wall.sh
+++ b/bench/bin/tpch_wall.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Run per-query TPC-H wall-clock timing against a running mysqld.
+# Method: single stream, one discarded warm run, N timed runs, and external
+# mysql-client wall-clock timing.
+# Usage: tpch_wall.sh <label> [--runs 3] [--db benchbase] [--socket /tmp/mysql.sock]
+#        [--queries bench/queries/tpch] [--out <dir>] [--timeout 120] [--only "1 6 18"]
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+LABEL=${1:?usage: tpch_wall.sh <label> [options]}
+shift
+
+RUNS=3
+DB=benchbase
+SOCKET=/tmp/mysql.sock
+QDIR="$ROOT/bench/queries/tpch"
+OUT="$ROOT/bench/results/tpch_wall"
+TIMEOUT=120
+ONLY=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --runs)
+      RUNS=$2
+      shift 2
+      ;;
+    --db)
+      DB=$2
+      shift 2
+      ;;
+    --socket)
+      SOCKET=$2
+      shift 2
+      ;;
+    --queries)
+      QDIR=$2
+      shift 2
+      ;;
+    --out)
+      OUT=$2
+      shift 2
+      ;;
+    --timeout)
+      TIMEOUT=$2
+      shift 2
+      ;;
+    --only)
+      ONLY=$2
+      shift 2
+      ;;
+    *)
+      echo "unknown arg $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+MYSQL="$ROOT/build/runtime_output_directory/mysql"
+[ -x "$MYSQL" ] || MYSQL=$(command -v mysql)
+mkdir -p "$OUT"
+
+RESULT="$OUT/${LABEL}.tsv"
+: > "$RESULT"
+echo "# label=$LABEL runs=$RUNS db=$DB queries=$QDIR $(date -Is)" >> "$RESULT"
+
+QLIST=${ONLY:-$(seq 1 22)}
+for q in $QLIST; do
+  SQL_FILE="$QDIR/q$q.sql"
+  if [ ! -f "$SQL_FILE" ]; then
+    echo "q$q MISSING" >> "$RESULT"
+    continue
+  fi
+
+  timeout "$TIMEOUT" "$MYSQL" -u root --socket="$SOCKET" "$DB" -B -N \
+    < "$SQL_FILE" > /dev/null 2>"$OUT/${LABEL}_q${q}.err" \
+    || {
+      echo -e "q$q\tERR\t$(head -c 120 "$OUT/${LABEL}_q${q}.err" | tr '\t\n' '  ')" >> "$RESULT"
+      continue
+    }
+
+  TIMES=()
+  for _ in $(seq 1 "$RUNS"); do
+    T0=$(python3 -c 'import time; print(int(time.time()*1000))')
+    timeout "$TIMEOUT" "$MYSQL" -u root --socket="$SOCKET" "$DB" -B -N \
+      < "$SQL_FILE" > "$OUT/${LABEL}_q${q}.out" 2>/dev/null
+    RC=$?
+    T1=$(python3 -c 'import time; print(int(time.time()*1000))')
+    [ $RC -ne 0 ] && {
+      TIMES=()
+      break
+    }
+    TIMES+=( $((T1 - T0)) )
+  done
+
+  if [ ${#TIMES[@]} -eq 0 ]; then
+    echo -e "q$q\tERR\trun-failed" >> "$RESULT"
+    continue
+  fi
+
+  MD5=$(md5sum "$OUT/${LABEL}_q${q}.out" | cut -d' ' -f1)
+  echo -e "q$q\t$(IFS=,; echo "${TIMES[*]}")\tmd5=$MD5" >> "$RESULT"
+  echo "[$LABEL] q$q: ${TIMES[*]} ms"
+done
+
+echo "results -> $RESULT"

--- a/bench/queries/tpch/q1.sql
+++ b/bench/queries/tpch/q1.sql
@@ -1,0 +1,22 @@
+-- TPC-H Q1 (qualification parameters)
+SELECT
+   l_returnflag,
+   l_linestatus,
+   SUM(l_quantity) AS sum_qty,
+   SUM(l_extendedprice) AS sum_base_price,
+   SUM(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+   SUM(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+   AVG(l_quantity) AS avg_qty,
+   AVG(l_extendedprice) AS avg_price,
+   AVG(l_discount) AS avg_disc,
+   COUNT(*) AS count_order
+FROM
+   lineitem
+WHERE
+   l_shipdate <= DATE '1998-12-01' - INTERVAL '90' DAY
+GROUP BY
+   l_returnflag,
+   l_linestatus
+ORDER BY
+   l_returnflag,
+   l_linestatus;

--- a/bench/queries/tpch/q10.sql
+++ b/bench/queries/tpch/q10.sql
@@ -1,0 +1,32 @@
+-- TPC-H Q10 (qualification parameters)
+SELECT
+   c_custkey,
+   c_name,
+   SUM(l_extendedprice * (1 - l_discount)) AS revenue,
+   c_acctbal,
+   n_name,
+   c_address,
+   c_phone,
+   c_comment
+FROM
+   customer,
+   orders,
+   lineitem,
+   nation
+WHERE
+   c_custkey = o_custkey
+   AND l_orderkey = o_orderkey
+   AND o_orderdate >= DATE '1993-10-01'
+   AND o_orderdate < DATE '1993-10-01' + INTERVAL '3' MONTH
+   AND l_returnflag = 'R'
+   AND c_nationkey = n_nationkey
+GROUP BY
+   c_custkey,
+   c_name,
+   c_acctbal,
+   c_phone,
+   n_name,
+   c_address,
+   c_comment
+ORDER BY
+   revenue DESC LIMIT 20;

--- a/bench/queries/tpch/q11.sql
+++ b/bench/queries/tpch/q11.sql
@@ -1,0 +1,26 @@
+-- TPC-H Q11 (qualification parameters)
+SELECT
+   ps_partkey,
+   SUM(ps_supplycost * ps_availqty) AS VALUE
+FROM
+   partsupp,
+   supplier,
+   nation
+WHERE
+   ps_suppkey = s_suppkey
+   AND s_nationkey = n_nationkey
+   AND n_name = 'GERMANY'
+GROUP BY
+   ps_partkey
+HAVING
+   SUM(ps_supplycost * ps_availqty) > (
+   SELECT
+      SUM(ps_supplycost * ps_availqty) * 0.0001
+   FROM
+      partsupp, supplier, nation
+   WHERE
+      ps_suppkey = s_suppkey
+      AND s_nationkey = n_nationkey
+      AND n_name = 'GERMANY' )
+   ORDER BY
+      VALUE DESC;

--- a/bench/queries/tpch/q12.sql
+++ b/bench/queries/tpch/q12.sql
@@ -1,0 +1,37 @@
+-- TPC-H Q12 (qualification parameters)
+SELECT
+    l_shipmode,
+    SUM(
+        CASE
+            WHEN
+                o_orderpriority = '1-URGENT' OR o_orderpriority = '2-HIGH'
+            THEN
+                1
+            ELSE
+                0
+        END
+    ) AS high_line_count,
+    SUM(
+        CASE
+            WHEN
+                o_orderpriority <> '1-URGENT' AND o_orderpriority <> '2-HIGH'
+            THEN
+                1
+            ELSE
+                0
+        END
+    ) AS low_line_count
+FROM
+    orders,
+    lineitem
+WHERE
+    o_orderkey = l_orderkey
+    AND l_shipmode IN ('MAIL', 'SHIP')
+    AND l_commitdate < l_receiptdate
+    AND l_shipdate < l_commitdate
+    AND l_receiptdate >= DATE '1994-01-01'
+    AND l_receiptdate < DATE '1994-01-01' + INTERVAL '1' YEAR
+GROUP BY
+    l_shipmode
+ORDER BY
+    l_shipmode;

--- a/bench/queries/tpch/q13.sql
+++ b/bench/queries/tpch/q13.sql
@@ -1,0 +1,24 @@
+-- TPC-H Q13 (qualification parameters)
+SELECT
+   c_count,
+   COUNT(*) AS custdist
+FROM
+   (
+      SELECT
+         c_custkey,
+         COUNT(o_orderkey) AS c_count
+      FROM
+         customer
+         LEFT OUTER JOIN
+            orders
+            ON c_custkey = o_custkey
+            AND o_comment NOT LIKE '%special%requests%'
+      GROUP BY
+         c_custkey
+   )
+   AS c_orders
+GROUP BY
+   c_count
+ORDER BY
+   custdist DESC,
+   c_count DESC;

--- a/bench/queries/tpch/q14.sql
+++ b/bench/queries/tpch/q14.sql
@@ -1,0 +1,18 @@
+-- TPC-H Q14 (qualification parameters)
+SELECT
+   100.00 * SUM(
+   CASE
+      WHEN
+         p_type LIKE 'PROMO%'
+      THEN
+         l_extendedprice * (1 - l_discount)
+      ELSE
+         0
+   END
+) / SUM(l_extendedprice * (1 - l_discount)) AS promo_revenue
+FROM
+   lineitem, part
+WHERE
+   l_partkey = p_partkey
+   AND l_shipdate >= DATE '1995-09-01'
+   AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' MONTH;

--- a/bench/queries/tpch/q15.sql
+++ b/bench/queries/tpch/q15.sql
@@ -1,0 +1,34 @@
+-- TPC-H Q15 (qualification parameters)
+CREATE view revenue0 (supplier_no, total_revenue) AS
+SELECT
+   l_suppkey,
+   SUM(l_extendedprice * (1 - l_discount))
+FROM
+   lineitem
+WHERE
+   l_shipdate >= DATE '1996-01-01'
+   AND l_shipdate < DATE '1996-01-01' + INTERVAL '3' MONTH
+GROUP BY
+   l_suppkey;
+
+SELECT
+   s_suppkey,
+   s_name,
+   s_address,
+   s_phone,
+   total_revenue
+FROM
+   supplier,
+   revenue0
+WHERE
+   s_suppkey = supplier_no
+   AND total_revenue = (
+      SELECT
+         MAX(total_revenue)
+      FROM
+         revenue0
+   )
+ORDER BY
+   s_suppkey;
+
+DROP VIEW revenue0;

--- a/bench/queries/tpch/q16.sql
+++ b/bench/queries/tpch/q16.sql
@@ -1,0 +1,32 @@
+-- TPC-H Q16 (qualification parameters)
+SELECT
+   p_brand,
+   p_type,
+   p_size,
+   COUNT(DISTINCT ps_suppkey) AS supplier_cnt
+FROM
+   partsupp,
+   part
+WHERE
+   p_partkey = ps_partkey
+   AND p_brand <> 'Brand#45'
+   AND p_type NOT LIKE 'MEDIUM POLISHED%'
+   AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
+   AND ps_suppkey NOT IN
+   (
+      SELECT
+         s_suppkey
+      FROM
+         supplier
+      WHERE
+         s_comment LIKE '%Customer%Complaints%'
+   )
+GROUP BY
+   p_brand,
+   p_type,
+   p_size
+ORDER BY
+   supplier_cnt DESC,
+   p_brand,
+   p_type,
+   p_size;

--- a/bench/queries/tpch/q17.sql
+++ b/bench/queries/tpch/q17.sql
@@ -1,0 +1,17 @@
+-- TPC-H Q17 (qualification parameters)
+SELECT
+   SUM(l_extendedprice) / 7.0 AS avg_yearly
+FROM
+   lineitem,
+   part
+WHERE
+   p_partkey = l_partkey
+   AND p_brand = 'Brand#23'
+   AND p_container = 'MED BOX'
+   AND l_quantity < (
+   SELECT
+      0.2 * AVG(l_quantity)
+   FROM
+      lineitem
+   WHERE
+      l_partkey = p_partkey );

--- a/bench/queries/tpch/q18.sql
+++ b/bench/queries/tpch/q18.sql
@@ -1,0 +1,35 @@
+-- TPC-H Q18 (qualification parameters)
+SELECT
+   c_name,
+   c_custkey,
+   o_orderkey,
+   o_orderdate,
+   o_totalprice,
+   SUM(l_quantity)
+FROM
+   customer,
+   orders,
+   lineitem
+WHERE
+   o_orderkey IN
+   (
+      SELECT
+         l_orderkey
+      FROM
+         lineitem
+      GROUP BY
+         l_orderkey
+      HAVING
+         SUM(l_quantity) > 300
+   )
+   AND c_custkey = o_custkey
+   AND o_orderkey = l_orderkey
+GROUP BY
+   c_name,
+   c_custkey,
+   o_orderkey,
+   o_orderdate,
+   o_totalprice
+ORDER BY
+   o_totalprice DESC,
+   o_orderdate LIMIT 100;

--- a/bench/queries/tpch/q19.sql
+++ b/bench/queries/tpch/q19.sql
@@ -1,0 +1,39 @@
+-- TPC-H Q19 (qualification parameters)
+SELECT
+   SUM(l_extendedprice* (1 - l_discount)) AS revenue
+FROM
+   lineitem,
+   part
+WHERE
+   (
+      p_partkey = l_partkey
+      AND p_brand = 'Brand#12'
+      AND p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+      AND l_quantity >= 1
+      AND l_quantity <= 1 + 10
+      AND p_size BETWEEN 1 AND 5
+      AND l_shipmode IN ('AIR', 'AIR REG')
+      AND l_shipinstruct = 'DELIVER IN PERSON'
+   )
+   OR
+   (
+      p_partkey = l_partkey
+      AND p_brand = 'Brand#23'
+      AND p_container IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+      AND l_quantity >= 10
+      AND l_quantity <= 10 + 10
+      AND p_size BETWEEN 1 AND 10
+      AND l_shipmode IN ('AIR', 'AIR REG')
+      AND l_shipinstruct = 'DELIVER IN PERSON'
+   )
+   OR
+   (
+      p_partkey = l_partkey
+      AND p_brand = 'Brand#34'
+      AND p_container IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+      AND l_quantity >= 20
+      AND l_quantity <= 20 + 10
+      AND p_size BETWEEN 1 AND 15
+      AND l_shipmode IN ('AIR', 'AIR REG')
+      AND l_shipinstruct = 'DELIVER IN PERSON'
+   );

--- a/bench/queries/tpch/q2.sql
+++ b/bench/queries/tpch/q2.sql
@@ -1,0 +1,45 @@
+-- TPC-H Q2 (qualification parameters)
+SELECT
+   s_acctbal,
+   s_name,
+   n_name,
+   p_partkey,
+   p_mfgr,
+   s_address,
+   s_phone,
+   s_comment
+FROM
+   part,
+   supplier,
+   partsupp,
+   nation,
+   region
+WHERE
+   p_partkey = ps_partkey
+   AND s_suppkey = ps_suppkey
+   AND p_size = 15
+   AND p_type LIKE '%BRASS'
+   AND s_nationkey = n_nationkey
+   AND n_regionkey = r_regionkey
+   AND r_name = 'EUROPE'
+   AND ps_supplycost =
+   (
+      SELECT
+         MIN(ps_supplycost)
+      FROM
+         partsupp,
+         supplier,
+         nation,
+         region
+      WHERE
+         p_partkey = ps_partkey
+         AND s_suppkey = ps_suppkey
+         AND s_nationkey = n_nationkey
+         AND n_regionkey = r_regionkey
+         AND r_name = 'EUROPE'
+   )
+ORDER BY
+   s_acctbal DESC,
+   n_name,
+   s_name,
+   p_partkey LIMIT 100;

--- a/bench/queries/tpch/q20.sql
+++ b/bench/queries/tpch/q20.sql
@@ -1,0 +1,39 @@
+-- TPC-H Q20 (qualification parameters)
+SELECT
+   s_name,
+   s_address
+FROM
+   supplier,
+   nation
+WHERE
+   s_suppkey IN
+   (
+      SELECT
+         ps_suppkey
+      FROM
+         partsupp
+      WHERE
+         ps_partkey IN
+         (
+            SELECT
+               p_partkey
+            FROM
+               part
+            WHERE
+               p_name LIKE 'forest%'
+         )
+         AND ps_availqty > (
+         SELECT
+            0.5 * SUM(l_quantity)
+         FROM
+            lineitem
+         WHERE
+            l_partkey = ps_partkey
+            AND l_suppkey = ps_suppkey
+            AND l_shipdate >= DATE '1994-01-01'
+            AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' YEAR )
+   )
+   AND s_nationkey = n_nationkey
+   AND n_name = 'CANADA'
+ORDER BY
+   s_name;

--- a/bench/queries/tpch/q21.sql
+++ b/bench/queries/tpch/q21.sql
@@ -1,0 +1,42 @@
+-- TPC-H Q21 (qualification parameters)
+SELECT
+   s_name,
+   COUNT(*) AS numwait
+FROM
+   supplier,
+   lineitem l1,
+   orders,
+   nation
+WHERE
+   s_suppkey = l1.l_suppkey
+   AND o_orderkey = l1.l_orderkey
+   AND o_orderstatus = 'F'
+   AND l1.l_receiptdate > l1.l_commitdate
+   AND EXISTS
+   (
+      SELECT
+         *
+      FROM
+         lineitem l2
+      WHERE
+         l2.l_orderkey = l1.l_orderkey
+         AND l2.l_suppkey <> l1.l_suppkey
+   )
+   AND NOT EXISTS
+   (
+      SELECT
+         *
+      FROM
+         lineitem l3
+      WHERE
+         l3.l_orderkey = l1.l_orderkey
+         AND l3.l_suppkey <> l1.l_suppkey
+         AND l3.l_receiptdate > l3.l_commitdate
+   )
+   AND s_nationkey = n_nationkey
+   AND n_name = 'SAUDI ARABIA'
+GROUP BY
+   s_name
+ORDER BY
+   numwait DESC,
+   s_name LIMIT 100;

--- a/bench/queries/tpch/q22.sql
+++ b/bench/queries/tpch/q22.sql
@@ -1,0 +1,39 @@
+-- TPC-H Q22 (qualification parameters)
+SELECT
+   cntrycode,
+   COUNT(*) AS numcust,
+   SUM(c_acctbal) AS totacctbal
+FROM
+   (
+      SELECT
+         SUBSTRING(c_phone FROM 1 FOR 2) AS cntrycode,
+         c_acctbal
+      FROM
+         customer
+      WHERE
+         SUBSTRING(c_phone FROM 1 FOR 2) IN ('13', '31', '23', '29', '30', '18', '17')
+         AND c_acctbal >
+         (
+             SELECT
+                AVG(c_acctbal)
+             FROM
+                customer
+             WHERE
+                c_acctbal > 0.00
+                AND SUBSTRING(c_phone FROM 1 FOR 2) IN ('13', '31', '23', '29', '30', '18', '17')
+         )
+         AND NOT EXISTS
+         (
+             SELECT
+                *
+             FROM
+                orders
+             WHERE
+                o_custkey = c_custkey
+         )
+   )
+   AS custsale
+GROUP BY
+   cntrycode
+ORDER BY
+   cntrycode;

--- a/bench/queries/tpch/q3.sql
+++ b/bench/queries/tpch/q3.sql
@@ -1,0 +1,23 @@
+-- TPC-H Q3 (qualification parameters)
+SELECT
+   l_orderkey,
+   SUM(l_extendedprice * (1 - l_discount)) AS revenue,
+   o_orderdate,
+   o_shippriority
+FROM
+   customer,
+   orders,
+   lineitem
+WHERE
+   c_mktsegment = 'BUILDING'
+   AND c_custkey = o_custkey
+   AND l_orderkey = o_orderkey
+   AND o_orderdate < DATE '1995-03-15'
+   AND l_shipdate > DATE '1995-03-15'
+GROUP BY
+   l_orderkey,
+   o_orderdate,
+   o_shippriority
+ORDER BY
+   revenue DESC,
+   o_orderdate LIMIT 10;

--- a/bench/queries/tpch/q4.sql
+++ b/bench/queries/tpch/q4.sql
@@ -1,0 +1,23 @@
+-- TPC-H Q4 (qualification parameters)
+SELECT
+   o_orderpriority,
+   COUNT(*) AS order_count
+FROM
+   orders
+WHERE
+   o_orderdate >= DATE '1993-07-01'
+   AND o_orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH
+   AND EXISTS
+   (
+      SELECT
+         *
+      FROM
+         lineitem
+      WHERE
+         l_orderkey = o_orderkey
+         AND l_commitdate < l_receiptdate
+   )
+GROUP BY
+   o_orderpriority
+ORDER BY
+   o_orderpriority;

--- a/bench/queries/tpch/q5.sql
+++ b/bench/queries/tpch/q5.sql
@@ -1,0 +1,25 @@
+-- TPC-H Q5 (qualification parameters)
+SELECT
+   n_name,
+   SUM(l_extendedprice * (1 - l_discount)) AS revenue
+FROM
+   customer,
+   orders,
+   lineitem,
+   supplier,
+   nation,
+   region
+WHERE
+   c_custkey = o_custkey
+   AND l_orderkey = o_orderkey
+   AND l_suppkey = s_suppkey
+   AND c_nationkey = s_nationkey
+   AND s_nationkey = n_nationkey
+   AND n_regionkey = r_regionkey
+   AND r_name = 'ASIA'
+   AND o_orderdate >= DATE '1994-01-01'
+   AND o_orderdate < DATE '1994-01-01' + INTERVAL '1' YEAR
+GROUP BY
+   n_name
+ORDER BY
+   revenue DESC;

--- a/bench/queries/tpch/q6.sql
+++ b/bench/queries/tpch/q6.sql
@@ -1,0 +1,10 @@
+-- TPC-H Q6 (qualification parameters)
+SELECT
+   SUM(l_extendedprice * l_discount) AS revenue
+FROM
+   lineitem
+WHERE
+   l_shipdate >= DATE '1994-01-01'
+   AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' YEAR
+   AND l_discount BETWEEN '0.06' - 0.01 AND '0.06' + 0.01
+   AND l_quantity < 24;

--- a/bench/queries/tpch/q7.sql
+++ b/bench/queries/tpch/q7.sql
@@ -1,0 +1,45 @@
+-- TPC-H Q7 (qualification parameters)
+SELECT
+   supp_nation,
+   cust_nation,
+   l_year,
+   SUM(volume) AS revenue
+FROM
+   (
+      SELECT
+         n1.n_name AS supp_nation,
+         n2.n_name AS cust_nation,
+         EXTRACT(YEAR
+      FROM
+         l_shipdate) AS l_year,
+         l_extendedprice * (1 - l_discount) AS volume
+      FROM
+         supplier,
+         lineitem,
+         orders,
+         customer,
+         nation n1,
+         nation n2
+      WHERE
+         s_suppkey = l_suppkey
+         AND o_orderkey = l_orderkey
+         AND c_custkey = o_custkey
+         AND s_nationkey = n1.n_nationkey
+         AND c_nationkey = n2.n_nationkey
+         AND
+         (
+            (n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY')
+            OR
+            (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE')
+         )
+         AND l_shipdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+   )
+   AS shipping
+GROUP BY
+   supp_nation,
+   cust_nation,
+   l_year
+ORDER BY
+   supp_nation,
+   cust_nation,
+   l_year;

--- a/bench/queries/tpch/q8.sql
+++ b/bench/queries/tpch/q8.sql
@@ -1,0 +1,47 @@
+-- TPC-H Q8 (qualification parameters)
+SELECT
+   o_year,
+   SUM(
+   CASE
+      WHEN
+         nation = 'BRAZIL'
+      THEN
+         volume
+      ELSE
+         0
+   END
+) / SUM(volume) AS mkt_share
+FROM
+   (
+      SELECT
+         EXTRACT(YEAR
+      FROM
+         o_orderdate) AS o_year,
+         l_extendedprice * (1 - l_discount) AS volume,
+         n2.n_name AS nation
+      FROM
+         part,
+         supplier,
+         lineitem,
+         orders,
+         customer,
+         nation n1,
+         nation n2,
+         region
+      WHERE
+         p_partkey = l_partkey
+         AND s_suppkey = l_suppkey
+         AND l_orderkey = o_orderkey
+         AND o_custkey = c_custkey
+         AND c_nationkey = n1.n_nationkey
+         AND n1.n_regionkey = r_regionkey
+         AND r_name = 'AMERICA'
+         AND s_nationkey = n2.n_nationkey
+         AND o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+         AND p_type = 'ECONOMY ANODIZED STEEL'
+   )
+   AS all_nations
+GROUP BY
+   o_year
+ORDER BY
+   o_year;

--- a/bench/queries/tpch/q9.sql
+++ b/bench/queries/tpch/q9.sql
@@ -1,0 +1,36 @@
+-- TPC-H Q9 (qualification parameters)
+SELECT
+   nation,
+   o_year,
+   SUM(amount) AS sum_profit
+FROM
+   (
+      SELECT
+         n_name AS nation,
+         EXTRACT(YEAR
+      FROM
+         o_orderdate) AS o_year,
+         l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
+      FROM
+         part,
+         supplier,
+         lineitem,
+         partsupp,
+         orders,
+         nation
+      WHERE
+         s_suppkey = l_suppkey
+         AND ps_suppkey = l_suppkey
+         AND ps_partkey = l_partkey
+         AND p_partkey = l_partkey
+         AND o_orderkey = l_orderkey
+         AND s_nationkey = n_nationkey
+         AND p_name LIKE '%green%'
+   )
+   AS profit
+GROUP BY
+   nation,
+   o_year
+ORDER BY
+   nation,
+   o_year DESC;

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -734,6 +734,18 @@ message QueryBlockAggregate {
     repeated QueryBlockAggFunc aggs = 3;
     // Optional predicate over the emitted group row.
     PushedPredicate having = 4;
+    // Optional regrouping over this aggregate's output rows.
+    //
+    // Ordinals address the first-stage row layout:
+    //   0..group_columns_size-1 are group values
+    //   group_columns_size.. are aggregate values
+    // When this is present, QueryBlockOutputExpr ordinals address the regrouped
+    // layout: GROUP i is group_value_ordinals[i], AGG 0 is COUNT(*).
+    message Regroup {
+        repeated uint32 group_value_ordinals = 1;
+        bool count_star = 2;
+    }
+    Regroup regroup = 5;
 }
 
 message QueryBlockSortKey {

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -52,6 +52,10 @@ enum OpCode {
     TX_VALIDATE_AND_COMMIT = 29;
     TX_EXECUTE_READ_PLAN = 30;
     TX_GET_TABLE_STATS = 31;
+
+    // Secondary-engine computation pushdown.
+    // Executes a query-block operator tree on the LineairDB server.
+    TX_EXECUTE_QUERY_BLOCK = 36;
 }
 
 enum BatchOpType {
@@ -675,6 +679,101 @@ message TxFetchLastSecondaryEntryInRange {
         bool found = 1;
         SecondaryIndexEntry entry = 2;
         bool is_aborted = 3;
+    }
+}
+
+// Secondary-engine query-block request representation.
+//
+// A query block is represented as a tree of scan, join, and aggregate
+// operators over base tables. This is not SQL text, MySQL's AccessPath, or a
+// MySQL Query Execution Plan object; the proxy lowers supported query shapes
+// into this RPC form so the LineairDB server can execute them. Server execution
+// keeps rows as table row references until an expression needs a column value.
+// The response carries final rows in the proxy row format, one field per output
+// expression.
+message QueryBlockAggFunc {
+    enum Kind { COUNT = 0; SUM = 1; AVG = 2; MIN = 3; MAX = 4; }
+    Kind kind = 1;
+    // Table the argument reads from, as an index into Request.tables.
+    uint32 arg_table = 2;
+    // Argument expression over that table's columns. Unset for COUNT(*).
+    FilterExpr arg = 3;
+    // Optional per-row predicate, for conditional aggregates.
+    PushedPredicate filter = 4;
+    // Decimal scale of the argument for result formatting.
+    uint32 arg_scale = 5;
+    // MIN/MAX comparison semantics: 0=numeric decimal, 1=binary string.
+    uint32 cmp_kind = 6;
+}
+
+message QueryBlockColumnRef {
+    uint32 table_idx = 1;
+    uint32 column = 2;      // 0-based TABLE::field index.
+    uint32 cmp_kind = 3;    // 0=int64, 1=binary string, 2=decimal-as-number.
+}
+
+message QueryBlockScan {
+    uint32 table_idx = 1;
+    // Fully pushed single-table predicates for this scan.
+    PushedPredicate filter = 2;
+}
+
+message QueryBlockJoin {
+    uint32 build = 1;  // Node index into TxExecuteQueryBlock.Request.nodes.
+    uint32 probe = 2;
+    // Equi-key pairs, stored as parallel arrays.
+    repeated QueryBlockColumnRef build_keys = 3;
+    repeated QueryBlockColumnRef probe_keys = 4;
+    enum Type { INNER = 0; LEFT = 1; SEMI = 2; ANTI = 3; }
+    Type type = 5;
+}
+
+message QueryBlockAggregate {
+    uint32 input = 1;                       // Node index.
+    repeated QueryBlockColumnRef group_columns = 2; // Byte-equality grouping keys.
+    repeated QueryBlockAggFunc aggs = 3;
+    // Optional predicate over the emitted group row.
+    PushedPredicate having = 4;
+}
+
+message QueryBlockSortKey {
+    uint32 output_ordinal = 1;
+    bool descending = 2;
+    uint32 cmp_kind = 3;  // 0=int64 numeric, 1=binary string, 2=decimal numeric.
+}
+
+message QueryBlockNode {
+    oneof op {
+        QueryBlockScan scan = 1;
+        QueryBlockJoin join = 2;
+        QueryBlockAggregate aggregate = 3;
+    }
+}
+
+message QueryBlockOutputExpr {
+    enum Source { GROUP = 0; AGG = 1; COLUMN = 2; }
+    Source source = 1;
+    uint32 ordinal = 2;      // GROUP: group key index; AGG: aggregate index.
+    QueryBlockColumnRef column = 3;  // Used when source is COLUMN.
+}
+
+message TxExecuteQueryBlock {
+    message TableDesc {
+        string table_name = 1;
+    }
+    message Request {
+        repeated TableDesc tables = 1;
+        // Topological order; the last node is the root.
+        repeated QueryBlockNode nodes = 2;
+        repeated QueryBlockOutputExpr output = 3;
+        repeated QueryBlockSortKey order_by = 4;
+        uint64 limit = 5;  // 0 means no limit.
+        uint64 offset = 6;
+    }
+    message Response {
+        bool ok = 1;
+        string error = 2;
+        repeated bytes rows = 3;  // Proxy row format, output order.
     }
 }
 

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -726,10 +726,19 @@ message QueryBlockColumnRef {
     uint32 prefix_len = 4;
 }
 
+// Runtime semi-filter: keep rows whose local column value appears in the key
+// set produced by an earlier query-block node.
+message QueryBlockSemiFilter {
+    uint32 source_node = 1;  // Node index, already executed.
+    QueryBlockColumnRef source_column = 2;
+    uint32 my_column = 3;    // Column of this scan's table.
+}
+
 message QueryBlockScan {
     uint32 table_idx = 1;
     // Fully pushed single-table predicates for this scan.
     PushedPredicate filter = 2;
+    QueryBlockSemiFilter semi = 3;
 }
 
 message QueryBlockTupleFilter {
@@ -788,6 +797,9 @@ message QueryBlockSortKey {
 // sub-block output ordinals, and refs are row numbers.
 message QueryBlockSubBlock {
     TxExecuteQueryBlock.Request block = 1;
+    QueryBlockSemiFilter semi = 2;
+    uint32 target_table = 3;
+    uint32 target_column = 4;
 }
 
 message QueryBlockNode {

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -696,7 +696,10 @@ message QueryBlockAggFunc {
     Kind kind = 1;
     // Table the argument reads from, as an index into Request.tables.
     uint32 arg_table = 2;
-    // Argument expression over that table's columns. Unset for COUNT(*).
+    // Argument expression over that table's columns. COLUMN_REF nodes may
+    // address another request table by encoding (table_idx << 16) | column in
+    // column_index; arg_table remains the default table for untagged refs.
+    // Unset for COUNT(*).
     FilterExpr arg = 3;
     // Optional per-row predicate, for conditional aggregates.
     PushedPredicate filter = 4;
@@ -710,6 +713,8 @@ message QueryBlockColumnRef {
     uint32 table_idx = 1;
     uint32 column = 2;      // 0-based TABLE::field index.
     uint32 cmp_kind = 3;    // 0=int64, 1=binary string, 2=decimal-as-number.
+    // When nonzero, grouping and output use only the first N cell bytes.
+    uint32 prefix_len = 4;
 }
 
 message QueryBlockScan {

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -714,6 +714,8 @@ message QueryBlockAggFunc {
     // arg_table when the filter and aggregate argument come from different
     // joined tables.
     uint32 filter_table = 8;
+    // COUNT(DISTINCT col): count distinct non-NULL cell values per group.
+    bool distinct = 9;
 }
 
 message QueryBlockColumnRef {

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -474,6 +474,12 @@ message TxUpdateSecondaryIndex {
 message DbCreateTable {
     message Request {
         string table_name = 1;
+        // PAX storage cell widths per encoded row field. Entry 0 is the
+        // null-flags field; later entries follow TABLE::field order. Empty
+        // means the table uses the ordinary row layout. Proxies may send this
+        // unconditionally because the server enables it only under its PAX
+        // storage gate.
+        repeated uint32 pax_field_max_bytes = 2 [packed = true];
     }
     message Response {
         bool success = 1;

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -707,6 +707,13 @@ message QueryBlockAggFunc {
     uint32 arg_scale = 5;
     // MIN/MAX comparison semantics: 0=numeric decimal, 1=binary string.
     uint32 cmp_kind = 6;
+    // Conditional SUM over an ELSE 0 branch returns 0 for a group with no
+    // matching rows instead of SQL NULL.
+    bool zero_if_empty = 7;
+    // Table read by the optional per-row predicate. It may differ from
+    // arg_table when the filter and aggregate argument come from different
+    // joined tables.
+    uint32 filter_table = 8;
 }
 
 message QueryBlockColumnRef {
@@ -723,6 +730,13 @@ message QueryBlockScan {
     PushedPredicate filter = 2;
 }
 
+message QueryBlockTupleFilter {
+    // Predicate over a joined tuple. FilterExpr COLUMN_REF ordinals address
+    // the columns registry below rather than one physical table.
+    PushedPredicate predicate = 1;
+    repeated QueryBlockColumnRef columns = 2;
+}
+
 message QueryBlockJoin {
     uint32 build = 1;  // Node index into TxExecuteQueryBlock.Request.nodes.
     uint32 probe = 2;
@@ -731,6 +745,13 @@ message QueryBlockJoin {
     repeated QueryBlockColumnRef probe_keys = 4;
     enum Type { INNER = 0; LEFT = 1; SEMI = 2; ANTI = 3; }
     Type type = 5;
+    // Optional per-match predicate over the combined probe/build tuple.
+    QueryBlockTupleFilter residual = 6;
+}
+
+message QueryBlockTupleFilterNode {
+    uint32 input = 1;
+    QueryBlockTupleFilter filter = 2;
 }
 
 message QueryBlockAggregate {
@@ -764,14 +785,19 @@ message QueryBlockNode {
         QueryBlockScan scan = 1;
         QueryBlockJoin join = 2;
         QueryBlockAggregate aggregate = 3;
+        QueryBlockTupleFilterNode filter = 4;
     }
 }
 
 message QueryBlockOutputExpr {
-    enum Source { GROUP = 0; AGG = 1; COLUMN = 2; }
+    enum Source { GROUP = 0; AGG = 1; COLUMN = 2; EXPR = 3; }
     Source source = 1;
     uint32 ordinal = 2;      // GROUP: group key index; AGG: aggregate index.
     QueryBlockColumnRef column = 3;  // Used when source is COLUMN.
+    // Arithmetic expression over emitted aggregate-row values. COLUMN_REF
+    // ordinals address [group columns..., aggregate values...].
+    FilterExpr expr = 4;
+    uint32 result_scale = 5;
 }
 
 message TxExecuteQueryBlock {

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -780,12 +780,21 @@ message QueryBlockSortKey {
     uint32 cmp_kind = 3;  // 0=int64 numeric, 1=binary string, 2=decimal numeric.
 }
 
+// A nested query block for a derived table. The server executes it recursively
+// and exposes its output rows as a virtual table. Virtual table indexes start at
+// tables_size and follow sub_block node order; virtual column refs address the
+// sub-block output ordinals, and refs are row numbers.
+message QueryBlockSubBlock {
+    TxExecuteQueryBlock.Request block = 1;
+}
+
 message QueryBlockNode {
     oneof op {
         QueryBlockScan scan = 1;
         QueryBlockJoin join = 2;
         QueryBlockAggregate aggregate = 3;
         QueryBlockTupleFilterNode filter = 4;
+        QueryBlockSubBlock sub_block = 5;
     }
 }
 

--- a/proxy/CMakeLists.txt
+++ b/proxy/CMakeLists.txt
@@ -39,6 +39,7 @@ set(LINEAIRDB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/LineairDB")
 add_subdirectory(${LINEAIRDB_DIR} ${CMAKE_CURRENT_BINARY_DIR}/LineairDB)
 set(LINEAIRDB_PLUGIN_DYNAMIC "ha_lineairdb")
 set(LINEAIRDB_SOURCES ha_lineairdb.cc ha_lineairdb.hh
+                      ha_lineairdb_columnar.cc ha_lineairdb_columnar.hh
                       aggregate_pushdown.cc aggregate_pushdown.hh
                       ddl.cc
                       dml.cc

--- a/proxy/aggregate_pushdown.cc
+++ b/proxy/aggregate_pushdown.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "lineairdb.pb.h"
+#include "lineairdb_keyenc.hh"
 #include "lineairdb_pushdown.hh"
 #include "storage/lineairdb/ha_lineairdb.hh"
 #include "sql/field.h"
@@ -793,6 +794,133 @@ bool ha_lineairdb::tx_has_grouped_semijoin() {
  */
 LineairDBTransaction *ha_lineairdb::tx_for_autogen() {
   return get_transaction(ha_thd());
+}
+
+/**
+ * @brief Materialize a skipped grouped summary leaf as synthetic handler rows.
+ *
+ * Autogen removes the base full-table scan for a recognized grouped summary
+ * leaf, then this helper serves the server-produced group rows through the
+ * normal handler cursor buffers that rnd_next() and index_next() consume.
+ */
+int ha_lineairdb::fill_grouped_summary_buffers(LineairDBTransaction *tx) {
+  const LineairDBTransaction::GroupedSummaryRegistration *registration =
+      tx->grouped_summary_registration(table);
+  if (registration == nullptr) {
+    my_error(ER_INTERNAL_ERROR, MYF(0),
+             "grouped summary scan skipped without registration");
+    return HA_ERR_INTERNAL_ERROR;
+  }
+
+  std::vector<std::string> group_rows;
+  if (const std::vector<std::string> *cached =
+          tx->grouped_semijoin_group_rows(db_table_name)) {
+    group_rows = *cached;
+  } else {
+    LineairDBProxy::ReadPlanStep step;
+    step.table_name = db_table_name;
+    step.is_scan = true;
+    step.end_key_prefix = lineairdb_keyenc::scan_end_sentinel();
+    step.aggregate_serialized = registration->spec;
+    step.serialized_filter = registration->filter;
+    if (!tx->execute_read_plan_raw({step}, &group_rows)) {
+      my_error(ER_LOCK_DEADLOCK, MYF(0));
+      return HA_ERR_LOCK_DEADLOCK;
+    }
+    tx->cache_grouped_semijoin_group_rows(db_table_name, group_rows);
+  }
+
+  reset_index_search_buffers();
+  scanned_keys_.clear();
+  scanned_values_.clear();
+  scan_cache_.clear();
+  buffer_position_ = 0;
+  scan_exhausted_ = true;
+
+  secondary_index_results_.reserve(group_rows.size());
+  secondary_index_payloads_.reserve(group_rows.size());
+  scanned_keys_.reserve(group_rows.size());
+  scanned_values_.reserve(group_rows.size());
+
+  const uint field_count = table->s->fields;
+  if (registration->template_cols.size() != field_count ||
+      registration->group_col >= field_count ||
+      registration->col_a >= field_count ||
+      (!registration->single_sum && registration->col_b >= field_count)) {
+    my_error(ER_INTERNAL_ERROR, MYF(0),
+             "grouped summary registration does not match table shape");
+    return HA_ERR_INTERNAL_ERROR;
+  }
+
+  std::vector<uchar> null_flags(table->s->null_bytes, 0);
+  LineairDBField encoder;
+  LineairDBField group_decoder;
+  const size_t synthetic_key_size =
+      ref_length > sizeof(uint16_t) ? ref_length - sizeof(uint16_t) : 0;
+  if (synthetic_key_size < 2) {
+    my_error(ER_INTERNAL_ERROR, MYF(0),
+             "grouped summary cursor ref is too small");
+    return HA_ERR_INTERNAL_ERROR;
+  }
+
+  for (const std::string &group_row : group_rows) {
+    group_decoder.make_mysql_table_row(
+        reinterpret_cast<const std::byte *>(group_row.data()),
+        group_row.size());
+    if (group_decoder.get_row_size() < (registration->single_sum ? 2 : 3)) {
+      my_error(ER_INTERNAL_ERROR, MYF(0), "malformed grouped summary row");
+      return HA_ERR_INTERNAL_ERROR;
+    }
+
+    std::vector<std::string> row = registration->template_cols;
+    row[registration->group_col] =
+        std::string(group_decoder.get_column_of_row(0));
+    row[registration->col_a] = std::string(group_decoder.get_column_of_row(1));
+    if (!registration->single_sum) {
+      row[registration->col_b] =
+          std::string(group_decoder.get_column_of_row(2));
+    }
+
+    encoder.set_null_field(null_flags.data(), null_flags.size());
+    std::string encoded_row = encoder.get_null_field();
+    for (const std::string &field : row) {
+      encoder.set_lineairdb_field(field.data(), field.size());
+      encoded_row += encoder.get_lineairdb_field();
+    }
+
+    const size_t row_index = scanned_values_.size();
+    const size_t ordinal_bytes = synthetic_key_size - 1;
+    if (ordinal_bytes < sizeof(size_t) &&
+        (row_index >> (ordinal_bytes * 8)) != 0) {
+      my_error(ER_INTERNAL_ERROR, MYF(0),
+               "grouped summary cursor key space exhausted");
+      return HA_ERR_INTERNAL_ERROR;
+    }
+
+    // Grouped summary rows are aggregate output, so they have no storage
+    // primary key. The handler cursor still needs a key for position(),
+    // rnd_pos(), and scan_cache_; keep it within ref_length because MySQL
+    // copies this value through the handler ref buffer.
+    std::string synthetic_key(synthetic_key_size, '\0');
+    synthetic_key[0] = '\x01';
+    for (size_t byte = 1; byte < synthetic_key.size() &&
+                          byte <= sizeof(size_t);
+         ++byte) {
+      synthetic_key[byte] =
+          static_cast<char>((row_index >> ((byte - 1) * 8)) & 0xff);
+    }
+
+    scanned_keys_.push_back(synthetic_key);
+    secondary_index_results_.push_back(synthetic_key);
+    secondary_index_payloads_.push_back(encoded_row);
+    scan_cache_[synthetic_key] = row_index;
+    scanned_values_.emplace_back(
+        reinterpret_cast<const std::byte *>(encoded_row.data()),
+        reinterpret_cast<const std::byte *>(encoded_row.data()) +
+            encoded_row.size());
+  }
+
+  return 0;
 }
 
 /**

--- a/proxy/aggregate_pushdown.cc
+++ b/proxy/aggregate_pushdown.cc
@@ -5,6 +5,7 @@
 #include <map>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "lineairdb.pb.h"
@@ -735,6 +736,56 @@ bool ha_lineairdb::tx_set_pushed_aggregate(const std::string &s) {
 bool ha_lineairdb::tx_is_aborted() {
   auto tx = get_transaction(ha_thd());
   return tx == nullptr || tx->is_aborted();
+}
+
+/**
+ * @brief Register a grouped aggregate leaf for synthetic summary-row serving.
+ */
+void ha_lineairdb::tx_register_grouped_summary(
+    LineairDBTransaction::GroupedSummaryRegistration registration) {
+  auto tx = get_transaction(ha_thd());
+  if (tx == nullptr) return;
+
+  THD *thd = ha_thd();
+  const uint64_t query_id =
+      thd != nullptr ? static_cast<uint64_t>(thd->query_id) : 0;
+  if (tx->autogen_query_id() != query_id) {
+    tx->reset_autogen_for_statement(query_id);
+  }
+  tx->register_grouped_summary(table, std::move(registration));
+}
+
+/**
+ * @brief Register a grouped semijoin reduction for this statement.
+ */
+void ha_lineairdb::tx_register_grouped_semijoin(
+    LineairDBTransaction::GroupedSemijoin grouped_semijoin) {
+  auto tx = get_transaction(ha_thd());
+  if (tx == nullptr) return;
+
+  THD *thd = ha_thd();
+  const uint64_t query_id =
+      thd != nullptr ? static_cast<uint64_t>(thd->query_id) : 0;
+  if (tx->autogen_query_id() != query_id) {
+    tx->reset_autogen_for_statement(query_id);
+  }
+  tx->register_grouped_semijoin(std::move(grouped_semijoin));
+}
+
+/**
+ * @brief Return true if this statement already has grouped-semijoin state.
+ */
+bool ha_lineairdb::tx_has_grouped_semijoin() {
+  auto tx = get_transaction(ha_thd());
+  if (tx == nullptr) return false;
+
+  THD *thd = ha_thd();
+  const uint64_t query_id =
+      thd != nullptr ? static_cast<uint64_t>(thd->query_id) : 0;
+  if (tx->autogen_query_id() != query_id) return false;
+
+  return tx->has_grouped_summary_registrations() ||
+         !tx->grouped_semijoins().empty();
 }
 
 /**

--- a/proxy/aggregate_pushdown.cc
+++ b/proxy/aggregate_pushdown.cc
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
 #include <map>
 #include <string>
@@ -17,6 +18,7 @@
 #include "sql/item.h"
 #include "sql/item_cmpfunc.h"
 #include "sql/item_func.h"
+#include "sql/item_subselect.h"
 #include "sql/item_sum.h"
 #include "sql/join_optimizer/access_path.h"
 #include "sql/join_optimizer/walk_access_paths.h"
@@ -596,6 +598,142 @@ static bool build_aggregate_having_filter(
   rhs->set_string_val(
       std::string(constant_text.ptr(), constant_text.length()));
   predicate.SerializeToString(out);
+  return true;
+}
+
+/**
+ * @brief Return the handler table key used by read-plan steps.
+ */
+static std::string physical_table_key(const TABLE *table) {
+  if (table == nullptr || table->s == nullptr) return {};
+  const TABLE_SHARE *share = table->s;
+  if (share->normalized_path.str == nullptr ||
+      share->normalized_path.length == 0) {
+    return {};
+  }
+  return std::string(share->normalized_path.str, share->normalized_path.length);
+}
+
+/**
+ * @brief Unwrap a WHERE item when it represents an IN subquery predicate.
+ */
+static Item_in_subselect *as_where_in_subselect(Item *item) {
+  if (item == nullptr) return nullptr;
+  Item *current = item->real_item();
+  if (current == nullptr) return nullptr;
+  if (current->type() == Item::CACHE_ITEM) {
+    current = down_cast<Item_cache *>(current)->get_example();
+    if (current == nullptr) return nullptr;
+    current = current->real_item();
+    if (current == nullptr) return nullptr;
+  }
+  if (current->type() == Item::SUBSELECT_ITEM) {
+    Item_subselect *subselect = down_cast<Item_subselect *>(current);
+    if (subselect->substype() == Item_subselect::IN_SUBS) {
+      return down_cast<Item_in_subselect *>(subselect);
+    }
+  }
+
+  if (current->type() != Item::FUNC_ITEM) return nullptr;
+  Item_func *func = down_cast<Item_func *>(current);
+  if (func->argument_count() != 1 ||
+      std::strcmp(func->func_name(), "<in_optimizer>") != 0) {
+    return nullptr;
+  }
+  Item *arg = func->get_arg(0);
+  if (arg == nullptr) return nullptr;
+  arg = arg->real_item();
+  if (arg == nullptr || arg->type() != Item::SUBSELECT_ITEM) return nullptr;
+  Item_subselect *subselect = down_cast<Item_subselect *>(arg);
+  if (subselect->substype() != Item_subselect::IN_SUBS) return nullptr;
+  return down_cast<Item_in_subselect *>(subselect);
+}
+
+/**
+ * @brief Return true if the IN predicate is a top-level WHERE conjunct.
+ */
+static bool is_outer_where_top_level_in(Item *where,
+                                        const Item_in_subselect *subselect) {
+  if (where == nullptr || subselect == nullptr) return false;
+  if (as_where_in_subselect(where) == subselect) return true;
+  if (where->type() != Item::COND_ITEM ||
+      down_cast<Item_cond *>(where)->functype() !=
+          Item_func::COND_AND_FUNC) {
+    return false;
+  }
+  for (Item &arg : *down_cast<Item_cond *>(where)->argument_list()) {
+    if (as_where_in_subselect(&arg) == subselect) return true;
+  }
+  return false;
+}
+
+/**
+ * @brief Return true if table is one of the query block's leaf tables.
+ */
+static bool table_belongs_to_query_block(const Query_block *query_block,
+                                         const TABLE *table) {
+  if (query_block == nullptr || table == nullptr) return false;
+  for (const Table_ref *table_ref = query_block->leaf_tables;
+       table_ref != nullptr; table_ref = table_ref->next_leaf) {
+    if (table_ref->table == table) return true;
+  }
+  return false;
+}
+
+/**
+ * @brief Reject ambiguous physical-table matches in statement read-plan steps.
+ */
+static bool physical_table_is_unique_in_statement(THD *thd,
+                                                  const TABLE *table) {
+  if (thd == nullptr || thd->lex == nullptr || table == nullptr) return false;
+  const std::string key = physical_table_key(table);
+  if (key.empty()) return false;
+
+  int count = 0;
+  for (const Table_ref *table_ref = thd->lex->query_tables;
+       table_ref != nullptr; table_ref = table_ref->next_global) {
+    if (table_ref->table != nullptr &&
+        physical_table_key(table_ref->table) == key) {
+      if (++count > 1) return false;
+    }
+  }
+  return count == 1;
+}
+
+/**
+ * @brief Return true if a grouped-semijoin key can compare raw bytes safely.
+ */
+static bool grouped_semijoin_integer_key_type(const Field *field) {
+  if (field == nullptr || field->result_type() != INT_RESULT) return false;
+  switch (field->type()) {
+    case MYSQL_TYPE_TINY:
+    case MYSQL_TYPE_SHORT:
+    case MYSQL_TYPE_INT24:
+    case MYSQL_TYPE_LONG:
+    case MYSQL_TYPE_LONGLONG:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * @brief Return true if SQL equality matches server byte membership checks.
+ */
+static bool grouped_semijoin_key_bytes_match_sql_equality(
+    const Field *group_field, const Field *outer_field) {
+  if (!grouped_semijoin_integer_key_type(group_field) ||
+      !grouped_semijoin_integer_key_type(outer_field)) {
+    return false;
+  }
+  if (group_field->is_unsigned() != outer_field->is_unsigned()) return false;
+
+  // Field::val_str() zero-pads ZEROFILL integers to display width, so SQL-equal
+  // values from different column widths can have different bytes.
+  if (down_cast<const Field_num *>(group_field)->zerofill ||
+      down_cast<const Field_num *>(outer_field)->zerofill) {
+    return false;
+  }
   return true;
 }
 

--- a/proxy/aggregate_pushdown.cc
+++ b/proxy/aggregate_pushdown.cc
@@ -14,6 +14,7 @@
 #include "storage/lineairdb/ha_lineairdb.hh"
 #include "sql/field.h"
 #include "sql/item.h"
+#include "sql/item_cmpfunc.h"
 #include "sql/item_func.h"
 #include "sql/item_sum.h"
 #include "sql/join_optimizer/access_path.h"
@@ -55,6 +56,20 @@ struct LineairDBAggAccumulator {
   my_decimal p_dec;
   String p_str;            // owns a copy
 };
+
+// HAVING predicate form supported by grouped-semijoin pushdown.
+struct LineairDBHavingPredicate {
+  Item_sum *aggregate = nullptr;
+  LineairDBAggKind kind = LineairDBAggKind::kCount;
+  Item *arg = nullptr;
+  Item_result result_type = INT_RESULT;
+  Item_func::Functype op = Item_func::EQ_FUNC;
+  Item *constant = nullptr;
+};
+
+// Keep aggregate decimal inputs inside the server's __int128 accumulator.
+constexpr uint kLineairDBAggregateDecimalPrecisionMax = 18;
+
 }  // namespace
 
 /**
@@ -184,6 +199,44 @@ static bool is_aggregate_pushdown_shape(THD *thd, JOIN *join) {
 }
 
 /**
+ * @brief Return true if a Field::val_str() value is safe decimal input.
+ *
+ * The server parses aggregate arguments from raw column bytes, so accepted
+ * fields must serialize to decimal text with the same meaning SQL gives them.
+ * Temporal text and wide DECIMAL values are rejected here rather than relying
+ * on server-side overflow checks.
+ */
+static bool is_safe_decimal_aggregate_field(const Field *field) {
+  if (field == nullptr || field->is_array()) return false;
+  switch (field->real_type()) {
+    case MYSQL_TYPE_TINY:
+    case MYSQL_TYPE_SHORT:
+    case MYSQL_TYPE_INT24:
+    case MYSQL_TYPE_LONG:
+    case MYSQL_TYPE_LONGLONG:
+      return field->result_type() == INT_RESULT;
+    case MYSQL_TYPE_NEWDECIMAL:
+      return field->result_type() == DECIMAL_RESULT &&
+             down_cast<const Field_new_decimal *>(field)->precision <=
+                 kLineairDBAggregateDecimalPrecisionMax;
+    default:
+      return false;
+  }
+}
+
+/**
+ * @brief Return a bare field item if it is valid decimal aggregate input.
+ */
+static Item_field *safe_bare_decimal_aggregate_arg(Item *arg) {
+  if (arg == nullptr) return nullptr;
+  Item *real = arg->real_item();
+  if (real == nullptr || real->type() != Item::FIELD_ITEM) return nullptr;
+  Item_field *field_arg = down_cast<Item_field *>(real);
+  return is_safe_decimal_aggregate_field(field_arg->field) ? field_arg
+                                                          : nullptr;
+}
+
+/**
  * @brief Allocate writable Item_cache cells for the already-described output.
  */
 static bool make_aggregate_output_caches(JOIN *join,
@@ -244,6 +297,155 @@ static bool serialize_aggregate_expression(
     default:
       return false;
   }
+}
+
+/**
+ * @brief Classify COUNT/SUM/AVG used by a supported HAVING predicate.
+ */
+static bool classify_having_aggregate(Item_sum *sum,
+                                      LineairDBHavingPredicate *out) {
+  if (sum == nullptr || out == nullptr) return false;
+  if (sum->has_wf() || sum->has_subquery()) return false;
+  switch (sum->sum_func()) {
+    case Item_sum::COUNT_FUNC:
+      out->kind = LineairDBAggKind::kCount;
+      if (sum->argument_count() > 0) {
+        Item *arg0 = sum->arguments()[0];
+        if (!arg0->const_item() || arg0->is_nullable() || arg0->is_null()) {
+          return false;
+        }
+      }
+      break;
+    case Item_sum::SUM_FUNC:
+      out->kind = LineairDBAggKind::kSum;
+      break;
+    case Item_sum::AVG_FUNC:
+      out->kind = LineairDBAggKind::kAvg;
+      break;
+    default:
+      return false;
+  }
+
+  out->result_type = sum->result_type();
+  if (out->kind != LineairDBAggKind::kCount &&
+      out->result_type != DECIMAL_RESULT && out->result_type != INT_RESULT) {
+    return false;
+  }
+  out->arg = sum->argument_count() > 0 ? sum->arguments()[0] : nullptr;
+  if (out->arg != nullptr &&
+      (out->arg->has_subquery() || out->arg->has_aggregation() ||
+       out->arg->is_non_deterministic())) {
+    return false;
+  }
+  if (out->kind != LineairDBAggKind::kCount) {
+    Item_field *field_arg = safe_bare_decimal_aggregate_arg(out->arg);
+    if (field_arg == nullptr) return false;
+    out->arg = field_arg;
+  }
+  out->aggregate = sum;
+  return true;
+}
+
+/**
+ * @brief Parse HAVING of the form aggregate(column) compare constant.
+ *
+ * MySQL can add in2exists helper predicates to HAVING during subquery
+ * optimization. Those generated predicates are ignored; any user-written
+ * HAVING must be a single supported aggregate comparison.
+ */
+static bool parse_aggregate_having(Query_block *query_block,
+                                   LineairDBHavingPredicate *out) {
+  if (query_block == nullptr || out == nullptr) return false;
+  *out = LineairDBHavingPredicate();
+  Item *having = query_block->having_cond();
+  if (having == nullptr) return true;
+
+  if (having->type() == Item::COND_ITEM &&
+      down_cast<Item_cond *>(having)->functype() ==
+          Item_func::COND_AND_FUNC) {
+    Item *user_having = nullptr;
+    for (Item &condition : *down_cast<Item_cond *>(having)->argument_list()) {
+      if (condition.created_by_in2exists()) continue;
+      if (user_having != nullptr) return false;
+      user_having = &condition;
+    }
+    if (user_having == nullptr) return true;
+    having = user_having;
+  } else if (having->created_by_in2exists()) {
+    return true;
+  }
+
+  if (having->type() != Item::FUNC_ITEM) return false;
+  Item_func *func = down_cast<Item_func *>(having);
+  Item_func::Functype op = func->functype();
+  switch (op) {
+    case Item_func::EQ_FUNC:
+    case Item_func::NE_FUNC:
+    case Item_func::LT_FUNC:
+    case Item_func::LE_FUNC:
+    case Item_func::GT_FUNC:
+    case Item_func::GE_FUNC:
+      break;
+    default:
+      return false;
+  }
+  if (func->argument_count() != 2) return false;
+
+  Item *lhs = func->arguments()[0]->real_item();
+  Item *rhs = func->arguments()[1]->real_item();
+  Item *aggregate_side = nullptr;
+  Item *constant_side = nullptr;
+  bool aggregate_on_left = false;
+  if (lhs->type() == Item::SUM_FUNC_ITEM && rhs->const_item()) {
+    aggregate_side = lhs;
+    constant_side = rhs;
+    aggregate_on_left = true;
+  } else if (rhs->type() == Item::SUM_FUNC_ITEM && lhs->const_item()) {
+    aggregate_side = rhs;
+    constant_side = lhs;
+  } else {
+    return false;
+  }
+  if (constant_side->has_subquery() ||
+      constant_side->is_non_deterministic()) {
+    return false;
+  }
+  const Item_result constant_type = constant_side->result_type();
+  if (constant_type != INT_RESULT && constant_type != DECIMAL_RESULT) {
+    return false;
+  }
+  if (constant_type == DECIMAL_RESULT &&
+      constant_side->decimal_precision() >
+          kLineairDBAggregateDecimalPrecisionMax) {
+    return false;
+  }
+  if (!classify_having_aggregate(down_cast<Item_sum *>(aggregate_side), out)) {
+    return false;
+  }
+
+  if (aggregate_on_left) {
+    out->op = op;
+  } else {
+    switch (op) {
+      case Item_func::LT_FUNC:
+        out->op = Item_func::GT_FUNC;
+        break;
+      case Item_func::LE_FUNC:
+        out->op = Item_func::GE_FUNC;
+        break;
+      case Item_func::GT_FUNC:
+        out->op = Item_func::LT_FUNC;
+        break;
+      case Item_func::GE_FUNC:
+        out->op = Item_func::LE_FUNC;
+        break;
+      default:
+        out->op = op;
+        break;
+    }
+  }
+  out->constant = constant_side;
+  return true;
 }
 
 /**

--- a/proxy/aggregate_pushdown.cc
+++ b/proxy/aggregate_pushdown.cc
@@ -738,6 +738,165 @@ static bool grouped_semijoin_key_bytes_match_sql_equality(
 }
 
 /**
+ * @brief Register eligible grouped IN-subquery pushdown state.
+ */
+static void try_register_grouped_semijoin(THD *thd, JOIN *join) {
+  if (thd == nullptr || join == nullptr || thd->lex == nullptr) return;
+  if (thd->lex->sql_command != SQLCOM_SELECT || thd->lex->is_explain()) return;
+
+  Query_block *query_block = join->query_block;
+  if (query_block == nullptr ||
+      query_block->outer_query_block() == nullptr) {
+    return;
+  }
+  Query_block *outer_query_block = query_block->outer_query_block();
+  Query_expression *query_expression = query_block->master_query_expression();
+  if (query_expression == nullptr || !query_expression->is_simple() ||
+      query_expression->uncacheable != 0) {
+    return;
+  }
+  if (query_expression->item == nullptr ||
+      query_expression->item->substype() != Item_subselect::IN_SUBS) {
+    return;
+  }
+
+  Item_in_subselect *in_subquery =
+      down_cast<Item_in_subselect *>(query_expression->item);
+  if (in_subquery->left_expr == nullptr) return;
+  if (!is_outer_where_top_level_in(outer_query_block->where_cond(),
+                                   in_subquery)) {
+    return;
+  }
+  if (in_subquery->value_transform != Item::BOOL_IDENTITY &&
+      in_subquery->value_transform != Item::BOOL_IS_TRUE) {
+    return;
+  }
+
+  if (query_block->leaf_table_count != 1 || !query_block->is_grouped()) return;
+  if (query_block->is_distinct() || query_block->has_limit() ||
+      query_block->olap != UNSPECIFIED_OLAP_TYPE ||
+      query_block->has_windows() || query_block->group_list.elements != 1 ||
+      query_block->having_cond() == nullptr) {
+    return;
+  }
+  if (query_block->where_cond() != nullptr) return;
+
+  TABLE *inner_table = query_block->leaf_tables != nullptr
+                           ? query_block->leaf_tables->table
+                           : nullptr;
+  if (inner_table == nullptr || inner_table->file == nullptr ||
+      inner_table->file->ht != lineairdb_hton) {
+    return;
+  }
+  ha_lineairdb *inner_handler = down_cast<ha_lineairdb *>(inner_table->file);
+  if (!inner_handler->tx_ro_novalidate()) return;
+
+  Item *group_item = *query_block->group_list.first->item;
+  if (group_item->type() != Item::FIELD_ITEM || group_item->is_nullable()) {
+    return;
+  }
+  Field *group_field = down_cast<Item_field *>(group_item)->field;
+  if (group_field == nullptr || group_field->is_nullable()) return;
+
+  std::vector<LineairDBAggOutput> outputs;
+  if (!plan_aggregate_outputs(join, &outputs)) return;
+  if (outputs.size() != 1 ||
+      outputs[0].kind != LineairDBAggKind::kPass) {
+    return;
+  }
+  if (down_cast<Item_field *>(outputs[0].orig)->field != group_field) return;
+
+  LineairDBHavingPredicate having;
+  if (!parse_aggregate_having(query_block, &having) ||
+      having.aggregate == nullptr) {
+    return;
+  }
+
+  std::vector<Item *> group_items{group_item};
+  int having_aggregate_index = -1;
+  std::string aggregate_spec;
+  if (!build_grouped_aggregate_spec(
+          inner_table, inner_handler->tx_ro_novalidate(), outputs, group_items,
+          having, &having_aggregate_index, &aggregate_spec)) {
+    return;
+  }
+  if (having_aggregate_index < 0) return;
+
+  std::string having_filter;
+  const uint32_t having_value_column =
+      static_cast<uint32_t>(group_items.size() + 2 * having_aggregate_index);
+  if (!build_aggregate_having_filter(having, having_value_column,
+                                     &having_filter)) {
+    return;
+  }
+
+  Item *left = in_subquery->left_expr->real_item();
+  if (left->type() != Item::FIELD_ITEM) return;
+  Field *outer_field = down_cast<Item_field *>(left)->field;
+  if (outer_field == nullptr || outer_field->table == nullptr ||
+      outer_field->table->file == nullptr ||
+      outer_field->table->file->ht != lineairdb_hton) {
+    return;
+  }
+
+  TABLE *outer_table = outer_field->table;
+  if (outer_table == inner_table) return;
+  if (!table_belongs_to_query_block(outer_query_block, outer_table)) return;
+  if (!physical_table_is_unique_in_statement(thd, outer_table)) return;
+
+  int probe_column = -1;
+  for (uint field_index = 0; field_index < outer_table->s->fields;
+       ++field_index) {
+    if (outer_table->field[field_index] == outer_field) {
+      probe_column = static_cast<int>(field_index);
+      break;
+    }
+  }
+  if (probe_column < 0) return;
+
+  const Table_ref *outer_table_ref = outer_table->pos_in_table_list;
+  if (outer_table_ref == nullptr ||
+      outer_table_ref->is_inner_table_of_outer_join()) {
+    return;
+  }
+  for (const Table_ref *embedding = outer_table_ref->embedding;
+       embedding != nullptr; embedding = embedding->embedding) {
+    if (embedding->is_sj_or_aj_nest()) return;
+  }
+  if (outer_table_ref->query_block == nullptr ||
+      outer_table_ref->query_block->outer_query_block() != nullptr) {
+    return;
+  }
+  if (outer_field->is_nullable()) return;
+  if (group_field->type() != outer_field->type() ||
+      group_field->pack_length() != outer_field->pack_length()) {
+    return;
+  }
+  if (group_field->result_type() == STRING_RESULT &&
+      group_field->charset() != outer_field->charset()) {
+    return;
+  }
+  if (!grouped_semijoin_key_bytes_match_sql_equality(group_field,
+                                                     outer_field)) {
+    return;
+  }
+
+  const std::string inner_key = physical_table_key(inner_table);
+  const std::string outer_key = physical_table_key(outer_table);
+  if (inner_key.empty() || outer_key.empty()) return;
+
+  if (inner_handler->tx_has_grouped_semijoin()) return;
+
+  LineairDBTransaction::GroupedSemijoin grouped_semijoin;
+  grouped_semijoin.inner_table_key = inner_key;
+  grouped_semijoin.agg_spec = aggregate_spec;
+  grouped_semijoin.having_filter = having_filter;
+  grouped_semijoin.outer_table_key = outer_key;
+  grouped_semijoin.outer_probe_column = static_cast<uint32_t>(probe_column);
+  inner_handler->tx_register_grouped_semijoin(std::move(grouped_semijoin));
+}
+
+/**
  * @brief Execute a supported single-table aggregate SELECT.
  *
  * The caller owns result metadata and EOF. This function only sends data rows.
@@ -1182,6 +1341,7 @@ static bool leaf_is_full_primary_scan(AccessPath *root_path, JOIN *join) {
 }
 
 int lineairdb_push_to_engine(THD *thd, AccessPath *root_path, JOIN *join) {
+  try_register_grouped_semijoin(thd, join);
   if (!is_aggregate_pushdown_shape(thd, join)) return 0;
   // The override reads a PRIMARY full scan; install it only when the plan chose
   // that scan, else its read misses the staged secondary and prefetch aborts.

--- a/proxy/aggregate_pushdown.cc
+++ b/proxy/aggregate_pushdown.cc
@@ -894,6 +894,47 @@ static void try_register_grouped_semijoin(THD *thd, JOIN *join) {
   grouped_semijoin.outer_table_key = outer_key;
   grouped_semijoin.outer_probe_column = static_cast<uint32_t>(probe_column);
   inner_handler->tx_register_grouped_semijoin(std::move(grouped_semijoin));
+
+  if (having.kind != LineairDBAggKind::kSum || having.arg == nullptr) return;
+  Item *sum_arg = having.arg->real_item();
+  if (sum_arg->type() != Item::FIELD_ITEM || sum_arg->is_nullable()) return;
+  Field *sum_field = down_cast<Item_field *>(sum_arg)->field;
+  if (sum_field == nullptr || sum_field->table != inner_table ||
+      sum_field == group_field || sum_field->is_nullable()) {
+    return;
+  }
+
+  int sum_column = -1;
+  int group_column = -1;
+  for (uint field_index = 0; field_index < inner_table->s->fields;
+       ++field_index) {
+    if (inner_table->field[field_index] == sum_field) {
+      sum_column = static_cast<int>(field_index);
+    }
+    if (inner_table->field[field_index] == group_field) {
+      group_column = static_cast<int>(field_index);
+    }
+  }
+  if (sum_column < 0 || group_column < 0) return;
+
+  for (uint field_index = 0; field_index < inner_table->s->fields;
+       ++field_index) {
+    if (!bitmap_is_set(inner_table->read_set, field_index)) continue;
+    if (static_cast<int>(field_index) != sum_column &&
+        static_cast<int>(field_index) != group_column) {
+      return;
+    }
+  }
+
+  LineairDBTransaction::GroupedSummaryRegistration registration;
+  registration.spec = std::move(aggregate_spec);
+  registration.filter = std::move(having_filter);
+  registration.template_cols.assign(inner_table->s->fields, "0");
+  registration.group_col = static_cast<uint32_t>(group_column);
+  registration.col_a = static_cast<uint32_t>(sum_column);
+  registration.col_b = static_cast<uint32_t>(sum_column);
+  registration.single_sum = true;
+  inner_handler->tx_register_grouped_summary(std::move(registration));
 }
 
 /**

--- a/proxy/aggregate_pushdown.cc
+++ b/proxy/aggregate_pushdown.cc
@@ -263,7 +263,9 @@ static bool make_aggregate_output_caches(JOIN *join,
  *
  * Supports column refs, integer constants, and +, -, *, and unary minus.
  */
-static bool serialize_aggregate_expression(
+namespace lineairdb {
+
+bool serialize_aggregate_expression(
     const Item *it, LineairDB::Protocol::FilterExpr *out) {
   switch (it->type()) {
     case Item::FIELD_ITEM: {
@@ -304,6 +306,8 @@ static bool serialize_aggregate_expression(
       return false;
   }
 }
+
+}  // namespace lineairdb
 
 /**
  * @brief Classify COUNT/SUM/AVG used by a supported HAVING predicate.
@@ -508,8 +512,8 @@ static bool build_grouped_aggregate_spec(
                               : LineairDB::Protocol::AggFunc::AGG_AVG);
       if (outputs[output].rtype != DECIMAL_RESULT ||
           outputs[output].arg == nullptr ||
-          !serialize_aggregate_expression(outputs[output].arg,
-                                          aggregate->mutable_arg())) {
+          !lineairdb::serialize_aggregate_expression(
+              outputs[output].arg, aggregate->mutable_arg())) {
         return false;
       }
     }
@@ -525,8 +529,8 @@ static bool build_grouped_aggregate_spec(
                               ? LineairDB::Protocol::AggFunc::AGG_SUM
                               : LineairDB::Protocol::AggFunc::AGG_AVG);
       if (having.result_type != DECIMAL_RESULT || having.arg == nullptr ||
-          !serialize_aggregate_expression(having.arg,
-                                          aggregate->mutable_arg())) {
+          !lineairdb::serialize_aggregate_expression(
+              having.arg, aggregate->mutable_arg())) {
         return false;
       }
     }
@@ -1007,7 +1011,8 @@ static bool execute_aggregate_override(JOIN *join, Query_result *query_result) {
                            : LineairDB::Protocol::AggFunc::AGG_AVG);
           // Server-side SUM/AVG supports exact decimal expressions only.
           if (outs[c].rtype != DECIMAL_RESULT || outs[c].arg == nullptr ||
-              !serialize_aggregate_expression(outs[c].arg, af->mutable_arg())) {
+              !lineairdb::serialize_aggregate_expression(outs[c].arg,
+                                                         af->mutable_arg())) {
             can_use_server_aggregation = false;
             break;
           }

--- a/proxy/aggregate_pushdown.cc
+++ b/proxy/aggregate_pushdown.cc
@@ -789,6 +789,13 @@ bool ha_lineairdb::tx_has_grouped_semijoin() {
 }
 
 /**
+ * @brief Return the transaction used by QEP read-plan autogen.
+ */
+LineairDBTransaction *ha_lineairdb::tx_for_autogen() {
+  return get_transaction(ha_thd());
+}
+
+/**
  * @brief Clear the aggregate spec from the current transaction.
  */
 void ha_lineairdb::tx_clear_pushed_aggregate() {

--- a/proxy/aggregate_pushdown.cc
+++ b/proxy/aggregate_pushdown.cc
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <limits>
 #include <map>
 #include <string>
 #include <string_view>
@@ -70,6 +71,9 @@ struct LineairDBHavingPredicate {
 // Keep aggregate decimal inputs inside the server's __int128 accumulator.
 constexpr uint kLineairDBAggregateDecimalPrecisionMax = 18;
 
+// Wire marker also understood by server/rpc/aggregate_executor.cc.
+constexpr uint32_t kLineairDBAggregateHavingFilterColumns =
+    std::numeric_limits<uint32_t>::max();
 }  // namespace
 
 /**
@@ -445,6 +449,153 @@ static bool parse_aggregate_having(Query_block *query_block,
     }
   }
   out->constant = constant_side;
+  return true;
+}
+
+/**
+ * @brief Build an AggregateSpec that also emits a HAVING aggregate value.
+ */
+static bool build_grouped_aggregate_spec(
+    TABLE *table, bool read_only_no_validate,
+    const std::vector<LineairDBAggOutput> &outputs,
+    const std::vector<Item *> &group_items,
+    const LineairDBHavingPredicate &having, int *having_aggregate_index,
+    std::string *serialized_spec) {
+  if (table == nullptr || having_aggregate_index == nullptr ||
+      serialized_spec == nullptr) {
+    return false;
+  }
+
+  *having_aggregate_index = -1;
+  serialized_spec->clear();
+  if (!read_only_no_validate) return false;
+  for (Item *group_item : group_items) {
+    if (group_item == nullptr || group_item->is_nullable()) return false;
+  }
+
+  const size_t output_count = outputs.size();
+  for (size_t output = 0; output < output_count; ++output) {
+    if (outputs[output].kind == LineairDBAggKind::kPass) {
+      Field *field = down_cast<Item_field *>(outputs[output].orig)->field;
+      bool found_group_column = false;
+      for (size_t group = 0; group < group_items.size(); ++group) {
+        if (down_cast<Item_field *>(group_items[group])->field == field) {
+          found_group_column = true;
+          break;
+        }
+      }
+      if (!found_group_column) return false;
+    }
+  }
+
+  LineairDB::Protocol::AggregateSpec spec;
+  spec.set_num_columns(table->s->fields);
+  for (Item *group_item : group_items) {
+    spec.add_group_columns(
+        down_cast<Item_field *>(group_item)->field->field_index());
+  }
+
+  for (size_t output = 0; output < output_count; ++output) {
+    if (outputs[output].kind == LineairDBAggKind::kPass) continue;
+    auto *aggregate = spec.add_aggs();
+    if (outputs[output].kind == LineairDBAggKind::kCount) {
+      aggregate->set_kind(LineairDB::Protocol::AggFunc::AGG_COUNT);
+    } else {
+      aggregate->set_kind(outputs[output].kind == LineairDBAggKind::kSum
+                              ? LineairDB::Protocol::AggFunc::AGG_SUM
+                              : LineairDB::Protocol::AggFunc::AGG_AVG);
+      if (outputs[output].rtype != DECIMAL_RESULT ||
+          outputs[output].arg == nullptr ||
+          !serialize_aggregate_expression(outputs[output].arg,
+                                          aggregate->mutable_arg())) {
+        return false;
+      }
+    }
+    aggregate->set_result_scale(0);
+  }
+
+  if (having.aggregate != nullptr) {
+    auto *aggregate = spec.add_aggs();
+    if (having.kind == LineairDBAggKind::kCount) {
+      aggregate->set_kind(LineairDB::Protocol::AggFunc::AGG_COUNT);
+    } else {
+      aggregate->set_kind(having.kind == LineairDBAggKind::kSum
+                              ? LineairDB::Protocol::AggFunc::AGG_SUM
+                              : LineairDB::Protocol::AggFunc::AGG_AVG);
+      if (having.result_type != DECIMAL_RESULT || having.arg == nullptr ||
+          !serialize_aggregate_expression(having.arg,
+                                          aggregate->mutable_arg())) {
+        return false;
+      }
+    }
+    aggregate->set_result_scale(0);
+    *having_aggregate_index = spec.aggs_size() - 1;
+  }
+
+  spec.SerializeToString(serialized_spec);
+  return true;
+}
+
+/**
+ * @brief Serialize HAVING as a group-row predicate for the server aggregate.
+ */
+static bool build_aggregate_having_filter(
+    const LineairDBHavingPredicate &having, uint32_t group_row_value_column,
+    std::string *out) {
+  if (out == nullptr || having.aggregate == nullptr ||
+      having.constant == nullptr) {
+    return false;
+  }
+  out->clear();
+
+  // The grouped summary bridge currently consumes SUM/COUNT result columns.
+  if (having.kind == LineairDBAggKind::kAvg) return false;
+
+  LineairDB::Protocol::FilterExpr::Op op;
+  switch (having.op) {
+    case Item_func::GT_FUNC:
+      op = LineairDB::Protocol::FilterExpr::OP_GT;
+      break;
+    case Item_func::GE_FUNC:
+      op = LineairDB::Protocol::FilterExpr::OP_GE;
+      break;
+    case Item_func::LT_FUNC:
+      op = LineairDB::Protocol::FilterExpr::OP_LT;
+      break;
+    case Item_func::LE_FUNC:
+      op = LineairDB::Protocol::FilterExpr::OP_LE;
+      break;
+    case Item_func::EQ_FUNC:
+      op = LineairDB::Protocol::FilterExpr::OP_EQ;
+      break;
+    case Item_func::NE_FUNC:
+      op = LineairDB::Protocol::FilterExpr::OP_NE;
+      break;
+    default:
+      return false;
+  }
+
+  my_decimal decimal_constant;
+  my_decimal *constant = having.constant->val_decimal(&decimal_constant);
+  if (constant == nullptr || having.constant->null_value) return false;
+  String constant_text;
+  if (my_decimal2string(E_DEC_FATAL_ERROR, constant, &constant_text) !=
+      E_DEC_OK) {
+    return false;
+  }
+
+  LineairDB::Protocol::PushedPredicate predicate;
+  predicate.set_num_columns(kLineairDBAggregateHavingFilterColumns);
+  auto *expr = predicate.mutable_expr();
+  expr->set_op(op);
+  auto *lhs = expr->add_children();
+  lhs->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+  lhs->set_column_index(group_row_value_column);
+  auto *rhs = expr->add_children();
+  rhs->set_op(LineairDB::Protocol::FilterExpr::CONST_STRING);
+  rhs->set_string_val(
+      std::string(constant_text.ptr(), constant_text.length()));
+  predicate.SerializeToString(out);
   return true;
 }
 

--- a/proxy/aggregate_pushdown.hh
+++ b/proxy/aggregate_pushdown.hh
@@ -3,9 +3,26 @@
 // Declares the LineairDB engine-pushdown hook installed during plugin
 // initialization.
 
+#include "lineairdb.pb.h"
+
+class Item;
 class THD;
 class JOIN;
 struct AccessPath;
+
+namespace lineairdb {
+
+/**
+ * @brief Serialize an aggregate argument expression for LineairDB.
+ *
+ * Supports field references, integer constants, and simple arithmetic over
+ * those terms. The server evaluates the serialized tree for decimal SUM/AVG
+ * aggregation.
+ */
+bool serialize_aggregate_expression(
+    const Item *item, LineairDB::Protocol::FilterExpr *out);
+
+}  // namespace lineairdb
 
 /**
  * @brief Install the aggregate executor override for supported query shapes.

--- a/proxy/ddl.cc
+++ b/proxy/ddl.cc
@@ -1,5 +1,6 @@
 #include "storage/lineairdb/ha_lineairdb.hh"
 
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -29,6 +30,72 @@ constexpr uint kUniqueSecondaryIndex = 1u;
 constexpr bool kFence = false;
 constexpr uint64_t kBackfillWriteChunkRows = 2000;
 constexpr size_t kBackfillParallelWorkers = 16;
+
+/**
+  @brief Computes PAX cell widths for the encoded row fields of `table`.
+
+  @details LineairDB rows store each MySQL field as the string payload produced
+  by Field::val_str(). The returned vector contains one maximum payload width
+  per encoded row field: entry 0 is the row null-flags field, and the remaining
+  entries follow TABLE::field order. A table with any field wider than the PAX
+  cell cap returns an empty vector so CREATE TABLE keeps the ordinary row
+  layout instead of reserving very wide cells for every row.
+
+  @return Per-field maximum payload widths, or an empty vector when the table
+  should not use PAX storage.
+*/
+std::vector<uint32_t> compute_pax_field_widths(TABLE *table) {
+  // Keep fixed-width cells bounded for variable-width columns such as TEXT.
+  constexpr uint32_t kMaxCellBytes = 2048;
+
+  std::vector<uint32_t> widths;
+  widths.reserve(table->s->fields + 1);
+  widths.push_back(table->s->null_bytes);
+
+  for (uint i = 0; i < table->s->fields; i++) {
+    Field *field = table->field[i];
+    uint32_t width = field->field_length;
+
+    switch (field->type()) {
+      case MYSQL_TYPE_TINY:
+      case MYSQL_TYPE_SHORT:
+      case MYSQL_TYPE_INT24:
+      case MYSQL_TYPE_LONG:
+      case MYSQL_TYPE_LONGLONG:
+      case MYSQL_TYPE_YEAR:
+        // Integer display width is not a payload bound for signed 64-bit text.
+        width = std::max<uint32_t>(width, 21);
+        break;
+      case MYSQL_TYPE_FLOAT:
+      case MYSQL_TYPE_DOUBLE:
+        width = std::max<uint32_t>(width, 40);
+        break;
+      case MYSQL_TYPE_DECIMAL:
+      case MYSQL_TYPE_NEWDECIMAL:
+        // Reserve slack for a sign and decimal point when Field::val_str()
+        // renders a base-10 fixed-point value.
+        width += 2;
+        break;
+      case MYSQL_TYPE_DATE:
+      case MYSQL_TYPE_NEWDATE:
+      case MYSQL_TYPE_TIME:
+      case MYSQL_TYPE_TIME2:
+      case MYSQL_TYPE_DATETIME:
+      case MYSQL_TYPE_DATETIME2:
+      case MYSQL_TYPE_TIMESTAMP:
+      case MYSQL_TYPE_TIMESTAMP2:
+        width = std::max<uint32_t>(width, 32);
+        break;
+      default:
+        break;
+    }
+
+    if (width > kMaxCellBytes) return {};
+    widths.push_back(width);
+  }
+
+  return widths;
+}
 
 }  // namespace
 
@@ -119,7 +186,7 @@ int ha_lineairdb::create(const char *table_name, TABLE *table, HA_CREATE_INFO *,
   // storage. The table/index may already exist from another node's CREATE
   // TABLE; MySQL-side metadata still needs to be created.
   auto proxy = get_proxy();
-  proxy->db_create_table(db_table_name);
+  proxy->db_create_table(db_table_name, compute_pax_field_widths(table));
 
   for (uint i = 0; i < table->s->keys; i++) {
     auto key_info = table->key_info[i];

--- a/proxy/ddl.cc
+++ b/proxy/ddl.cc
@@ -212,6 +212,17 @@ enum_alter_inplace_result ha_lineairdb::check_if_supported_inplace_alter(
       Alter_inplace_info::ADD_UNIQUE_INDEX |
       Alter_inplace_info::DROP_UNIQUE_INDEX;
 
+  // ALTER TABLE ... SECONDARY_ENGINE = x|NULL only changes DD metadata.
+  if (ha_alter_info->handler_flags ==
+          Alter_inplace_info::CHANGE_CREATE_OPTION &&
+      ha_alter_info->create_info != nullptr &&
+      (ha_alter_info->create_info->used_fields &
+       HA_CREATE_USED_SECONDARY_ENGINE) != 0 &&
+      (ha_alter_info->create_info->used_fields &
+       ~HA_CREATE_USED_SECONDARY_ENGINE) == 0) {
+    return HA_ALTER_INPLACE_INSTANT;
+  }
+
   if (ha_alter_info->handler_flags & ~dominated_flags) {
     return HA_ALTER_INPLACE_NOT_SUPPORTED;
   }

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -250,7 +250,11 @@ static int lineairdb_init_func(void *p) {
   lineairdb_hton = (handlerton *)p;
   lineairdb_hton->state = SHOW_OPTION_YES;
   lineairdb_hton->create = lineairdb_create_handler;
-  lineairdb_hton->flags = HTON_CAN_RECREATE;
+  lineairdb_hton->flags =
+      HTON_CAN_RECREATE | HTON_SUPPORTS_SECONDARY_ENGINE;
+  // SECONDARY_LOAD/UNLOAD cleanup calls the primary engine's post_ddl hook.
+  // LineairDB has no post-DDL storage work here, but the hook must be present.
+  lineairdb_hton->post_ddl = [](THD *) {};
   lineairdb_hton->is_supported_system_table =
       lineairdb_is_supported_system_table;
   lineairdb_hton->db_type = DB_TYPE_UNKNOWN;

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -777,6 +777,10 @@ static SHOW_VAR func_status[] = {
      SHOW_SCOPE_GLOBAL},
     {nullptr, nullptr, SHOW_UNDEF, SHOW_SCOPE_UNDEF}};
 
+extern struct st_mysql_storage_engine lineairdb_columnar_storage_engine;
+extern int lineairdb_columnar_init(void *p);
+extern int lineairdb_columnar_deinit(void *p);
+
 mysql_declare_plugin(lineairdb){
     MYSQL_STORAGE_ENGINE_PLUGIN,
     &lineairdb_storage_engine,
@@ -792,4 +796,20 @@ mysql_declare_plugin(lineairdb){
     lineairdb_system_variables, /* system variables */
     nullptr,                    /* config options */
     0,                          /* flags */
+},
+{
+    MYSQL_STORAGE_ENGINE_PLUGIN,
+    &lineairdb_columnar_storage_engine,
+    "LINEAIRDB_COLUMNAR",
+    PLUGIN_AUTHOR_ORACLE,
+    "LineairDB columnar secondary engine",
+    PLUGIN_LICENSE_GPL,
+    lineairdb_columnar_init,   /* Plugin Init */
+    nullptr,                   /* Plugin check uninstall */
+    lineairdb_columnar_deinit, /* Plugin Deinit */
+    0x0001 /* 0.1 */,
+    nullptr, /* status variables */
+    nullptr, /* system variables */
+    nullptr, /* config options */
+    0,       /* flags */
 } mysql_declare_plugin_end;

--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -138,6 +138,7 @@ static ulong srv_server_port = 9999;
 static bool srv_prefetch_execution = false;
 // Non-static: read by LineairDBTransaction at begin (see lineairdb_transaction.cc)
 bool srv_prefetch_ro_novalidate = false;
+handlerton *lineairdb_hton;
 
 // THD-scoped context
 struct LineairDBThdCtx {
@@ -165,6 +166,17 @@ static void ensure_lineairdb_proxy(LineairDBThdCtx *&ctx) {
     ctx->proxy = std::make_shared<LineairDBProxy>(host, port);
   }
 }
+
+namespace lineairdb {
+
+std::shared_ptr<LineairDBProxy> acquire_shared_proxy(THD *thd) {
+  if (thd == nullptr || lineairdb_hton == nullptr) return nullptr;
+  LineairDBThdCtx *&ctx = lineairdb_thd_ctx(thd, lineairdb_hton);
+  ensure_lineairdb_proxy(ctx);
+  return ctx->proxy;
+}
+
+}  // namespace lineairdb
 
 static int lineairdb_commit(handlerton *hton, THD *thd, bool shouldCommit);
 static int lineairdb_abort(handlerton *hton, THD *thd, bool);
@@ -231,8 +243,6 @@ struct lineairdb_vars_t {
 
 static handler *lineairdb_create_handler(handlerton *hton, TABLE_SHARE *table,
                                          bool partitioned, MEM_ROOT *mem_root);
-
-handlerton *lineairdb_hton;
 
 /* Interface to mysqld, to check system tables supported by SE */
 static bool lineairdb_is_supported_system_table(const char *db,

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -45,6 +45,7 @@
 #include <atomic>
 #include <cmath>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
@@ -118,6 +119,18 @@ struct RangeScanLimit {
 RangeScanLimit range_scan_limit_for_order(THD *thd, const KEY *key,
                                           uint matched_prefix,
                                           bool has_mysql_only_filter);
+
+namespace lineairdb {
+
+/**
+ * @brief Return the THD-scoped RPC proxy shared by LineairDB engines.
+ *
+ * The primary handler owns the connection context. Secondary handlers use this
+ * entry point so both engines talk to the same LineairDB server for a session.
+ */
+std::shared_ptr<LineairDBProxy> acquire_shared_proxy(THD *thd);
+
+}  // namespace lineairdb
 
 /** @brief
   Class definition for the storage engine

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -195,6 +195,7 @@ private:
   std::string serialize_hidden_primary_key(uint64_t row_id) const;
   bool fetch_next_batch();
   void reset_index_search_buffers();
+  int fill_grouped_summary_buffers(LineairDBTransaction *tx);
 
 public:
   ha_lineairdb(handlerton *hton, TABLE_SHARE *table_arg);

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -534,6 +534,11 @@ public:
    */
   bool tx_has_grouped_semijoin();
 
+  /**
+   * @brief Return the transaction used by QEP read-plan autogen.
+   */
+  LineairDBTransaction *tx_for_autogen();
+
   int rnd_pos(uchar *buf, uchar *pos) override; ///< required
   void position(const uchar *record) override;  ///< required
   /**

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -517,6 +517,23 @@ public:
    */
   bool tx_is_aborted();
 
+  /**
+   * @brief Register a grouped aggregate leaf for synthetic summary-row serving.
+   */
+  void tx_register_grouped_summary(
+      LineairDBTransaction::GroupedSummaryRegistration registration);
+
+  /**
+   * @brief Register a grouped semijoin reduction for this statement.
+   */
+  void tx_register_grouped_semijoin(
+      LineairDBTransaction::GroupedSemijoin grouped_semijoin);
+
+  /**
+   * @brief Return true if this statement already has grouped-semijoin state.
+   */
+  bool tx_has_grouped_semijoin();
+
   int rnd_pos(uchar *buf, uchar *pos) override; ///< required
   void position(const uchar *record) override;  ///< required
   /**

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1232,42 +1232,34 @@ bool RecognizeFlattenedAggregate(JOIN *join, ColumnarExecutionContext *ctx,
 }
 
 /**
- * @brief Recognize aggregate query blocks supported by LINEAIRDB_COLUMNAR.
+ * @brief Build a query-block request for aggregate shapes.
  *
- * Unsupported shapes return false and set `why`; callers convert that into a
- * secondary-engine reject that may fall back to the primary engine when the
- * session allows it.
+ * Unsupported shapes return false and set `why`; callers decide whether the
+ * primary engine may run instead.
  */
-bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
-                         const char **why) {
+bool BuildQueryBlockRequest(
+    JOIN *join, Query_block *qb,
+    LineairDB::Protocol::TxExecuteQueryBlock::Request *request_out,
+    const char **why) {
 #define LDB_COL_REJECT(reason) \
   do {                         \
     *why = (reason);           \
     return false;              \
   } while (0)
 
-  ctx->query_block_request.Clear();
-  ctx->query_block_ready = false;
-
-  Query_block *qb = join->query_block;
-  if (qb == nullptr || qb->outer_query_block() != nullptr)
-    LDB_COL_REJECT("not top-level");
+  if (qb == nullptr || request_out == nullptr) LDB_COL_REJECT("missing block");
 
   Query_expression *unit = qb->master_query_expression();
   if (unit == nullptr || !unit->is_simple())
     LDB_COL_REJECT("not simple unit");
 
-  if (qb->leaf_tables != nullptr && qb->leaf_tables->next_leaf == nullptr &&
-      qb->leaf_tables->is_view_or_derived()) {
-    if (RecognizeDerivedRegroup(join, ctx, why)) return true;
-    return RecognizeFlattenedAggregate(join, ctx, why);
-  }
-
   if (qb->having_cond() != nullptr) LDB_COL_REJECT("has HAVING");
   if (qb->is_distinct()) LDB_COL_REJECT("has DISTINCT");
   if (qb->has_windows()) LDB_COL_REJECT("has windows");
   if (qb->olap != UNSPECIFIED_OLAP_TYPE) LDB_COL_REJECT("has ROLLUP");
-  if (!join->implicit_grouping && qb->group_list.elements == 0)
+  const bool implicit_grouping =
+      join != nullptr ? join->implicit_grouping : qb->is_implicitly_grouped();
+  if (!implicit_grouping && qb->group_list.elements == 0)
     LDB_COL_REJECT("no aggregation");
 
   struct SemijoinNest {
@@ -1338,7 +1330,9 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
   std::vector<JoinEdge> join_edges;
   std::vector<Item *> tuple_predicates;
   Item *where_cond =
-      qb->where_cond() != nullptr ? qb->where_cond() : join->where_cond;
+      qb->where_cond() != nullptr
+          ? qb->where_cond()
+          : (join != nullptr ? join->where_cond : nullptr);
   std::vector<Item *> predicates;
   FlattenAnd(where_cond, &predicates);
 
@@ -1492,7 +1486,8 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
     LDB_COL_REJECT("cross join");
 
   // Scan every table once, attaching only predicates that read that table.
-  auto &request = ctx->query_block_request;
+  auto &request = *request_out;
+  request.Clear();
   std::vector<int> scan_nodes(tables.size(), -1);
   for (size_t table_idx = 0; table_idx < tables.size(); table_idx++) {
     TABLE *table = tables[table_idx].table;
@@ -2165,12 +2160,47 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
     }
   }
 
-  ctx->query_block_ready = true;
-
   *why = nullptr;
   return true;
 
 #undef LDB_COL_REJECT
+}
+
+/**
+ * @brief Recognize aggregate query blocks supported by LINEAIRDB_COLUMNAR.
+ *
+ * Unsupported shapes return false and set `why`; callers convert that into a
+ * secondary-engine reject that may fall back to the primary engine when the
+ * session allows it.
+ */
+bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
+                         const char **why) {
+  ctx->query_block_request.Clear();
+  ctx->query_block_ready = false;
+
+  Query_block *qb = join == nullptr ? nullptr : join->query_block;
+  if (qb == nullptr || qb->outer_query_block() != nullptr) {
+    *why = "not top-level";
+    return false;
+  }
+
+  Query_expression *unit = qb->master_query_expression();
+  if (unit == nullptr || !unit->is_simple()) {
+    *why = "not simple unit";
+    return false;
+  }
+
+  if (qb->leaf_tables != nullptr && qb->leaf_tables->next_leaf == nullptr &&
+      qb->leaf_tables->is_view_or_derived()) {
+    if (RecognizeDerivedRegroup(join, ctx, why)) return true;
+    return RecognizeFlattenedAggregate(join, ctx, why);
+  }
+
+  if (!BuildQueryBlockRequest(join, qb, &ctx->query_block_request, why)) {
+    return false;
+  }
+  ctx->query_block_ready = true;
+  return true;
 }
 
 /**

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -247,18 +247,15 @@ bool GroupColumnIsBinarySafe(const Field *field) {
  * @brief Return the visible output ordinal used by an ORDER BY item.
  */
 int OrderOutputOrdinal(Item *order_item,
-                       const std::vector<Item *> &output_items, TABLE *table) {
+                       const std::vector<Item *> &output_items) {
   Item *order_real = order_item->real_item();
   for (size_t i = 0; i < output_items.size(); i++) {
     Item *output_real = output_items[i]->real_item();
     if (output_real == order_real) return static_cast<int>(i);
     if (order_real->type() == Item::FIELD_ITEM &&
         output_real->type() == Item::FIELD_ITEM) {
-      const Field *order_field = ResolveBaseField(
-          down_cast<Item_field *>(order_real)->field, table);
-      const Field *output_field = ResolveBaseField(
-          down_cast<Item_field *>(output_real)->field, table);
-      if (order_field != nullptr && order_field == output_field) {
+      if (down_cast<Item_field *>(order_real)->field ==
+          down_cast<Item_field *>(output_real)->field) {
         return static_cast<int>(i);
       }
     }
@@ -267,14 +264,105 @@ int OrderOutputOrdinal(Item *order_item,
 }
 
 /**
- * @brief Recognize single-table aggregate blocks supported by LINEAIRDB_COLUMNAR.
+ * @brief Flatten a top-level AND tree into individual predicates.
+ */
+void FlattenAnd(Item *condition, std::vector<Item *> *predicates) {
+  if (condition == nullptr) return;
+  if (condition->type() == Item::COND_ITEM &&
+      down_cast<Item_cond *>(condition)->functype() ==
+          Item_func::COND_AND_FUNC) {
+    List_iterator<Item> it(
+        *down_cast<Item_cond *>(condition)->argument_list());
+    for (Item *child = it++; child != nullptr; child = it++) {
+      FlattenAnd(child, predicates);
+    }
+    return;
+  }
+  predicates->push_back(condition);
+}
+
+/**
+ * @brief Convert SUM(CASE WHEN pred THEN 1 ELSE 0 END) to a COUNT filter.
+ */
+Item *CaseToCountFilter(Item *argument) {
+  if (argument->type() != Item::FUNC_ITEM) return nullptr;
+  auto *function = down_cast<Item_func *>(argument);
+  if (function->functype() != Item_func::CASE_FUNC) return nullptr;
+  if (function->argument_count() != 3) return nullptr;
+
+  Item *predicate = function->arguments()[0];
+  Item *then_item = function->arguments()[1];
+  Item *else_item = function->arguments()[2];
+  if (!then_item->const_item() || !else_item->const_item()) return nullptr;
+  if (then_item->val_int() != 1 || else_item->val_int() != 0) return nullptr;
+  return predicate;
+}
+
+struct QueryBlockTable {
+  TABLE *table = nullptr;
+  table_map map = 0;
+};
+
+/**
+ * @brief Return the only query table referenced by a table_map.
+ */
+int SingleTableOf(table_map used, const std::vector<QueryBlockTable> &tables) {
+  int found = -1;
+  for (size_t i = 0; i < tables.size(); i++) {
+    if ((used & tables[i].map) == 0) continue;
+    if (found >= 0) return -1;
+    found = static_cast<int>(i);
+  }
+  return found;
+}
+
+/**
+ * @brief Resolve a Field to the query table that owns it.
+ */
+int TableIndexOfField(const Field *field,
+                      const std::vector<QueryBlockTable> &tables) {
+  if (field == nullptr) return -1;
+  for (size_t i = 0; i < tables.size(); i++) {
+    if (field->table == tables[i].table) return static_cast<int>(i);
+  }
+  int found = -1;
+  for (size_t i = 0; i < tables.size(); i++) {
+    if (ResolveBaseField(field, tables[i].table) != nullptr) {
+      if (found >= 0) return -1;
+      found = static_cast<int>(i);
+    }
+  }
+  return found;
+}
+
+/**
+ * @brief Serialize one table's pushed predicates as a single PushedPredicate.
+ */
+bool SerializeTableFilters(const std::vector<Item *> &filters, TABLE *table,
+                           LineairDB::Protocol::PushedPredicate *predicate) {
+  if (filters.empty()) return true;
+  predicate->set_num_columns(table->s->fields);
+  if (filters.size() == 1) {
+    return serialize_item(filters[0], predicate->mutable_expr());
+  }
+
+  auto *root = predicate->mutable_expr();
+  root->set_op(LineairDB::Protocol::FilterExpr::OP_AND);
+  for (Item *filter : filters) {
+    if (!serialize_item(filter, root->add_children())) return false;
+  }
+  return true;
+}
+
+/**
+ * @brief Recognize aggregate query blocks supported by LINEAIRDB_COLUMNAR.
  *
  * Unsupported shapes return false and set `why`; callers convert that into a
  * secondary-engine reject that may fall back to the primary engine when the
  * session allows it.
  */
-bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
-                                   const char **why) {
+bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
+                         const char **why) {
 #define LDB_COL_REJECT(reason) \
   do {                         \
     *why = (reason);           \
@@ -292,13 +380,6 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
   if (unit == nullptr || !unit->is_simple())
     LDB_COL_REJECT("not simple unit");
 
-  Table_ref *table_ref = qb->leaf_tables;
-  if (table_ref == nullptr || table_ref->next_leaf != nullptr)
-    LDB_COL_REJECT("not single table");
-
-  TABLE *table = table_ref->table;
-  if (table == nullptr || table->s == nullptr) LDB_COL_REJECT("no TABLE");
-
   if (qb->having_cond() != nullptr) LDB_COL_REJECT("has HAVING");
   if (qb->is_distinct()) LDB_COL_REJECT("has DISTINCT");
   if (qb->has_windows()) LDB_COL_REJECT("has windows");
@@ -306,36 +387,164 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
   if (!join->implicit_grouping && qb->group_list.elements == 0)
     LDB_COL_REJECT("no aggregation");
 
-  if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
-    LDB_COL_REJECT("not SECONDARY_LOADed");
+  // The request table order is the stable numbering used by scan, join,
+  // grouping, and aggregate argument references.
+  std::vector<QueryBlockTable> tables;
+  for (Table_ref *table_ref = qb->leaf_tables; table_ref != nullptr;
+       table_ref = table_ref->next_leaf) {
+    TABLE *table = table_ref->table;
+    if (table == nullptr || table->s == nullptr) LDB_COL_REJECT("no TABLE");
+    if (table_ref->outer_join) LDB_COL_REJECT("outer join");
+    if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
+      LDB_COL_REJECT("not SECONDARY_LOADed");
+    tables.push_back({table, table_ref->map()});
+  }
+  if (tables.empty()) LDB_COL_REJECT("no tables");
 
-  auto &request = ctx->query_block_request;
-  request.add_tables()->set_table_name(table->s->normalized_path.str);
+  struct JoinEdge {
+    int left_table = -1;
+    int right_table = -1;
+    const Field *left_field = nullptr;
+    const Field *right_field = nullptr;
+  };
 
-  auto *scan_node = request.add_nodes();
-  auto *scan = scan_node->mutable_scan();
-  scan->set_table_idx(0);
+  std::vector<std::vector<Item *>> table_filters(tables.size());
+  std::vector<JoinEdge> join_edges;
   Item *where_cond =
       qb->where_cond() != nullptr ? qb->where_cond() : join->where_cond;
-  if (where_cond != nullptr) {
-    auto *predicate = scan->mutable_filter();
-    if (!serialize_item(where_cond, predicate->mutable_expr()))
-      LDB_COL_REJECT("WHERE not pushable");
-    predicate->set_num_columns(table->s->fields);
+  std::vector<Item *> predicates;
+  FlattenAnd(where_cond, &predicates);
+
+  // Local predicates become scan filters. Cross-table integer equalities become
+  // join edges; other cross-table shapes stay on the primary engine path.
+  for (Item *predicate : predicates) {
+    const table_map used = predicate->used_tables() & ~PSEUDO_TABLE_BITS;
+    const int table_idx = SingleTableOf(used, tables);
+    if (table_idx >= 0) {
+      table_filters[table_idx].push_back(predicate);
+      continue;
+    }
+    if (used == 0) {
+      table_filters[0].push_back(predicate);
+      continue;
+    }
+
+    if (predicate->type() != Item::FUNC_ITEM ||
+        down_cast<Item_func *>(predicate)->functype() != Item_func::EQ_FUNC) {
+      LDB_COL_REJECT("non-equi join predicate");
+    }
+    auto *equals = down_cast<Item_func *>(predicate);
+    Item *left = equals->arguments()[0]->real_item();
+    Item *right = equals->arguments()[1]->real_item();
+    if (left->type() != Item::FIELD_ITEM ||
+        right->type() != Item::FIELD_ITEM) {
+      LDB_COL_REJECT("join key not a column");
+    }
+
+    const Field *left_raw = down_cast<Item_field *>(left)->field;
+    const Field *right_raw = down_cast<Item_field *>(right)->field;
+    const int left_table = TableIndexOfField(left_raw, tables);
+    const int right_table = TableIndexOfField(right_raw, tables);
+    if (left_table < 0 || right_table < 0 || left_table == right_table) {
+      LDB_COL_REJECT("join key tables");
+    }
+    if (left_raw->result_type() != INT_RESULT ||
+        right_raw->result_type() != INT_RESULT) {
+      LDB_COL_REJECT("non-integer join key");
+    }
+
+    const Field *left_field =
+        ResolveBaseField(left_raw, tables[left_table].table);
+    const Field *right_field =
+        ResolveBaseField(right_raw, tables[right_table].table);
+    if (left_field == nullptr || right_field == nullptr) {
+      LDB_COL_REJECT("join key unresolvable");
+    }
+    join_edges.push_back({left_table, right_table, left_field, right_field});
+  }
+  if (tables.size() > 1 && join_edges.empty()) LDB_COL_REJECT("cross join");
+
+  // Scan every table once, attaching only predicates that read that table.
+  auto &request = ctx->query_block_request;
+  std::vector<int> scan_nodes(tables.size(), -1);
+  for (size_t table_idx = 0; table_idx < tables.size(); table_idx++) {
+    TABLE *table = tables[table_idx].table;
+    request.add_tables()->set_table_name(table->s->normalized_path.str);
+    auto *scan_node = request.add_nodes();
+    auto *scan = scan_node->mutable_scan();
+    scan->set_table_idx(static_cast<uint32_t>(table_idx));
+    scan_nodes[table_idx] = request.nodes_size() - 1;
+    if (!table_filters[table_idx].empty() &&
+        !SerializeTableFilters(table_filters[table_idx], table,
+                               scan->mutable_filter())) {
+      LDB_COL_REJECT("filter not pushable");
+    }
+  }
+
+  // Build a left-deep INNER join tree in FROM-clause order. Each new table must
+  // have at least one equality edge to the already joined side.
+  int current_node = scan_nodes[0];
+  std::vector<bool> joined(tables.size(), false);
+  joined[0] = true;
+  for (size_t table_idx = 1; table_idx < tables.size(); table_idx++) {
+    bool connected = false;
+    auto *join_node = request.add_nodes()->mutable_join();
+    join_node->set_type(LineairDB::Protocol::QueryBlockJoin::INNER);
+    join_node->set_build(scan_nodes[table_idx]);
+    join_node->set_probe(current_node);
+
+    for (const JoinEdge &edge : join_edges) {
+      const Field *build_field = nullptr;
+      const Field *probe_field = nullptr;
+      int probe_table = -1;
+      if (edge.left_table == static_cast<int>(table_idx) &&
+          joined[edge.right_table]) {
+        build_field = edge.left_field;
+        probe_field = edge.right_field;
+        probe_table = edge.right_table;
+      } else if (edge.right_table == static_cast<int>(table_idx) &&
+                 joined[edge.left_table]) {
+        build_field = edge.right_field;
+        probe_field = edge.left_field;
+        probe_table = edge.left_table;
+      } else {
+        continue;
+      }
+
+      auto *build_key = join_node->add_build_keys();
+      build_key->set_table_idx(static_cast<uint32_t>(table_idx));
+      build_key->set_column(build_field->field_index());
+      auto *probe_key = join_node->add_probe_keys();
+      probe_key->set_table_idx(static_cast<uint32_t>(probe_table));
+      probe_key->set_column(probe_field->field_index());
+      connected = true;
+    }
+
+    if (!connected) LDB_COL_REJECT("disconnected join graph");
+    joined[table_idx] = true;
+    current_node = request.nodes_size() - 1;
   }
 
   auto *aggregate_node = request.add_nodes();
   auto *aggregate = aggregate_node->mutable_aggregate();
-  aggregate->set_input(0);
-  std::vector<const Field *> group_fields;
+  aggregate->set_input(current_node);
+  struct GroupField {
+    int table = -1;
+    const Field *field = nullptr;
+  };
+  std::vector<GroupField> group_fields;
   for (ORDER *group = qb->group_list.first; group != nullptr;
        group = group->next) {
     Item *group_item = (*group->item)->real_item();
     if (group_item->type() != Item::FIELD_ITEM)
       LDB_COL_REJECT("group item not a column");
 
-    const Field *group_field = ResolveBaseField(
-        down_cast<Item_field *>(group_item)->field, table);
+    const Field *raw_group_field =
+        down_cast<Item_field *>(group_item)->field;
+    const int group_table = TableIndexOfField(raw_group_field, tables);
+    if (group_table < 0) LDB_COL_REJECT("group column foreign");
+    const Field *group_field =
+        ResolveBaseField(raw_group_field, tables[group_table].table);
     if (group_field == nullptr) LDB_COL_REJECT("group column foreign");
     if (group_field->is_nullable() ||
         !GroupColumnIsBinarySafe(group_field)) {
@@ -343,28 +552,36 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
     }
 
     auto *group_column = aggregate->add_group_columns();
-    group_column->set_table_idx(0);
+    group_column->set_table_idx(static_cast<uint32_t>(group_table));
     group_column->set_column(group_field->field_index());
     group_column->set_cmp_kind(group_field->result_type() == STRING_RESULT ? 1
                                                                            : 0);
-    group_fields.push_back(group_field);
+    group_fields.push_back({group_table, group_field});
   }
 
   std::vector<Item *> output_items;
   for (Item *item : VisibleFields(qb->fields)) output_items.push_back(item);
 
+  // The response must match MySQL's visible SELECT list exactly: grouped
+  // columns refer back to group keys, aggregate items refer to aggregate slots.
   for (Item *item : output_items) {
     Item *real = item->real_item();
     auto *output = request.add_output();
     if (real->type() == Item::FIELD_ITEM) {
-      const Field *output_field = ResolveBaseField(
-          down_cast<Item_field *>(real)->field, table);
+      const Field *raw_output_field = down_cast<Item_field *>(real)->field;
+      const int output_table = TableIndexOfField(raw_output_field, tables);
+      const Field *output_field =
+          output_table >= 0
+              ? ResolveBaseField(raw_output_field,
+                                 tables[output_table].table)
+              : nullptr;
       if (output_field == nullptr)
         LDB_COL_REJECT("output column unresolvable");
 
       int group_position = -1;
       for (size_t i = 0; i < group_fields.size(); i++) {
-        if (group_fields[i] == output_field) {
+        if (group_fields[i].table == output_table &&
+            group_fields[i].field == output_field) {
           group_position = static_cast<int>(i);
           break;
         }
@@ -384,10 +601,9 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
     if (sum->argument_count() > 1) LDB_COL_REJECT("aggregate arg count");
 
     auto *function = aggregate->add_aggs();
-    function->set_arg_table(0);
-
     switch (sum->sum_func()) {
       case Item_sum::COUNT_FUNC: {
+        function->set_arg_table(0);
         if (sum->argument_count() > 0) {
           Item *arg = sum->get_arg(0)->real_item();
           if (arg->const_item()) {
@@ -396,10 +612,17 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
           } else {
             if (arg->type() != Item::FIELD_ITEM)
               LDB_COL_REJECT("COUNT arg shape");
-            const Field *count_field = ResolveBaseField(
-                down_cast<Item_field *>(arg)->field, table);
+            const Field *raw_count_field =
+                down_cast<Item_field *>(arg)->field;
+            const int count_table = TableIndexOfField(raw_count_field, tables);
+            const Field *count_field =
+                count_table >= 0
+                    ? ResolveBaseField(raw_count_field,
+                                       tables[count_table].table)
+                    : nullptr;
             if (count_field == nullptr || count_field->is_nullable())
               LDB_COL_REJECT("COUNT arg nullable");
+            function->set_arg_table(static_cast<uint32_t>(count_table));
           }
         }
 
@@ -411,14 +634,33 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
       case Item_sum::AVG_FUNC: {
         if (sum->argument_count() != 1) LDB_COL_REJECT("aggregate arg count");
         Item *arg = sum->get_arg(0)->real_item();
+        if (sum->sum_func() == Item_sum::SUM_FUNC) {
+          if (Item *filter = CaseToCountFilter(arg)) {
+            const int filter_table = SingleTableOf(
+                filter->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+            if (filter_table < 0) LDB_COL_REJECT("CASE filter tables");
+            auto *predicate = function->mutable_filter();
+            predicate->set_num_columns(tables[filter_table].table->s->fields);
+            if (!serialize_item(filter, predicate->mutable_expr()))
+              LDB_COL_REJECT("CASE filter not pushable");
+            function->set_arg_table(static_cast<uint32_t>(filter_table));
+            function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
+            break;
+          }
+        }
         if (arg->result_type() != DECIMAL_RESULT &&
             arg->result_type() != INT_RESULT) {
           LDB_COL_REJECT("aggregate arg type");
         }
 
+        const int argument_table =
+            SingleTableOf(arg->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+        if (argument_table < 0) LDB_COL_REJECT("aggregate arg tables");
         if (arg->type() == Item::FIELD_ITEM) {
+          const Field *raw_argument_field =
+              down_cast<Item_field *>(arg)->field;
           const Field *argument_field = ResolveBaseField(
-              down_cast<Item_field *>(arg)->field, table);
+              raw_argument_field, tables[argument_table].table);
           if (argument_field == nullptr)
             LDB_COL_REJECT("aggregate arg unresolvable");
 
@@ -432,6 +674,7 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
           }
         }
 
+        function->set_arg_table(static_cast<uint32_t>(argument_table));
         function->set_kind(
             sum->sum_func() == Item_sum::SUM_FUNC
                 ? LineairDB::Protocol::QueryBlockAggFunc::SUM
@@ -445,13 +688,21 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
         if (sum->argument_count() != 1) LDB_COL_REJECT("aggregate arg count");
         Item *arg = sum->get_arg(0)->real_item();
         if (arg->type() != Item::FIELD_ITEM) LDB_COL_REJECT("minmax arg");
-        const Field *argument_field = ResolveBaseField(
-            down_cast<Item_field *>(arg)->field, table);
+        const Field *raw_argument_field =
+            down_cast<Item_field *>(arg)->field;
+        const int argument_table =
+            TableIndexOfField(raw_argument_field, tables);
+        const Field *argument_field =
+            argument_table >= 0
+                ? ResolveBaseField(raw_argument_field,
+                                   tables[argument_table].table)
+                : nullptr;
         if (argument_field == nullptr) LDB_COL_REJECT("minmax unresolvable");
 
         auto *ref = function->mutable_arg();
         ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
         ref->set_column_index(argument_field->field_index());
+        function->set_arg_table(static_cast<uint32_t>(argument_table));
         function->set_kind(
             sum->sum_func() == Item_sum::MIN_FUNC
                 ? LineairDB::Protocol::QueryBlockAggFunc::MIN
@@ -475,7 +726,7 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
   for (ORDER *order = qb->order_list.first; order != nullptr;
        order = order->next) {
     const int output_ordinal =
-        OrderOutputOrdinal(*order->item, output_items, table);
+        OrderOutputOrdinal(*order->item, output_items);
     if (output_ordinal < 0)
       LDB_COL_REJECT("ORDER BY not an output column");
 
@@ -592,7 +843,7 @@ bool OptimizeSecondaryEngine(THD *, LEX *lex) {
   Query_block *query_block = lex->unit->first_query_block();
   JOIN *join = query_block != nullptr ? query_block->join : nullptr;
   const char *why = "no JOIN";
-  if (join == nullptr || !RecognizeSingleTableAggregate(join, ctx, &why)) {
+  if (join == nullptr || !RecognizeQueryBlock(join, ctx, &why)) {
     char message[128];
     snprintf(message, sizeof(message),
              "LINEAIRDB_COLUMNAR unsupported shape: %s", why ? why : "?");

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -338,6 +338,26 @@ Item *CaseToCountFilter(Item *argument) {
   return predicate;
 }
 
+/**
+ * @brief Split SUM(CASE WHEN predicate THEN expression ELSE 0 END).
+ */
+bool CaseToFilteredSum(Item *argument, Item **predicate, Item **then_expr) {
+  if (argument->type() != Item::FUNC_ITEM) return false;
+  auto *function = down_cast<Item_func *>(argument);
+  if (function->functype() != Item_func::CASE_FUNC) return false;
+  if (function->argument_count() != 3) return false;
+
+  Item *condition = function->arguments()[0];
+  Item *value = function->arguments()[1];
+  Item *else_value = function->arguments()[2];
+  if (!IsBooleanFilterShape(condition)) return false;
+  if (!else_value->const_item() || else_value->val_int() != 0) return false;
+
+  *predicate = condition;
+  *then_expr = value;
+  return true;
+}
+
 struct QueryBlockTable {
   TABLE *table = nullptr;
   table_map map = 0;
@@ -1507,6 +1527,59 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
               LDB_COL_REJECT("CASE filter not pushable");
             function->set_arg_table(static_cast<uint32_t>(filter_table));
             function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
+            break;
+          }
+
+          Item *filter = nullptr;
+          Item *then_expr = nullptr;
+          if (CaseToFilteredSum(arg, &filter, &then_expr)) {
+            if (then_expr->result_type() != DECIMAL_RESULT &&
+                then_expr->result_type() != INT_RESULT) {
+              LDB_COL_REJECT("CASE expression type");
+            }
+
+            const int filter_table = SingleTableOf(
+                filter->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+            if (filter_table < 0) LDB_COL_REJECT("CASE filter tables");
+            auto *predicate = function->mutable_filter();
+            predicate->set_num_columns(tables[filter_table].table->s->fields);
+            if (!serialize_item(filter, predicate->mutable_expr()))
+              LDB_COL_REJECT("CASE filter not pushable");
+
+            int argument_table = SingleTableOf(
+                then_expr->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+            if (argument_table >= 0 &&
+                then_expr->real_item()->type() == Item::FIELD_ITEM) {
+              const Field *raw_argument_field =
+                  down_cast<Item_field *>(then_expr->real_item())->field;
+              const Field *argument_field = ResolveBaseField(
+                  raw_argument_field, tables[argument_table].table);
+              if (argument_field == nullptr)
+                LDB_COL_REJECT("CASE expression unresolvable");
+
+              auto *ref = function->mutable_arg();
+              ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+              ref->set_column_index(argument_field->field_index());
+            } else if (argument_table >= 0) {
+              if (!lineairdb::serialize_aggregate_expression(
+                      then_expr->real_item(), function->mutable_arg())) {
+                LDB_COL_REJECT("CASE expression not pushable");
+              }
+            } else {
+              argument_table = 0;
+              if (!SerializeAggregateExpressionForTables(
+                      then_expr->real_item(), tables,
+                      static_cast<uint32_t>(argument_table),
+                      function->mutable_arg())) {
+                LDB_COL_REJECT("CASE expression not pushable");
+              }
+            }
+
+            function->set_arg_table(static_cast<uint32_t>(argument_table));
+            function->set_filter_table(static_cast<uint32_t>(filter_table));
+            function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::SUM);
+            function->set_arg_scale(then_expr->decimals);
+            function->set_zero_if_empty(true);
             break;
           }
         }

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -287,6 +287,40 @@ void FlattenAnd(Item *condition, std::vector<Item *> *predicates) {
 }
 
 /**
+ * @brief Return true when an Item shape is a boolean filter predicate.
+ */
+bool IsBooleanFilterShape(Item *item) {
+  item = item == nullptr ? nullptr : item->real_item();
+  if (item == nullptr) return false;
+
+  if (item->type() == Item::COND_ITEM) {
+    const auto *condition = down_cast<const Item_cond *>(item);
+    return condition->functype() == Item_func::COND_AND_FUNC ||
+           condition->functype() == Item_func::COND_OR_FUNC;
+  }
+
+  if (item->type() != Item::FUNC_ITEM) return false;
+
+  switch (down_cast<const Item_func *>(item)->functype()) {
+    case Item_func::EQ_FUNC:
+    case Item_func::NE_FUNC:
+    case Item_func::LT_FUNC:
+    case Item_func::LE_FUNC:
+    case Item_func::GT_FUNC:
+    case Item_func::GE_FUNC:
+    case Item_func::BETWEEN:
+    case Item_func::IN_FUNC:
+    case Item_func::LIKE_FUNC:
+    case Item_func::ISNULL_FUNC:
+    case Item_func::ISNOTNULL_FUNC:
+    case Item_func::NOT_FUNC:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
  * @brief Convert SUM(CASE WHEN pred THEN 1 ELSE 0 END) to a COUNT filter.
  */
 Item *CaseToCountFilter(Item *argument) {
@@ -300,6 +334,7 @@ Item *CaseToCountFilter(Item *argument) {
   Item *else_item = function->arguments()[2];
   if (!then_item->const_item() || !else_item->const_item()) return nullptr;
   if (then_item->val_int() != 1 || else_item->val_int() != 0) return nullptr;
+  if (!IsBooleanFilterShape(predicate)) return nullptr;
   return predicate;
 }
 
@@ -586,6 +621,9 @@ bool RecognizeDerivedRegroup(JOIN *join, ColumnarExecutionContext *ctx,
     if (preserved_key->result_type() != INT_RESULT ||
         nullable_key->result_type() != INT_RESULT) {
       LDB_COL_REJECT("inner join key type");
+    }
+    if (preserved_key->is_nullable() || nullable_key->is_nullable()) {
+      LDB_COL_REJECT("inner join key nullable");
     }
   }
   if (preserved_key == nullptr) LDB_COL_REJECT("inner join key missing");
@@ -899,6 +937,9 @@ bool RecognizeFlattenedAggregate(JOIN *join, ColumnarExecutionContext *ctx,
         ResolveBaseField(right_raw, tables[right_table].table);
     if (left_field == nullptr || right_field == nullptr) {
       LDB_COL_REJECT("inner join key unresolvable");
+    }
+    if (left_field->is_nullable() || right_field->is_nullable()) {
+      LDB_COL_REJECT("inner join key nullable");
     }
     join_edges.push_back(
         {left_table, right_table, left_field, right_field});
@@ -1218,6 +1259,9 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
     if (left_field == nullptr || right_field == nullptr) {
       LDB_COL_REJECT("join key unresolvable");
     }
+    if (left_field->is_nullable() || right_field->is_nullable()) {
+      LDB_COL_REJECT("join key nullable");
+    }
     join_edges.push_back({left_table, right_table, left_field, right_field});
   }
   if (tables.size() > 1 && join_edges.empty()) LDB_COL_REJECT("cross join");
@@ -1522,6 +1566,11 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
                                    tables[argument_table].table)
                 : nullptr;
         if (argument_field == nullptr) LDB_COL_REJECT("minmax unresolvable");
+        if (argument_field->is_nullable()) LDB_COL_REJECT("minmax nullable");
+        if (argument_field->result_type() == STRING_RESULT &&
+            !argument_field->binary()) {
+          LDB_COL_REJECT("minmax collation");
+        }
 
         auto *ref = function->mutable_arg();
         ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1,0 +1,177 @@
+#include "ha_lineairdb_columnar.hh"
+
+#include <cassert>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "my_alloc.h"
+#include "my_dbug.h"
+#include "mysql/plugin.h"
+#include "mysqld_error.h"
+#include "sql/handler.h"
+#include "sql/sql_class.h"
+#include "sql/sql_lex.h"
+#include "sql/table.h"
+#include "thr_lock.h"
+
+namespace lineairdb_columnar {
+
+namespace {
+
+class LoadedTables {
+ public:
+  void add(const std::string &db, const std::string &table) {
+    const std::lock_guard<std::mutex> guard(mutex_);
+    tables_.emplace(std::piecewise_construct,
+                    std::forward_as_tuple(std::make_pair(db, table)),
+                    std::forward_as_tuple());
+  }
+
+  bool contains(const std::string &db, const std::string &table) {
+    const std::lock_guard<std::mutex> guard(mutex_);
+    return tables_.count(std::make_pair(db, table)) > 0;
+  }
+
+  THR_LOCK *lock(const std::string &db, const std::string &table) {
+    const std::lock_guard<std::mutex> guard(mutex_);
+    auto it = tables_.find(std::make_pair(db, table));
+    return it == tables_.end() ? nullptr : &it->second.lock;
+  }
+
+  void erase(const std::string &db, const std::string &table) {
+    const std::lock_guard<std::mutex> guard(mutex_);
+    tables_.erase(std::make_pair(db, table));
+  }
+
+ private:
+  struct TableState {
+    THR_LOCK lock;
+
+    TableState() { thr_lock_init(&lock); }
+    ~TableState() { thr_lock_delete(&lock); }
+
+    TableState(const TableState &) = delete;
+    TableState &operator=(const TableState &) = delete;
+  };
+
+  std::mutex mutex_;
+  std::map<std::pair<std::string, std::string>, TableState> tables_;
+};
+
+LoadedTables *loaded_tables = nullptr;
+
+bool RejectSecondaryExecution(THD *, LEX *) {
+  my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
+           "LINEAIRDB_COLUMNAR executor is not available yet");
+  return true;
+}
+
+handler *CreateColumnarHandler(handlerton *hton, TABLE_SHARE *table_share,
+                               bool, MEM_ROOT *mem_root) {
+  return new (mem_root) ha_lineairdb_columnar(hton, table_share);
+}
+
+}  // namespace
+
+ha_lineairdb_columnar::ha_lineairdb_columnar(handlerton *hton,
+                                             TABLE_SHARE *table_share_arg)
+    : handler(hton, table_share_arg) {}
+
+int ha_lineairdb_columnar::open(const char *, int, unsigned int,
+                                const dd::Table *) {
+  THR_LOCK *lock =
+      loaded_tables->lock(table_share->db.str, table_share->table_name.str);
+  if (lock == nullptr) {
+    my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0), "Table has not been loaded");
+    return HA_ERR_GENERIC;
+  }
+
+  thr_lock_data_init(lock, &lock_data_, nullptr);
+  return 0;
+}
+
+int ha_lineairdb_columnar::info(unsigned int flags) {
+  handler *primary = ha_get_primary_handler();
+  if (primary == nullptr) return HA_ERR_GENERIC;
+
+  const int error = primary->info(flags);
+  if (error == 0) stats.records = primary->stats.records;
+  return error;
+}
+
+ha_rows ha_lineairdb_columnar::records_in_range(unsigned int index,
+                                                key_range *min_key,
+                                                key_range *max_key) {
+  handler *primary = ha_get_primary_handler();
+  return primary == nullptr ? HA_POS_ERROR
+                            : primary->records_in_range(index, min_key,
+                                                        max_key);
+}
+
+unsigned long ha_lineairdb_columnar::index_flags(unsigned int index,
+                                                 unsigned int part,
+                                                 bool all_parts) const {
+  const handler *primary = ha_get_primary_handler();
+  const unsigned long primary_flags =
+      primary == nullptr ? 0 : primary->index_flags(index, part, all_parts);
+
+  // Indexes are available only to let the optimizer estimate primary ranges.
+  return (HA_READ_RANGE | HA_KEY_SCAN_NOT_ROR) & primary_flags;
+}
+
+THR_LOCK_DATA **ha_lineairdb_columnar::store_lock(THD *, THR_LOCK_DATA **to,
+                                                  thr_lock_type lock_type) {
+  if (lock_type != TL_IGNORE && lock_data_.type == TL_UNLOCK)
+    lock_data_.type = lock_type;
+  *to++ = &lock_data_;
+  return to;
+}
+
+int ha_lineairdb_columnar::load_table(const TABLE &table) {
+  assert(table.file != nullptr);
+  loaded_tables->add(table.s->db.str, table.s->table_name.str);
+  return 0;
+}
+
+int ha_lineairdb_columnar::unload_table(const char *db_name,
+                                        const char *table_name,
+                                        bool error_if_not_loaded) {
+  if (error_if_not_loaded &&
+      !loaded_tables->contains(db_name, table_name)) {
+    my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
+             "Table is not loaded on a secondary engine");
+    return 1;
+  }
+
+  loaded_tables->erase(db_name, table_name);
+  return 0;
+}
+
+}  // namespace lineairdb_columnar
+
+struct st_mysql_storage_engine lineairdb_columnar_storage_engine = {
+    MYSQL_HANDLERTON_INTERFACE_VERSION};
+
+int lineairdb_columnar_init(void *p) {
+  lineairdb_columnar::loaded_tables = new lineairdb_columnar::LoadedTables();
+
+  handlerton *hton = static_cast<handlerton *>(p);
+  hton->create = lineairdb_columnar::CreateColumnarHandler;
+  hton->state = SHOW_OPTION_YES;
+  hton->flags = HTON_IS_SECONDARY_ENGINE;
+  hton->db_type = DB_TYPE_UNKNOWN;
+  hton->prepare_secondary_engine = lineairdb_columnar::RejectSecondaryExecution;
+  hton->secondary_engine_flags =
+      MakeSecondaryEngineFlags(SecondaryEngineFlag::USE_EXTERNAL_EXECUTOR);
+  return 0;
+}
+
+int lineairdb_columnar_deinit(void *) {
+  delete lineairdb_columnar::loaded_tables;
+  lineairdb_columnar::loaded_tables = nullptr;
+  return 0;
+}

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1818,7 +1818,33 @@ bool BuildQueryBlockRequest(
   int current_node = -1;
   if (plan_map) {
     std::map<int, std::set<int>> node_tables;
+    std::map<int, double> node_rows;
     size_t next_virtual_table = real_table_count;
+
+    struct MappedJoinKey {
+      LineairDB::Protocol::QueryBlockJoin::Type join_type;
+      int build_node = -1;
+      int probe_node = -1;
+      uint32_t build_table = 0;
+      uint32_t build_column = 0;
+      uint32_t probe_table = 0;
+      uint32_t probe_column = 0;
+    };
+    std::vector<MappedJoinKey> mapped_join_keys;
+
+    auto estimated_rows = [](const AccessPath *path) {
+      return std::max(1.0, path == nullptr ? 1.0 : path->num_output_rows());
+    };
+
+    auto table_rows = [&](size_t table_idx) {
+      if (table_idx >= tables.size() || tables[table_idx].table == nullptr ||
+          tables[table_idx].table->file == nullptr) {
+        return 1.0;
+      }
+      return std::max(
+          1.0,
+          static_cast<double>(tables[table_idx].table->file->stats.records));
+    };
 
     std::set<const Item *> having_predicates;
     if (qb->having_cond() != nullptr) {
@@ -1892,8 +1918,10 @@ bool BuildQueryBlockRequest(
             *why = "filter not pushable";
             return -1;
           }
-          node_tables[scan_nodes[table_idx]] = {table_idx};
-          return scan_nodes[table_idx];
+          const int self = scan_nodes[table_idx];
+          node_tables[self] = {table_idx};
+          node_rows[self] = estimated_rows(path);
+          return self;
         }
 
         case AccessPath::FILTER: {
@@ -1916,7 +1944,14 @@ bool BuildQueryBlockRequest(
             }
             residuals.push_back(part);
           }
-          if (residuals.empty()) return input;
+          if (residuals.empty()) {
+            auto it = node_rows.find(input);
+            node_rows[input] = it == node_rows.end()
+                                   ? estimated_rows(path)
+                                   : std::min(it->second,
+                                              estimated_rows(path));
+            return input;
+          }
 
           for (Item *residual : residuals) {
             const table_map used =
@@ -1939,6 +1974,7 @@ bool BuildQueryBlockRequest(
           }
           const int self = request.nodes_size() - 1;
           node_tables[self] = node_tables[input];
+          node_rows[self] = estimated_rows(path);
           return self;
         }
 
@@ -2076,6 +2112,10 @@ bool BuildQueryBlockRequest(
             auto *probe_key = join_node->add_probe_keys();
             probe_key->set_table_idx(static_cast<uint32_t>(right_table));
             probe_key->set_column(right_field->field_index());
+            mapped_join_keys.push_back(
+                {join_type, build, probe, static_cast<uint32_t>(left_table),
+                 left_field->field_index(), static_cast<uint32_t>(right_table),
+                 right_field->field_index()});
           }
 
           if (!expression->join_conditions.empty()) {
@@ -2125,6 +2165,7 @@ bool BuildQueryBlockRequest(
                                  node_tables[build].end());
           }
           node_tables[self] = std::move(output_tables);
+          node_rows[self] = estimated_rows(path);
           return self;
         }
 
@@ -2174,6 +2215,7 @@ bool BuildQueryBlockRequest(
             }
             scan_nodes[table_idx] = request.nodes_size() - 1;
             node_tables[scan_nodes[table_idx]] = {table_idx};
+            node_rows[scan_nodes[table_idx]] = estimated_rows(path);
           }
           return scan_nodes[table_idx];
         }
@@ -2221,6 +2263,134 @@ bool BuildQueryBlockRequest(
 
     current_node = map_path(plan, true);
     if (current_node < 0) return false;
+
+    // Add scan-level semi-filters after the mapped tree is complete. A scan can
+    // only read key sets from earlier nodes, and probe-side filtering is unsafe
+    // for LEFT/ANTI joins because non-matching probe rows must survive.
+    auto join_side_filterable =
+        [](LineairDB::Protocol::QueryBlockJoin::Type join_type,
+           bool target_is_build) {
+          if (target_is_build) return true;
+          return join_type == LineairDB::Protocol::QueryBlockJoin::INNER ||
+                 join_type == LineairDB::Protocol::QueryBlockJoin::SEMI;
+        };
+
+    struct SemiSource {
+      double rows = -1.0;
+      int source_node = -1;
+      uint32_t source_table = 0;
+      uint32_t source_column = 0;
+      uint32_t target_column = 0;
+    };
+
+    // Effective cardinality is only used to choose semi-filter sources. When a
+    // scan gets filtered by a smaller key domain, later scans can use the
+    // reduced estimate rather than the table's raw row count.
+    std::vector<double> effective_rows(tables.size(), 1.0);
+    for (size_t table_idx = 0; table_idx < tables.size(); table_idx++) {
+      if (scan_nodes[table_idx] >= 0 &&
+          node_rows.count(scan_nodes[table_idx]) != 0) {
+        effective_rows[table_idx] = node_rows[scan_nodes[table_idx]];
+      } else if (table_idx < real_table_count) {
+        effective_rows[table_idx] = table_rows(table_idx);
+      }
+    }
+
+    auto leading_records_per_key = [&](size_t table_idx, uint32_t column) {
+      if (table_idx >= real_table_count ||
+          tables[table_idx].table == nullptr) {
+        return 0.0;
+      }
+      TABLE *table = tables[table_idx].table;
+      for (uint key_idx = 0; key_idx < table->s->keys; key_idx++) {
+        const KEY &key = table->key_info[key_idx];
+        if (key.actual_key_parts == 0 || key.key_part == nullptr ||
+            key.key_part[0].field == nullptr) {
+          continue;
+        }
+        if (key.key_part[0].field->field_index() == column &&
+            key.has_records_per_key(0)) {
+          return std::max(1.0, static_cast<double>(key.records_per_key(0)));
+        }
+      }
+      return 0.0;
+    };
+
+    auto best_scan_source = [&](uint32_t target_table, int target_node,
+                                double target_rows) {
+      SemiSource best;
+      auto consider = [&](int node, double rows, uint32_t source_table,
+                          uint32_t source_column,
+                          uint32_t target_column) {
+        if (node < 0 || node >= target_node) return;
+        if (rows * 8.0 > target_rows) return;
+        if (best.source_node < 0 || rows < best.rows) {
+          best = {rows, node, source_table, source_column, target_column};
+        }
+      };
+
+      for (const MappedJoinKey &key : mapped_join_keys) {
+        auto consider_side =
+            [&](bool target_is_build, uint32_t key_target_table,
+                uint32_t key_source_table, uint32_t key_target_column,
+                uint32_t key_source_column, int partner_node) {
+              if (key_target_table != target_table) return;
+              if (!join_side_filterable(key.join_type, target_is_build))
+                return;
+              if (key_source_table < scan_nodes.size()) {
+                consider(scan_nodes[key_source_table],
+                         effective_rows[key_source_table], key_source_table,
+                         key_source_column, key_target_column);
+              }
+              const auto rows_it = node_rows.find(partner_node);
+              consider(partner_node,
+                       rows_it == node_rows.end() ? 1e30 : rows_it->second,
+                       key_source_table, key_source_column,
+                       key_target_column);
+            };
+
+        consider_side(true, key.build_table, key.probe_table,
+                      key.build_column, key.probe_column, key.probe_node);
+        consider_side(false, key.probe_table, key.build_table,
+                      key.probe_column, key.build_column, key.build_node);
+      }
+      return best;
+    };
+
+    std::vector<size_t> scan_order;
+    for (size_t table_idx = 0; table_idx < real_table_count; table_idx++) {
+      if (scan_nodes[table_idx] >= 0) scan_order.push_back(table_idx);
+    }
+    std::sort(scan_order.begin(), scan_order.end(), [&](size_t left,
+                                                        size_t right) {
+      return scan_nodes[left] < scan_nodes[right];
+    });
+
+    for (size_t table_idx : scan_order) {
+      const int node = scan_nodes[table_idx];
+      if (!request.nodes(node).has_scan() ||
+          request.nodes(node).scan().has_semi()) {
+        continue;
+      }
+
+      const SemiSource source = best_scan_source(
+          static_cast<uint32_t>(table_idx), node, effective_rows[table_idx]);
+      if (source.source_node < 0) continue;
+
+      auto *semi = request.mutable_nodes(node)->mutable_scan()->mutable_semi();
+      semi->set_source_node(source.source_node);
+      auto *source_column = semi->mutable_source_column();
+      source_column->set_table_idx(source.source_table);
+      source_column->set_column(source.source_column);
+      semi->set_my_column(source.target_column);
+
+      const double fanout =
+          leading_records_per_key(table_idx, source.target_column);
+      if (fanout > 0.0) {
+        effective_rows[table_idx] = std::max(
+            1.0, std::min(effective_rows[table_idx], source.rows * fanout));
+      }
+    }
   } else {
     // Scan every table once, attaching only predicates that read that table.
     for (size_t table_idx = 0; table_idx < real_table_count; table_idx++) {

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -627,6 +627,9 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
             if (count_field == nullptr || count_field->is_nullable())
               LDB_COL_REJECT("COUNT arg nullable");
             function->set_arg_table(static_cast<uint32_t>(count_table));
+            auto *ref = function->mutable_arg();
+            ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+            ref->set_column_index(count_field->field_index());
           }
         }
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1375,6 +1375,8 @@ bool BuildQueryBlockRequest(
   } while (0)
 
   if (qb == nullptr || request_out == nullptr) LDB_COL_REJECT("missing block");
+  auto &request = *request_out;
+  request.Clear();
 
   Query_expression *unit = qb->master_query_expression();
   if (unit == nullptr || !unit->is_simple())
@@ -1503,6 +1505,11 @@ bool BuildQueryBlockRequest(
     return virtual_idx < virtual_block_is_scalar_aggregate.size() &&
            virtual_block_is_scalar_aggregate[virtual_idx];
   };
+
+  for (size_t table_idx = 0; table_idx < real_table_count; table_idx++) {
+    request.add_tables()->set_table_name(
+        tables[table_idx].table->s->normalized_path.str);
+  }
 
   struct JoinEdge {
     int left_table = -1;
@@ -1779,12 +1786,12 @@ bool BuildQueryBlockRequest(
   }
 
   // Scan every table once, attaching only predicates that read that table.
-  auto &request = *request_out;
-  request.Clear();
   std::vector<int> scan_nodes(tables.size(), -1);
-  for (size_t table_idx = 0; table_idx < real_table_count; table_idx++) {
+  auto emit_scan = [&](size_t table_idx) -> bool {
+    if (table_idx >= real_table_count) return false;
+    if (scan_nodes[table_idx] >= 0) return true;
+
     TABLE *table = tables[table_idx].table;
-    request.add_tables()->set_table_name(table->s->normalized_path.str);
     auto *scan_node = request.add_nodes();
     auto *scan = scan_node->mutable_scan();
     scan->set_table_idx(static_cast<uint32_t>(table_idx));
@@ -1792,8 +1799,13 @@ bool BuildQueryBlockRequest(
     if (!table_filters[table_idx].empty() &&
         !SerializeTableFilters(table_filters[table_idx], table,
                                scan->mutable_filter())) {
-      LDB_COL_REJECT("filter not pushable");
+      return false;
     }
+    return true;
+  };
+
+  for (size_t table_idx = 0; table_idx < real_table_count; table_idx++) {
+    if (!emit_scan(table_idx)) LDB_COL_REJECT("filter not pushable");
   }
 
   for (size_t table_idx = real_table_count; table_idx < tables.size();

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -85,6 +85,39 @@ class LoadedTables {
 
 LoadedTables *loaded_tables = nullptr;
 
+struct ColumnarFailReason {
+  THD *thd = nullptr;
+  query_id_t query_id = 0;
+  std::string reason;
+};
+
+thread_local ColumnarFailReason columnar_fail_reason;
+
+const char *GetColumnarFailReason(THD *thd) {
+  if (thd == nullptr || columnar_fail_reason.thd != thd ||
+      columnar_fail_reason.query_id != thd->query_id ||
+      columnar_fail_reason.reason.empty()) {
+    return nullptr;
+  }
+  return columnar_fail_reason.reason.c_str();
+}
+
+void SetColumnarFailReason(THD *thd, const char *reason) {
+  if (reason == nullptr) {
+    columnar_fail_reason = {};
+  } else {
+    columnar_fail_reason.thd = thd;
+    columnar_fail_reason.query_id = thd == nullptr ? 0 : thd->query_id;
+    columnar_fail_reason.reason.assign(reason);
+  }
+}
+
+bool RaiseColumnarError(THD *thd, const char *message) {
+  SetColumnarFailReason(thd, message);
+  my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0), message);
+  return true;
+}
+
 // send_result_set_metadata() has already described the original SELECT fields.
 // The override executor only needs Item instances that carry computed values
 // through Query_result::send_data(), so this class mirrors the prototype type
@@ -413,20 +446,16 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
  * that match that already-described metadata.
  */
 bool ExecuteColumnarAggregate(JOIN *join, Query_result *result) {
-  THD *thd = current_thd;
+  THD *thd = join->thd;
   auto *ctx = static_cast<ColumnarExecutionContext *>(
       thd->lex->secondary_engine_execution_context());
   if (ctx == nullptr || ctx->serialized_aggregate.empty()) {
-    my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
-             "LINEAIRDB_COLUMNAR: no offload plan");
-    return true;
+    return RaiseColumnarError(thd, "LINEAIRDB_COLUMNAR: no offload plan");
   }
 
   std::shared_ptr<LineairDBProxy> proxy = lineairdb::acquire_shared_proxy(thd);
   if (!proxy) {
-    my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
-             "LINEAIRDB_COLUMNAR: no server connection");
-    return true;
+    return RaiseColumnarError(thd, "LINEAIRDB_COLUMNAR: no server connection");
   }
 
   LineairDBProxy::ReadPlanStep step;
@@ -438,9 +467,8 @@ bool ExecuteColumnarAggregate(JOIN *join, Query_result *result) {
 
   LineairDBProxy::ReadPlanResult rpc = proxy->tx_execute_read_plan({step});
   if (!rpc.ok || rpc.steps.size() != 1) {
-    my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
-             "LINEAIRDB_COLUMNAR: aggregate scan RPC failed");
-    return true;
+    return RaiseColumnarError(thd,
+                              "LINEAIRDB_COLUMNAR: aggregate scan RPC failed");
   }
 
   mem_root_deque<Item *> output_items(thd->mem_root);
@@ -453,26 +481,23 @@ bool ExecuteColumnarAggregate(JOIN *join, Query_result *result) {
     output_items.push_back(value);
   }
   if (values.size() != ctx->bindings.size()) {
-    my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
-             "LINEAIRDB_COLUMNAR: output binding mismatch");
-    return true;
+    return RaiseColumnarError(thd,
+                              "LINEAIRDB_COLUMNAR: output binding mismatch");
   }
 
   std::vector<DecodedField> fields;
   for (const std::string &row : rpc.steps[0].scan_values) {
     if (!DecodeRowFields(row, &fields)) {
-      my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
-               "LINEAIRDB_COLUMNAR: malformed group row");
-      return true;
+      return RaiseColumnarError(thd,
+                                "LINEAIRDB_COLUMNAR: malformed group row");
     }
 
     // Server aggregate rows are [null_flags][group cols][value,count per agg].
     const size_t expected = 1 + static_cast<size_t>(ctx->group_column_count) +
                             2 * static_cast<size_t>(ctx->aggregate_count);
     if (fields.size() != expected) {
-      my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
-               "LINEAIRDB_COLUMNAR: unexpected group row shape");
-      return true;
+      return RaiseColumnarError(
+          thd, "LINEAIRDB_COLUMNAR: unexpected group row shape");
     }
 
     for (size_t i = 0; i < ctx->bindings.size(); i++) {
@@ -504,6 +529,7 @@ bool ExecuteColumnarAggregate(JOIN *join, Query_result *result) {
 }
 
 bool PrepareSecondaryEngine(THD *thd, LEX *lex) {
+  SetColumnarFailReason(thd, nullptr);
   lex->add_statement_options(OPTION_NO_CONST_TABLES |
                              OPTION_NO_SUBQUERY_DURING_OPTIMIZATION);
 
@@ -514,12 +540,12 @@ bool PrepareSecondaryEngine(THD *thd, LEX *lex) {
 }
 
 bool OptimizeSecondaryEngine(THD *, LEX *lex) {
+  SetColumnarFailReason(lex->thd, nullptr);
   auto *ctx = static_cast<ColumnarExecutionContext *>(
       lex->secondary_engine_execution_context());
   if (ctx == nullptr) {
-    my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
-             "LINEAIRDB_COLUMNAR statement context is not available");
-    return true;
+    return RaiseColumnarError(
+        lex->thd, "LINEAIRDB_COLUMNAR statement context is not available");
   }
 
   Query_block *query_block = lex->unit->first_query_block();
@@ -529,8 +555,7 @@ bool OptimizeSecondaryEngine(THD *, LEX *lex) {
     char message[128];
     snprintf(message, sizeof(message),
              "LINEAIRDB_COLUMNAR unsupported shape: %s", why ? why : "?");
-    my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0), message);
-    return true;
+    return RaiseColumnarError(lex->thd, message);
   }
 
   join->override_executor_func = ExecuteColumnarAggregate;
@@ -648,6 +673,10 @@ int lineairdb_columnar_init(void *p) {
   hton->prepare_secondary_engine = lineairdb_columnar::PrepareSecondaryEngine;
   hton->optimize_secondary_engine = lineairdb_columnar::OptimizeSecondaryEngine;
   hton->compare_secondary_engine_cost = lineairdb_columnar::CompareJoinCost;
+  hton->get_secondary_engine_offload_or_exec_fail_reason =
+      lineairdb_columnar::GetColumnarFailReason;
+  hton->set_secondary_engine_offload_fail_reason =
+      lineairdb_columnar::SetColumnarFailReason;
   hton->secondary_engine_flags =
       MakeSecondaryEngineFlags(SecondaryEngineFlag::SUPPORTS_HASH_JOIN,
                                SecondaryEngineFlag::SUPPORTS_NESTED_LOOP_JOIN);

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1490,6 +1490,18 @@ bool BuildQueryBlockRequest(
     return ResolveBaseField(field, tables[table_idx].table);
   };
 
+  auto is_scalar_virtual_table = [&](int table_idx) {
+    if (table_idx < static_cast<int>(real_table_count) ||
+        table_idx >= static_cast<int>(table_is_virtual.size()) ||
+        !table_is_virtual[table_idx]) {
+      return false;
+    }
+    const size_t virtual_idx =
+        static_cast<size_t>(table_idx) - real_table_count;
+    return virtual_idx < virtual_block_is_scalar_aggregate.size() &&
+           virtual_block_is_scalar_aggregate[virtual_idx];
+  };
+
   struct JoinEdge {
     int left_table = -1;
     int right_table = -1;
@@ -1755,8 +1767,14 @@ bool BuildQueryBlockRequest(
     }
     join_edges.push_back({left_table, right_table, left_field, right_field});
   }
-  if (main_tables.size() > 1 && join_edges.empty())
+  size_t main_non_scalar_tables = 0;
+  for (int table_idx : main_tables) {
+    if (!is_scalar_virtual_table(table_idx)) main_non_scalar_tables++;
+  }
+  if (main_tables.size() > 1 && join_edges.empty() &&
+      main_non_scalar_tables > 1) {
     LDB_COL_REJECT("cross join");
+  }
 
   // Scan every table once, attaching only predicates that read that table.
   auto &request = *request_out;
@@ -1789,16 +1807,23 @@ bool BuildQueryBlockRequest(
 
   // Build a left-deep INNER join tree by walking FROM order and retrying tables
   // whose equality edges are not connected yet.
-  int current_node = scan_nodes[main_tables[0]];
+  auto first_input =
+      std::find_if(main_tables.begin(), main_tables.end(), [&](int table_idx) {
+        return !is_scalar_virtual_table(table_idx);
+      });
+  const int first_table =
+      first_input != main_tables.end() ? *first_input : main_tables[0];
+  int current_node = scan_nodes[first_table];
   std::vector<bool> joined(tables.size(), false);
-  joined[main_tables[0]] = true;
+  joined[first_table] = true;
   std::vector<int> pending_tables;
-  for (size_t table_idx = 1; table_idx < main_tables.size(); table_idx++) {
-    pending_tables.push_back(main_tables[table_idx]);
+  for (int table_idx : main_tables) {
+    if (table_idx != first_table) pending_tables.push_back(table_idx);
   }
   while (!pending_tables.empty()) {
     int table_idx = -1;
     size_t pending_idx = 0;
+    bool keyless_one_row_join = false;
     for (size_t idx = 0; idx < pending_tables.size(); idx++) {
       for (const JoinEdge &edge : join_edges) {
         if ((edge.left_table == pending_tables[idx] &&
@@ -1812,10 +1837,22 @@ bool BuildQueryBlockRequest(
       }
       if (table_idx >= 0) break;
     }
+    if (table_idx < 0) {
+      // Scalar aggregate sub-blocks produce at most one row, so they are the
+      // only virtual inputs that can use a keyless INNER join.
+      for (size_t idx = 0; idx < pending_tables.size(); idx++) {
+        if (is_scalar_virtual_table(pending_tables[idx])) {
+          table_idx = pending_tables[idx];
+          pending_idx = idx;
+          keyless_one_row_join = true;
+          break;
+        }
+      }
+    }
     if (table_idx < 0) LDB_COL_REJECT("disconnected join graph");
     pending_tables.erase(pending_tables.begin() + pending_idx);
 
-    bool connected = false;
+    bool connected = keyless_one_row_join;
     auto *join_node = request.add_nodes()->mutable_join();
     join_node->set_type(LineairDB::Protocol::QueryBlockJoin::INNER);
     join_node->set_build(scan_nodes[table_idx]);
@@ -1906,8 +1943,20 @@ bool BuildQueryBlockRequest(
       return false;
     };
 
+    int first_inner_table = semijoin.inner_tables[0];
+    if (semijoin.inner_tables.size() > 1) {
+      auto first_inner_input =
+          std::find_if(semijoin.inner_tables.begin(),
+                       semijoin.inner_tables.end(), [&](int table_idx) {
+                         return !is_scalar_virtual_table(table_idx);
+                       });
+      if (first_inner_input != semijoin.inner_tables.end()) {
+        first_inner_table = *first_inner_input;
+      }
+    }
+
     // Multi-table semijoin nests become a build-side INNER-join mini tree.
-    int build_node = scan_nodes[semijoin.inner_tables[0]];
+    int build_node = scan_nodes[first_inner_table];
     if (semijoin.inner_tables.size() > 1) {
       struct InnerJoinEdge {
         int left_table = -1;
@@ -1955,14 +2004,18 @@ bool BuildQueryBlockRequest(
       semijoin.residual_predicates = std::move(remaining_residuals);
 
       std::vector<bool> inner_joined(tables.size(), false);
-      inner_joined[semijoin.inner_tables[0]] = true;
-      std::vector<int> pending_inner_tables(
-          semijoin.inner_tables.begin() + 1,
-          semijoin.inner_tables.end());
+      inner_joined[first_inner_table] = true;
+      std::vector<int> pending_inner_tables;
+      for (int table_idx : semijoin.inner_tables) {
+        if (table_idx != first_inner_table) {
+          pending_inner_tables.push_back(table_idx);
+        }
+      }
 
       while (!pending_inner_tables.empty()) {
         int picked_table = -1;
         size_t picked_idx = 0;
+        bool keyless_one_row_join = false;
         for (size_t idx = 0; idx < pending_inner_tables.size(); idx++) {
           for (const InnerJoinEdge &edge : inner_edges) {
             if ((edge.left_table == pending_inner_tables[idx] &&
@@ -1976,10 +2029,21 @@ bool BuildQueryBlockRequest(
           }
           if (picked_table >= 0) break;
         }
+        if (picked_table < 0) {
+          // Keep keyless INNER joins limited to one-row virtual inputs.
+          for (size_t idx = 0; idx < pending_inner_tables.size(); idx++) {
+            if (is_scalar_virtual_table(pending_inner_tables[idx])) {
+              picked_table = pending_inner_tables[idx];
+              picked_idx = idx;
+              keyless_one_row_join = true;
+              break;
+            }
+          }
+        }
         if (picked_table < 0) LDB_COL_REJECT("semijoin disconnected");
         pending_inner_tables.erase(pending_inner_tables.begin() + picked_idx);
 
-        bool connected = false;
+        bool connected = keyless_one_row_join;
         auto *inner_join = request.add_nodes()->mutable_join();
         inner_join->set_type(LineairDB::Protocol::QueryBlockJoin::INNER);
         inner_join->set_build(static_cast<uint32_t>(scan_nodes[picked_table]));

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -576,11 +576,13 @@ const Field *SubstringPrefixField(Item *item, uint32_t *prefix_len) {
   Item *from = function->arguments()[1];
   Item *length = function->arguments()[2];
   if (column->type() != Item::FIELD_ITEM) return nullptr;
+  const Field *field = down_cast<Item_field *>(column)->field;
+  if (field->result_type() != STRING_RESULT) return nullptr;
   if (!from->const_item() || from->val_int() != 1) return nullptr;
   if (!length->const_item() || length->val_int() <= 0) return nullptr;
 
   *prefix_len = static_cast<uint32_t>(length->val_int());
-  return down_cast<Item_field *>(column)->field;
+  return field;
 }
 
 /**
@@ -2186,6 +2188,28 @@ bool BuildQueryBlockRequest(
       group_column->set_column(group_field->field_index());
       group_column->set_prefix_len(4);
       group_column->set_cmp_kind(0);
+      group_fields.push_back({group_table, nullptr});
+      continue;
+    }
+
+    uint32_t substring_prefix_len = 0;
+    if (const Field *substring_field =
+            SubstringPrefixField(group_item, &substring_prefix_len)) {
+      const int group_table = TableIndexOfField(substring_field, tables);
+      const Field *group_field =
+          group_table >= 0
+              ? resolve_query_field(substring_field, group_table)
+              : nullptr;
+      if (group_field == nullptr ||
+          (!table_is_virtual[group_table] && group_field->is_nullable())) {
+        LDB_COL_REJECT("group substring column");
+      }
+
+      auto *group_column = aggregate->add_group_columns();
+      group_column->set_table_idx(static_cast<uint32_t>(group_table));
+      group_column->set_column(group_field->field_index());
+      group_column->set_prefix_len(substring_prefix_len);
+      group_column->set_cmp_kind(1);
       group_fields.push_back({group_table, nullptr});
       continue;
     }

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -231,10 +231,14 @@ const Field *ResolveBaseField(const Field *field, TABLE *table) {
 
 /**
  * @brief Return true when raw-byte GROUP BY keys match MySQL equality.
+ *
+ * DECIMAL cells are stored as canonical base-10 text in PAX, so equal values
+ * have equal bytes within one schema.
  */
 bool GroupColumnIsBinarySafe(const Field *field) {
   switch (field->result_type()) {
     case INT_RESULT:
+    case DECIMAL_RESULT:
       return true;
     case STRING_RESULT:
       return field->binary();

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1897,6 +1897,33 @@ bool BuildQueryBlockRequest(
       return true;
     };
 
+    // Join keys emitted below are enforced equalities. Later mapped joins may
+    // need the same column through a surviving equivalent column if the
+    // optimizer removed an intermediate table from the mapped tree.
+    using ColRef = std::pair<int, uint32_t>;
+    std::vector<std::pair<ColRef, ColRef>> enforced_equalities;
+
+    auto equivalent_columns = [&](ColRef start) {
+      std::set<ColRef> columns{start};
+      bool grew = true;
+      while (grew) {
+        grew = false;
+        for (const auto &edge : enforced_equalities) {
+          if (columns.count(edge.first) != 0 &&
+              columns.count(edge.second) == 0) {
+            columns.insert(edge.second);
+            grew = true;
+          }
+          if (columns.count(edge.second) != 0 &&
+              columns.count(edge.first) == 0) {
+            columns.insert(edge.first);
+            grew = true;
+          }
+        }
+      }
+      return columns;
+    };
+
     auto emit_mapped_join =
         [&](LineairDB::Protocol::QueryBlockJoin::Type join_type, int probe,
             int build, RelationalExpression *expression,
@@ -1953,28 +1980,65 @@ bool BuildQueryBlockRequest(
           return -1;
         }
 
+        ColRef build_ref{-1, 0};
+        ColRef probe_ref{-1, 0};
         if (node_tables[build].count(left_table) > 0 &&
             node_tables[probe].count(right_table) > 0) {
-          // left stays on the build side and right stays on the probe side.
+          build_ref = {left_table, left_field->field_index()};
+          probe_ref = {right_table, right_field->field_index()};
         } else if (node_tables[build].count(right_table) > 0 &&
                    node_tables[probe].count(left_table) > 0) {
-          std::swap(left_table, right_table);
-          std::swap(left_field, right_field);
+          build_ref = {right_table, right_field->field_index()};
+          probe_ref = {left_table, left_field->field_index()};
         } else {
+          // Rewrite through equivalence only after both direct side matches
+          // fail, so already-resolved joins keep their original columns.
+          auto pick_from_side = [](const std::set<ColRef> &columns,
+                                   const std::set<int> &side_tables) {
+            for (const ColRef &column : columns) {
+              if (side_tables.count(column.first) != 0) return column;
+            }
+            return ColRef{-1, 0};
+          };
+
+          const std::set<ColRef> left_equivalents =
+              equivalent_columns({left_table, left_field->field_index()});
+          const std::set<ColRef> right_equivalents =
+              equivalent_columns({right_table, right_field->field_index()});
+          build_ref = pick_from_side(left_equivalents, node_tables[build]);
+          probe_ref = pick_from_side(right_equivalents, node_tables[probe]);
+          if (build_ref.first < 0 || probe_ref.first < 0) {
+            build_ref = pick_from_side(right_equivalents, node_tables[build]);
+            probe_ref = pick_from_side(left_equivalents, node_tables[probe]);
+          }
+        }
+        if (build_ref.first < 0 || probe_ref.first < 0) {
           *why = "plan join key sides";
           return -1;
         }
 
         auto *build_key = join_node->add_build_keys();
-        build_key->set_table_idx(static_cast<uint32_t>(left_table));
-        build_key->set_column(left_field->field_index());
+        build_key->set_table_idx(static_cast<uint32_t>(build_ref.first));
+        build_key->set_column(build_ref.second);
         auto *probe_key = join_node->add_probe_keys();
-        probe_key->set_table_idx(static_cast<uint32_t>(right_table));
-        probe_key->set_column(right_field->field_index());
+        probe_key->set_table_idx(static_cast<uint32_t>(probe_ref.first));
+        probe_key->set_column(probe_ref.second);
         mapped_join_keys.push_back(
-            {join_type, build, probe, static_cast<uint32_t>(left_table),
-             left_field->field_index(), static_cast<uint32_t>(right_table),
-             right_field->field_index()});
+            {join_type, build, probe, static_cast<uint32_t>(build_ref.first),
+             build_ref.second, static_cast<uint32_t>(probe_ref.first),
+             probe_ref.second});
+      }
+
+      if (join_type == LineairDB::Protocol::QueryBlockJoin::INNER ||
+          join_type == LineairDB::Protocol::QueryBlockJoin::SEMI) {
+        for (int key_idx = 0; key_idx < join_node->build_keys_size();
+             key_idx++) {
+          enforced_equalities.push_back(
+              {{static_cast<int>(join_node->build_keys(key_idx).table_idx()),
+                join_node->build_keys(key_idx).column()},
+               {static_cast<int>(join_node->probe_keys(key_idx).table_idx()),
+                join_node->probe_keys(key_idx).column()}});
+        }
       }
 
       std::vector<Item *> residuals;

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -18,6 +18,7 @@
 #include "sql/handler.h"
 #include "sql/item.h"
 #include "sql/item_sum.h"
+#include "sql/item_timefunc.h"
 #include "sql/mem_root_array.h"
 #include "sql/query_result.h"
 #include "sql/sql_const.h"
@@ -337,6 +338,114 @@ int TableIndexOfField(const Field *field,
     }
   }
   return found;
+}
+
+/**
+ * @brief Encode a column reference inside an aggregate expression.
+ *
+ * Untagged column refs read from the aggregate function's default table. Tagged
+ * refs use the upper bits for the query-block table index, allowing one SUM
+ * expression to read columns from multiple joined tables.
+ */
+uint32_t EncodeAggregateColumnRef(uint32_t default_table_idx,
+                                  uint32_t table_idx, uint32_t column_idx) {
+  if (table_idx == default_table_idx) return column_idx;
+  return (table_idx << 16) | column_idx;
+}
+
+/**
+ * @brief Serialize arithmetic aggregate arguments with table-aware column refs.
+ *
+ * Supports column refs, integer constants, and +, -, *, and unary minus. This
+ * is used only when the expression may read more than one joined table; single
+ * table aggregate expressions keep using the shared serializer.
+ */
+bool SerializeAggregateExpressionForTables(
+    Item *item, const std::vector<QueryBlockTable> &tables,
+    uint32_t default_table_idx, LineairDB::Protocol::FilterExpr *out) {
+  item = item->real_item();
+  switch (item->type()) {
+    case Item::FIELD_ITEM: {
+      const Field *raw_field = down_cast<Item_field *>(item)->field;
+      const int table_idx = TableIndexOfField(raw_field, tables);
+      if (table_idx < 0) return false;
+      const Field *field =
+          ResolveBaseField(raw_field, tables[table_idx].table);
+      if (field == nullptr) return false;
+
+      out->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+      out->set_column_index(EncodeAggregateColumnRef(
+          default_table_idx, static_cast<uint32_t>(table_idx),
+          field->field_index()));
+      return true;
+    }
+    case Item::INT_ITEM: {
+      out->set_op(LineairDB::Protocol::FilterExpr::CONST_INT);
+      out->set_int_val(item->val_int());
+      return true;
+    }
+    case Item::FUNC_ITEM: {
+      auto *function = down_cast<Item_func *>(item);
+      using FilterExpr = LineairDB::Protocol::FilterExpr;
+      FilterExpr::Op op;
+      switch (function->functype()) {
+        case Item_func::PLUS_FUNC:
+          op = FilterExpr::OP_ADD;
+          break;
+        case Item_func::MINUS_FUNC:
+          op = FilterExpr::OP_SUB;
+          break;
+        case Item_func::MUL_FUNC:
+          op = FilterExpr::OP_MUL;
+          break;
+        case Item_func::NEG_FUNC:
+          op = FilterExpr::OP_NEG;
+          break;
+        default:
+          return false;
+      }
+
+      out->set_op(op);
+      if (op == FilterExpr::OP_NEG) {
+        if (function->argument_count() != 1) return false;
+        return SerializeAggregateExpressionForTables(
+            function->arguments()[0], tables, default_table_idx,
+            out->add_children());
+      }
+      if (function->argument_count() != 2) return false;
+      return SerializeAggregateExpressionForTables(
+                 function->arguments()[0], tables, default_table_idx,
+                 out->add_children()) &&
+             SerializeAggregateExpressionForTables(
+                 function->arguments()[1], tables, default_table_idx,
+                 out->add_children());
+    }
+    default:
+      return false;
+  }
+}
+
+/**
+ * @brief Return the date field inside EXTRACT(YEAR FROM field), if supported.
+ */
+const Field *ExtractYearField(Item *item) {
+  Item *real = item->real_item();
+  if (real->type() != Item::FUNC_ITEM) return nullptr;
+  auto *function = down_cast<Item_func *>(real);
+  if (function->functype() != Item_func::EXTRACT_FUNC) return nullptr;
+
+  auto *extract = down_cast<Item_extract *>(function);
+  if (extract->int_type != INTERVAL_YEAR) return nullptr;
+  Item *arg = extract->arguments()[0]->real_item();
+  if (arg->type() != Item::FIELD_ITEM) return nullptr;
+
+  const Field *field = down_cast<Item_field *>(arg)->field;
+  if (field->type() != MYSQL_TYPE_DATE &&
+      field->type() != MYSQL_TYPE_DATETIME &&
+      field->type() != MYSQL_TYPE_NEWDATE) {
+    return nullptr;
+  }
+  return field;
 }
 
 /**
@@ -796,12 +905,34 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
     }
   }
 
-  // Build a left-deep INNER join tree in FROM-clause order. Each new table must
-  // have at least one equality edge to the already joined side.
+  // Build a left-deep INNER join tree by walking FROM order and retrying tables
+  // whose equality edges are not connected yet.
   int current_node = scan_nodes[0];
   std::vector<bool> joined(tables.size(), false);
   joined[0] = true;
+  std::vector<int> pending_tables;
   for (size_t table_idx = 1; table_idx < tables.size(); table_idx++) {
+    pending_tables.push_back(static_cast<int>(table_idx));
+  }
+  while (!pending_tables.empty()) {
+    int table_idx = -1;
+    size_t pending_idx = 0;
+    for (size_t idx = 0; idx < pending_tables.size(); idx++) {
+      for (const JoinEdge &edge : join_edges) {
+        if ((edge.left_table == pending_tables[idx] &&
+             joined[edge.right_table]) ||
+            (edge.right_table == pending_tables[idx] &&
+             joined[edge.left_table])) {
+          table_idx = pending_tables[idx];
+          pending_idx = idx;
+          break;
+        }
+      }
+      if (table_idx >= 0) break;
+    }
+    if (table_idx < 0) LDB_COL_REJECT("disconnected join graph");
+    pending_tables.erase(pending_tables.begin() + pending_idx);
+
     bool connected = false;
     auto *join_node = request.add_nodes()->mutable_join();
     join_node->set_type(LineairDB::Protocol::QueryBlockJoin::INNER);
@@ -848,9 +979,30 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
     const Field *field = nullptr;
   };
   std::vector<GroupField> group_fields;
+  std::vector<Item *> group_items;
   for (ORDER *group = qb->group_list.first; group != nullptr;
        group = group->next) {
     Item *group_item = (*group->item)->real_item();
+    group_items.push_back(group_item);
+    if (const Field *year_field = ExtractYearField(group_item)) {
+      const int group_table = TableIndexOfField(year_field, tables);
+      const Field *group_field =
+          group_table >= 0
+              ? ResolveBaseField(year_field, tables[group_table].table)
+              : nullptr;
+      if (group_field == nullptr || group_field->is_nullable()) {
+        LDB_COL_REJECT("group year column");
+      }
+
+      auto *group_column = aggregate->add_group_columns();
+      group_column->set_table_idx(static_cast<uint32_t>(group_table));
+      group_column->set_column(group_field->field_index());
+      group_column->set_prefix_len(4);
+      group_column->set_cmp_kind(0);
+      group_fields.push_back({group_table, nullptr});
+      continue;
+    }
+
     if (group_item->type() != Item::FIELD_ITEM)
       LDB_COL_REJECT("group item not a column");
 
@@ -895,7 +1047,8 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
 
       int group_position = -1;
       for (size_t i = 0; i < group_fields.size(); i++) {
-        if (group_fields[i].table == output_table &&
+        if (group_fields[i].field != nullptr &&
+            group_fields[i].table == output_table &&
             group_fields[i].field == output_field) {
           group_position = static_cast<int>(i);
           break;
@@ -909,8 +1062,21 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
       continue;
     }
 
-    if (real->type() != Item::SUM_FUNC_ITEM)
-      LDB_COL_REJECT("output not aggregate");
+    if (real->type() != Item::SUM_FUNC_ITEM) {
+      int group_position = -1;
+      for (size_t group_idx = 0; group_idx < group_items.size();
+           group_idx++) {
+        if (group_items[group_idx] == real ||
+            group_items[group_idx]->eq(real, true)) {
+          group_position = static_cast<int>(group_idx);
+          break;
+        }
+      }
+      if (group_position < 0) LDB_COL_REJECT("output not aggregate");
+      output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::GROUP);
+      output->set_ordinal(group_position);
+      continue;
+    }
 
     Item_sum *sum = down_cast<Item_sum *>(real);
     if (sum->argument_count() > 1) LDB_COL_REJECT("aggregate arg count");
@@ -971,10 +1137,9 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
           LDB_COL_REJECT("aggregate arg type");
         }
 
-        const int argument_table =
+        int argument_table =
             SingleTableOf(arg->used_tables() & ~PSEUDO_TABLE_BITS, tables);
-        if (argument_table < 0) LDB_COL_REJECT("aggregate arg tables");
-        if (arg->type() == Item::FIELD_ITEM) {
+        if (argument_table >= 0 && arg->type() == Item::FIELD_ITEM) {
           const Field *raw_argument_field =
               down_cast<Item_field *>(arg)->field;
           const Field *argument_field = ResolveBaseField(
@@ -985,9 +1150,16 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
           auto *ref = function->mutable_arg();
           ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
           ref->set_column_index(argument_field->field_index());
-        } else {
+        } else if (argument_table >= 0) {
           if (!lineairdb::serialize_aggregate_expression(
                   arg, function->mutable_arg())) {
+            LDB_COL_REJECT("aggregate expr not pushable");
+          }
+        } else {
+          argument_table = 0;
+          if (!SerializeAggregateExpressionForTables(
+                  arg, tables, static_cast<uint32_t>(argument_table),
+                  function->mutable_arg())) {
             LDB_COL_REJECT("aggregate expr not pushable");
           }
         }

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -3513,6 +3513,54 @@ bool OptimizeSecondaryEngine(THD *, LEX *lex) {
   return false;
 }
 
+bool ModifyAccessPathCost(THD *thd [[maybe_unused]],
+                          const JoinHypergraph &hypergraph [[maybe_unused]],
+                          AccessPath *path) {
+  switch (path->type) {
+    case AccessPath::NESTED_LOOP_JOIN:
+    case AccessPath::BKA_JOIN:
+    case AccessPath::NESTED_LOOP_SEMIJOIN_WITH_DUPLICATE_REMOVAL:
+    case AccessPath::EQ_REF:
+    case AccessPath::REF:
+    case AccessPath::REF_OR_NULL:
+    case AccessPath::INDEX_SCAN:
+    case AccessPath::INDEX_RANGE_SCAN: {
+      constexpr double kPenalty = 100.0;
+      path->cost = std::max(path->cost, 0.0) * kPenalty + 1.0;
+      path->cost_before_filter = path->cost;
+      if (path->init_cost >= 0.0) path->init_cost *= kPenalty;
+      return false;
+    }
+
+    case AccessPath::HASH_JOIN: {
+      const double build =
+          std::max(1.0, path->hash_join().inner->num_output_rows());
+      const double probe =
+          std::max(1.0, path->hash_join().outer->num_output_rows());
+      const double output = std::max(1.0, path->num_output_rows());
+      const double cost = path->hash_join().outer->cost +
+                          path->hash_join().inner->cost +
+                          0.05 * (build + probe) + 0.01 * output;
+      path->cost = cost;
+      path->cost_before_filter = cost;
+      path->init_cost = path->hash_join().inner->cost + 0.05 * build;
+      return false;
+    }
+
+    case AccessPath::TABLE_SCAN: {
+      const double rows = std::max(1.0, path->num_output_rows());
+      const double cost = 0.01 * rows;
+      path->cost = cost;
+      path->cost_before_filter = cost;
+      path->init_cost = 0.0;
+      return false;
+    }
+
+    default:
+      return false;
+  }
+}
+
 bool CompareJoinCost(THD *thd, const JOIN &join, double optimizer_cost,
                      bool *use_best_so_far, bool *cheaper,
                      double *secondary_engine_cost) {
@@ -3658,6 +3706,8 @@ int lineairdb_columnar_init(void *p) {
   hton->prepare_secondary_engine = lineairdb_columnar::PrepareSecondaryEngine;
   hton->optimize_secondary_engine = lineairdb_columnar::OptimizeSecondaryEngine;
   hton->compare_secondary_engine_cost = lineairdb_columnar::CompareJoinCost;
+  hton->secondary_engine_modify_access_path_cost =
+      lineairdb_columnar::ModifyAccessPathCost;
   hton->get_secondary_engine_offload_or_exec_fail_reason =
       lineairdb_columnar::GetColumnarFailReason;
   hton->set_secondary_engine_offload_fail_reason =

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -68,6 +68,10 @@ class LoadedTables {
 
 LoadedTables *loaded_tables = nullptr;
 
+// send_result_set_metadata() has already described the original SELECT fields.
+// The override executor only needs Item instances that carry computed values
+// through Query_result::send_data(), so this class mirrors the prototype type
+// metadata while storing the server-produced value as text.
 class ItemColumnarValue final : public Item_string {
  public:
   explicit ItemColumnarValue(const Item *prototype)
@@ -92,6 +96,9 @@ struct OutBinding {
   int index = 0;
 };
 
+// Statement-local state owned by LEX::secondary_engine_execution_context.
+// Recognition fills the serialized LineairDB request and output bindings;
+// execution consumes them after MySQL calls JOIN::override_executor_func.
 class ColumnarExecutionContext : public Secondary_engine_execution_context {
  public:
   bool BestPlanSoFar(const JOIN &join, double cost) {

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -400,6 +400,7 @@ bool CaseToFilteredSum(Item *argument, Item **predicate, Item **then_expr) {
 }
 
 struct QueryBlockTable {
+  Table_ref *table_ref = nullptr;
   TABLE *table = nullptr;
   table_map map = 0;
 };
@@ -1076,7 +1077,7 @@ bool RecognizeFlattenedAggregate(JOIN *join, ColumnarExecutionContext *ctx,
     if (table_ref->outer_join) LDB_COL_REJECT("inner outer join");
     if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
       LDB_COL_REJECT("inner not SECONDARY_LOADed");
-    tables.push_back({table, table_ref->map()});
+    tables.push_back({table_ref, table, table_ref->map()});
   }
   if (tables.size() < 2) LDB_COL_REJECT("inner too few tables");
 
@@ -1428,6 +1429,7 @@ bool BuildQueryBlockRequest(
   std::vector<bool> table_is_virtual;
   std::vector<Query_block *> virtual_blocks;
   std::vector<bool> virtual_block_is_scalar_aggregate;
+  std::vector<int> outer_derived_tables;
   for (Table_ref *table_ref = qb->leaf_tables; table_ref != nullptr;
        table_ref = table_ref->next_leaf) {
     if (table_ref->is_view_or_derived()) continue;
@@ -1438,7 +1440,7 @@ bool BuildQueryBlockRequest(
       LDB_COL_REJECT("outer join");
     if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
       LDB_COL_REJECT("not SECONDARY_LOADed");
-    tables.push_back({table, table_ref->map()});
+    tables.push_back({table_ref, table, table_ref->map()});
     table_semijoin_nest.push_back(semijoin_nest);
     table_is_virtual.push_back(false);
     if (semijoin_nest < 0) {
@@ -1454,8 +1456,6 @@ bool BuildQueryBlockRequest(
        table_ref = table_ref->next_leaf) {
     if (!table_ref->is_view_or_derived()) continue;
     const int semijoin_nest = semijoin_nest_of(table_ref);
-    if (semijoin_nest < 0 && table_ref->outer_join)
-      LDB_COL_REJECT("outer derived table");
     if (table_ref->table == nullptr) LDB_COL_REJECT("derived no TABLE");
 
     Query_expression *derived_unit = table_ref->derived_query_expression();
@@ -1464,7 +1464,7 @@ bool BuildQueryBlockRequest(
     Query_block *derived_qb = derived_unit->first_query_block();
     if (derived_qb == nullptr) LDB_COL_REJECT("derived no query block");
 
-    tables.push_back({table_ref->table, table_ref->map()});
+    tables.push_back({table_ref, table_ref->table, table_ref->map()});
     table_semijoin_nest.push_back(semijoin_nest);
     table_is_virtual.push_back(true);
     virtual_blocks.push_back(derived_qb);
@@ -1474,6 +1474,8 @@ bool BuildQueryBlockRequest(
     if (semijoin_nest >= 0) {
       semijoin_nests[semijoin_nest].inner_tables.push_back(
           static_cast<int>(tables.size()) - 1);
+    } else if (table_ref->outer_join) {
+      outer_derived_tables.push_back(static_cast<int>(tables.size()) - 1);
     } else {
       main_tables.push_back(static_cast<int>(tables.size()) - 1);
     }
@@ -1887,6 +1889,109 @@ bool BuildQueryBlockRequest(
 
     if (!connected) LDB_COL_REJECT("disconnected join graph");
     joined[table_idx] = true;
+    current_node = request.nodes_size() - 1;
+  }
+
+  // MySQL may rewrite correlated subqueries into derived tables on the
+  // nullable side of a LEFT join. Execute the derived block as a virtual table,
+  // then split the ON condition into equality keys and residual predicates.
+  for (int table_idx : outer_derived_tables) {
+    Table_ref *table_ref = tables[table_idx].table_ref;
+    Item *join_condition =
+        table_ref == nullptr ? nullptr : table_ref->join_cond();
+    if (join_condition == nullptr) LDB_COL_REJECT("derived LEFT without ON");
+
+    std::vector<Item *> join_predicates;
+    FlattenAnd(join_condition, &join_predicates);
+    std::vector<Item *> residual_predicates;
+
+    auto *join_node = request.add_nodes()->mutable_join();
+    join_node->set_type(LineairDB::Protocol::QueryBlockJoin::LEFT);
+    join_node->set_build(static_cast<uint32_t>(scan_nodes[table_idx]));
+    join_node->set_probe(static_cast<uint32_t>(current_node));
+
+    for (Item *predicate : join_predicates) {
+      bool is_join_key = false;
+      if (predicate->type() == Item::FUNC_ITEM &&
+          down_cast<Item_func *>(predicate)->functype() ==
+              Item_func::EQ_FUNC) {
+        auto *equals = down_cast<Item_func *>(predicate);
+        Item *left = equals->arguments()[0]->real_item();
+        Item *right = equals->arguments()[1]->real_item();
+        if (left->type() == Item::FIELD_ITEM &&
+            right->type() == Item::FIELD_ITEM) {
+          const Field *left_raw = semijoin_outer_equivalent(
+              down_cast<Item_field *>(left)->field);
+          const Field *right_raw = semijoin_outer_equivalent(
+              down_cast<Item_field *>(right)->field);
+          int left_table = TableIndexOfField(left_raw, tables);
+          int right_table = TableIndexOfField(right_raw, tables);
+          if (left_table == table_idx || right_table == table_idx) {
+            if (left_table != table_idx) {
+              std::swap(left_table, right_table);
+              std::swap(left_raw, right_raw);
+            }
+            if (right_table >= 0 &&
+                JoinColumnsUseByteEquality(left_raw, right_raw)) {
+              const Field *build_field =
+                  resolve_query_field(left_raw, left_table);
+              const Field *probe_field =
+                  resolve_query_field(right_raw, right_table);
+              if (build_field != nullptr && probe_field != nullptr) {
+                auto *build_key = join_node->add_build_keys();
+                build_key->set_table_idx(static_cast<uint32_t>(table_idx));
+                build_key->set_column(build_field->field_index());
+                auto *probe_key = join_node->add_probe_keys();
+                probe_key->set_table_idx(static_cast<uint32_t>(right_table));
+                probe_key->set_column(probe_field->field_index());
+                is_join_key = true;
+              }
+            }
+          }
+        }
+      }
+      if (!is_join_key) residual_predicates.push_back(predicate);
+    }
+
+    if (join_node->build_keys_size() == 0)
+      LDB_COL_REJECT("derived LEFT keyless");
+
+    if (!residual_predicates.empty()) {
+      TupleColumnRegistry registry;
+      registry.table_of = [&](const Field *field) {
+        return TableIndexOfField(field, tables);
+      };
+      registry.resolve = [&](const Field *field, int table_idx) {
+        return resolve_query_field(field, table_idx);
+      };
+
+      auto *residual = join_node->mutable_residual();
+      auto *predicate = residual->mutable_predicate();
+      auto *expression = predicate->mutable_expr();
+      if (residual_predicates.size() == 1) {
+        if (!SerializeTuplePredicate(residual_predicates[0], expression,
+                                     &registry)) {
+          LDB_COL_REJECT("derived ON residual not pushable");
+        }
+      } else {
+        expression->set_op(LineairDB::Protocol::FilterExpr::OP_AND);
+        for (Item *residual_predicate : residual_predicates) {
+          if (!SerializeTuplePredicate(residual_predicate,
+                                       expression->add_children(),
+                                       &registry)) {
+            LDB_COL_REJECT("derived ON residual not pushable");
+          }
+        }
+      }
+
+      predicate->set_num_columns(registry.columns.size());
+      for (const auto &column_ref : registry.columns) {
+        auto *column = residual->add_columns();
+        column->set_table_idx(static_cast<uint32_t>(column_ref.first));
+        column->set_column(column_ref.second->field_index());
+      }
+    }
+
     current_node = request.nodes_size() - 1;
   }
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -18,6 +18,8 @@
 #include "sql/handler.h"
 #include "sql/item.h"
 #include "sql/item_sum.h"
+#include "sql/mem_root_array.h"
+#include "sql/query_result.h"
 #include "sql/sql_const.h"
 #include "sql/sql_class.h"
 #include "sql/sql_lex.h"
@@ -28,8 +30,14 @@
 #include "thr_lock.h"
 
 #include "aggregate_pushdown.hh"
+#include "lineairdb_keyenc.hh"
 #include "lineairdb.pb.h"
+#include "lineairdb_proxy.hh"
 #include "lineairdb_pushdown.hh"
+
+namespace lineairdb {
+std::shared_ptr<LineairDBProxy> acquire_shared_proxy(THD *thd);
+}  // namespace lineairdb
 
 namespace lineairdb_columnar {
 
@@ -397,6 +405,104 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
 #undef LDB_COL_REJECT
 }
 
+/**
+ * @brief Execute a recognized aggregate block through LineairDB.
+ *
+ * MySQL has already sent result-set metadata for the original SELECT list. This
+ * override runs one aggregate read-plan step and sends value-only Item carriers
+ * that match that already-described metadata.
+ */
+bool ExecuteColumnarAggregate(JOIN *join, Query_result *result) {
+  THD *thd = current_thd;
+  auto *ctx = static_cast<ColumnarExecutionContext *>(
+      thd->lex->secondary_engine_execution_context());
+  if (ctx == nullptr || ctx->serialized_aggregate.empty()) {
+    my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
+             "LINEAIRDB_COLUMNAR: no offload plan");
+    return true;
+  }
+
+  std::shared_ptr<LineairDBProxy> proxy = lineairdb::acquire_shared_proxy(thd);
+  if (!proxy) {
+    my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
+             "LINEAIRDB_COLUMNAR: no server connection");
+    return true;
+  }
+
+  LineairDBProxy::ReadPlanStep step;
+  step.table_name = ctx->table_name;
+  step.is_scan = true;
+  step.end_key_prefix = lineairdb_keyenc::scan_end_sentinel();
+  step.serialized_filter = ctx->serialized_filter;
+  step.aggregate_serialized = ctx->serialized_aggregate;
+
+  LineairDBProxy::ReadPlanResult rpc = proxy->tx_execute_read_plan({step});
+  if (!rpc.ok || rpc.steps.size() != 1) {
+    my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
+             "LINEAIRDB_COLUMNAR: aggregate scan RPC failed");
+    return true;
+  }
+
+  mem_root_deque<Item *> output_items(thd->mem_root);
+  std::vector<ItemColumnarValue *> values;
+  values.reserve(ctx->bindings.size());
+  for (Item *item : VisibleFields(join->query_block->fields)) {
+    auto *value = new (thd->mem_root) ItemColumnarValue(item);
+    if (value == nullptr) return true;
+    values.push_back(value);
+    output_items.push_back(value);
+  }
+  if (values.size() != ctx->bindings.size()) {
+    my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
+             "LINEAIRDB_COLUMNAR: output binding mismatch");
+    return true;
+  }
+
+  std::vector<DecodedField> fields;
+  for (const std::string &row : rpc.steps[0].scan_values) {
+    if (!DecodeRowFields(row, &fields)) {
+      my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
+               "LINEAIRDB_COLUMNAR: malformed group row");
+      return true;
+    }
+
+    // Server aggregate rows are [null_flags][group cols][value,count per agg].
+    const size_t expected = 1 + static_cast<size_t>(ctx->group_column_count) +
+                            2 * static_cast<size_t>(ctx->aggregate_count);
+    if (fields.size() != expected) {
+      my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
+               "LINEAIRDB_COLUMNAR: unexpected group row shape");
+      return true;
+    }
+
+    for (size_t i = 0; i < ctx->bindings.size(); i++) {
+      const OutBinding &binding = ctx->bindings[i];
+      const DecodedField &field =
+          binding.is_aggregate
+              ? fields[1 + ctx->group_column_count + 2 * binding.index]
+              : fields[1 + binding.index];
+
+      if (!field.empty) {
+        values[i]->set_value(field.ptr, field.len);
+        continue;
+      }
+
+      // Empty aggregate fields are SQL NULL, while GROUP BY fields are
+      // non-nullable by recognition and represent an empty byte string.
+      if (binding.is_aggregate) {
+        values[i]->set_null_value();
+      } else {
+        values[i]->set_value("", 0);
+      }
+    }
+
+    if (result->send_data(thd, output_items)) return true;
+    ++join->send_records;
+  }
+
+  return false;
+}
+
 bool PrepareSecondaryEngine(THD *thd, LEX *lex) {
   lex->add_statement_options(OPTION_NO_CONST_TABLES |
                              OPTION_NO_SUBQUERY_DURING_OPTIMIZATION);
@@ -427,9 +533,8 @@ bool OptimizeSecondaryEngine(THD *, LEX *lex) {
     return true;
   }
 
-  my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
-           "LINEAIRDB_COLUMNAR executor is not available yet");
-  return true;
+  join->override_executor_func = ExecuteColumnarAggregate;
+  return false;
 }
 
 bool CompareJoinCost(THD *thd, const JOIN &join, double optimizer_cost,

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -277,6 +277,19 @@ bool GroupColumnIsBinarySafe(const Field *field) {
 }
 
 /**
+ * @brief Return true when a join key can use byte equality on stored cells.
+ *
+ * Integer cells and canonical DECIMAL text cells compare correctly with byte
+ * equality when both sides use the same MySQL result type.
+ */
+bool JoinColumnsUseByteEquality(const Field *left, const Field *right) {
+  if (left == nullptr || right == nullptr) return false;
+  if (left->result_type() != right->result_type()) return false;
+  return left->result_type() == INT_RESULT ||
+         left->result_type() == DECIMAL_RESULT;
+}
+
+/**
  * @brief Return the visible output ordinal used by an ORDER BY item.
  */
 int OrderOutputOrdinal(Item *order_item,
@@ -815,8 +828,7 @@ bool RecognizeDerivedRegroup(JOIN *join, ColumnarExecutionContext *ctx,
     } else {
       LDB_COL_REJECT("inner join key tables");
     }
-    if (preserved_key->result_type() != INT_RESULT ||
-        nullable_key->result_type() != INT_RESULT) {
+    if (!JoinColumnsUseByteEquality(preserved_key, nullable_key)) {
       LDB_COL_REJECT("inner join key type");
     }
     if (preserved_key->is_nullable() || nullable_key->is_nullable()) {
@@ -1123,8 +1135,7 @@ bool RecognizeFlattenedAggregate(JOIN *join, ColumnarExecutionContext *ctx,
     if (left_table < 0 || right_table < 0 || left_table == right_table) {
       LDB_COL_REJECT("inner join key tables");
     }
-    if (left_raw->result_type() != INT_RESULT ||
-        right_raw->result_type() != INT_RESULT) {
+    if (!JoinColumnsUseByteEquality(left_raw, right_raw)) {
       LDB_COL_REJECT("inner join key type");
     }
 
@@ -1516,8 +1527,7 @@ bool BuildQueryBlockRequest(
         table_semijoin_nest[right_table] >= 0) {
       return false;
     }
-    if (left_raw->result_type() != INT_RESULT ||
-        right_raw->result_type() != INT_RESULT) {
+    if (!JoinColumnsUseByteEquality(left_raw, right_raw)) {
       return false;
     }
 
@@ -1684,8 +1694,7 @@ bool BuildQueryBlockRequest(
               left_table == right_table) {
             continue;
           }
-          if (candidate.first->result_type() != INT_RESULT ||
-              candidate.second->result_type() != INT_RESULT) {
+          if (!JoinColumnsUseByteEquality(candidate.first, candidate.second)) {
             continue;
           }
 
@@ -1723,9 +1732,8 @@ bool BuildQueryBlockRequest(
     if (left_table < 0 || right_table < 0 || left_table == right_table) {
       LDB_COL_REJECT("join key tables");
     }
-    if (left_raw->result_type() != INT_RESULT ||
-        right_raw->result_type() != INT_RESULT) {
-      LDB_COL_REJECT("non-integer join key");
+    if (!JoinColumnsUseByteEquality(left_raw, right_raw)) {
+      LDB_COL_REJECT("join key type");
     }
 
     const Field *left_field = resolve_query_field(left_raw, left_table);
@@ -1916,8 +1924,7 @@ bool BuildQueryBlockRequest(
       if (outer_table < 0 || inner_key_table != inner_table) {
         LDB_COL_REJECT("semijoin key tables");
       }
-      if (raw_outer_field->result_type() != INT_RESULT ||
-          raw_inner_field->result_type() != INT_RESULT) {
+      if (!JoinColumnsUseByteEquality(raw_outer_field, raw_inner_field)) {
         LDB_COL_REJECT("semijoin key type");
       }
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -18,6 +18,7 @@
 #include "mysqld_error.h"
 #include "sql/handler.h"
 #include "sql/item.h"
+#include "sql/item_cmpfunc.h"
 #include "sql/item_sum.h"
 #include "sql/item_timefunc.h"
 #include "sql/mem_root_array.h"
@@ -1301,6 +1302,7 @@ bool BuildQueryBlockRequest(
   std::vector<int> table_semijoin_nest;
   std::vector<bool> table_is_virtual;
   std::vector<Query_block *> virtual_blocks;
+  std::vector<bool> virtual_block_is_scalar_aggregate;
   for (Table_ref *table_ref = qb->leaf_tables; table_ref != nullptr;
        table_ref = table_ref->next_leaf) {
     if (table_ref->is_view_or_derived()) continue;
@@ -1340,6 +1342,9 @@ bool BuildQueryBlockRequest(
     table_semijoin_nest.push_back(-1);
     table_is_virtual.push_back(true);
     virtual_blocks.push_back(derived_qb);
+    virtual_block_is_scalar_aggregate.push_back(
+        derived_qb->is_implicitly_grouped() &&
+        derived_qb->group_list.elements == 0);
     main_tables.push_back(static_cast<int>(tables.size()) - 1);
   }
   if (main_tables.empty()) LDB_COL_REJECT("no tables");
@@ -1361,8 +1366,60 @@ bool BuildQueryBlockRequest(
     const Field *right_field = nullptr;
   };
 
+  auto semijoin_outer_equivalent = [&](const Field *field) -> const Field * {
+    for (const SemijoinNest &semijoin : semijoin_nests) {
+      if (semijoin.nest == nullptr ||
+          semijoin.nest->nested_join == nullptr) {
+        continue;
+      }
+      const auto &outer_exprs =
+          semijoin.nest->nested_join->sj_outer_exprs;
+      const auto &inner_exprs =
+          semijoin.nest->nested_join->sj_inner_exprs;
+      for (size_t expr_idx = 0;
+           expr_idx < outer_exprs.size() && expr_idx < inner_exprs.size();
+           expr_idx++) {
+        Item *outer_item = outer_exprs[expr_idx]->real_item();
+        Item *inner_item = inner_exprs[expr_idx]->real_item();
+        if (outer_item->type() == Item::FIELD_ITEM &&
+            inner_item->type() == Item::FIELD_ITEM &&
+            down_cast<Item_field *>(inner_item)->field == field) {
+          return down_cast<Item_field *>(outer_item)->field;
+        }
+      }
+    }
+    return field;
+  };
+
   std::vector<std::vector<Item *>> table_filters(tables.size());
   std::vector<JoinEdge> join_edges;
+  auto add_join_edge_if_supported = [&](const Field *left_raw,
+                                        const Field *right_raw) -> bool {
+    const int left_table = TableIndexOfField(left_raw, tables);
+    const int right_table = TableIndexOfField(right_raw, tables);
+    if (left_table < 0 || right_table < 0 || left_table == right_table) {
+      return false;
+    }
+    if (table_semijoin_nest[left_table] >= 0 ||
+        table_semijoin_nest[right_table] >= 0) {
+      return false;
+    }
+    if (left_raw->result_type() != INT_RESULT ||
+        right_raw->result_type() != INT_RESULT) {
+      return false;
+    }
+
+    const Field *left_field = resolve_query_field(left_raw, left_table);
+    const Field *right_field = resolve_query_field(right_raw, right_table);
+    if (left_field == nullptr || right_field == nullptr) return false;
+    if ((!table_is_virtual[left_table] && left_field->is_nullable()) ||
+        (!table_is_virtual[right_table] && right_field->is_nullable())) {
+      return false;
+    }
+    join_edges.push_back({left_table, right_table, left_field, right_field});
+    return true;
+  };
+
   std::vector<Item *> tuple_predicates;
   Item *where_cond =
       qb->where_cond() != nullptr
@@ -1411,7 +1468,48 @@ bool BuildQueryBlockRequest(
       predicate_nest = table_nest;
     }
     if (spans_multiple_nests) LDB_COL_REJECT("predicate spans semijoins");
+    if (predicate->type() == Item::FUNC_ITEM &&
+        down_cast<Item_func *>(predicate)->functype() ==
+            Item_func::MULT_EQUAL_FUNC) {
+      auto *multiple_equal = down_cast<Item_equal *>(predicate);
+      if (multiple_equal->const_arg() != nullptr) {
+        LDB_COL_REJECT("multiple equality with constant");
+      }
+      std::vector<const Field *> equal_fields;
+      for (Item_field &field_item : multiple_equal->get_fields()) {
+        equal_fields.push_back(field_item.field);
+      }
+      for (size_t left_idx = 0; left_idx < equal_fields.size(); left_idx++) {
+        for (size_t right_idx = left_idx + 1; right_idx < equal_fields.size();
+             right_idx++) {
+          add_join_edge_if_supported(equal_fields[left_idx],
+                                     equal_fields[right_idx]);
+        }
+      }
+      continue;
+    }
     if (predicate_nest >= 0) {
+      if (predicate->type() == Item::FUNC_ITEM &&
+          down_cast<Item_func *>(predicate)->functype() ==
+              Item_func::EQ_FUNC) {
+        auto *equals = down_cast<Item_func *>(predicate);
+        Item *left = equals->arguments()[0]->real_item();
+        Item *right = equals->arguments()[1]->real_item();
+        if (left->type() == Item::FIELD_ITEM &&
+            right->type() == Item::FIELD_ITEM) {
+          const Field *left_raw = semijoin_outer_equivalent(
+              down_cast<Item_field *>(left)->field);
+          const Field *right_raw = semijoin_outer_equivalent(
+              down_cast<Item_field *>(right)->field);
+          const int left_table = TableIndexOfField(left_raw, tables);
+          const int right_table = TableIndexOfField(right_raw, tables);
+          if (left_table >= 0 && right_table >= 0 &&
+              left_table == right_table) {
+            continue;
+          }
+          if (add_join_edge_if_supported(left_raw, right_raw)) continue;
+        }
+      }
       semijoin_nests[predicate_nest].residual_predicates.push_back(predicate);
       continue;
     }
@@ -2103,6 +2201,36 @@ bool BuildQueryBlockRequest(
       expr->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
       expr->set_column_index(aggregate_output_base +
                              static_cast<uint32_t>(ordinal));
+      return true;
+    }
+    if (item->type() == Item::FIELD_ITEM) {
+      const Field *raw_field = down_cast<Item_field *>(item)->field;
+      const int table_idx = TableIndexOfField(raw_field, tables);
+      if (table_idx < static_cast<int>(real_table_count) ||
+          table_idx >= static_cast<int>(tables.size()) ||
+          !table_is_virtual[table_idx]) {
+        return false;
+      }
+      const size_t virtual_idx =
+          static_cast<size_t>(table_idx) - real_table_count;
+      if (virtual_idx >= virtual_block_is_scalar_aggregate.size() ||
+          !virtual_block_is_scalar_aggregate[virtual_idx]) {
+        return false;
+      }
+
+      auto *function = aggregate->add_aggs();
+      function->set_arg_table(static_cast<uint32_t>(table_idx));
+      auto *ref = function->mutable_arg();
+      ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+      ref->set_column_index(raw_field->field_index());
+      function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::MIN);
+      function->set_cmp_kind(raw_field->result_type() == STRING_RESULT ? 1
+                                                                       : 0);
+
+      expr->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+      expr->set_column_index(aggregate_output_base +
+                             static_cast<uint32_t>(
+                                 aggregate->aggs_size() - 1));
       return true;
     }
     if (item->type() == Item::INT_ITEM) {

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1253,7 +1253,6 @@ bool BuildQueryBlockRequest(
   if (unit == nullptr || !unit->is_simple())
     LDB_COL_REJECT("not simple unit");
 
-  if (qb->having_cond() != nullptr) LDB_COL_REJECT("has HAVING");
   if (qb->is_distinct()) LDB_COL_REJECT("has DISTINCT");
   if (qb->has_windows()) LDB_COL_REJECT("has windows");
   if (qb->olap != UNSPECIFIED_OLAP_TYPE) LDB_COL_REJECT("has ROLLUP");
@@ -1835,6 +1834,36 @@ bool BuildQueryBlockRequest(
 
     auto *function = aggregate->add_aggs();
     switch (sum->sum_func()) {
+      case Item_sum::COUNT_DISTINCT_FUNC: {
+        if (sum->argument_count() != 1) {
+          aggregate_error = "COUNT DISTINCT arg count";
+          return -1;
+        }
+        Item *arg = sum->get_arg(0)->real_item();
+        if (arg->type() != Item::FIELD_ITEM) {
+          aggregate_error = "COUNT DISTINCT arg shape";
+          return -1;
+        }
+        const Field *raw_count_field = down_cast<Item_field *>(arg)->field;
+        const int count_table = TableIndexOfField(raw_count_field, tables);
+        const Field *count_field =
+            count_table >= 0
+                ? resolve_query_field(raw_count_field, count_table)
+                : nullptr;
+        if (count_field == nullptr) {
+          aggregate_error = "COUNT DISTINCT arg unresolvable";
+          return -1;
+        }
+
+        function->set_arg_table(static_cast<uint32_t>(count_table));
+        auto *ref = function->mutable_arg();
+        ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+        ref->set_column_index(count_field->field_index());
+        function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
+        function->set_distinct(true);
+        return aggregate->aggs_size() - 1;
+      }
+
       case Item_sum::COUNT_FUNC: {
         function->set_arg_table(0);
         if (sum->argument_count() > 0) {
@@ -2195,7 +2224,73 @@ bool BuildQueryBlockRequest(
     output->set_result_scale(real->decimals);
   }
 
-  if (aggregate->aggs_size() == 0) LDB_COL_REJECT("no aggregates");
+  if (qb->having_cond() != nullptr) {
+    std::function<bool(Item *, LineairDB::Protocol::FilterExpr *)>
+        serialize_having;
+    serialize_having =
+        [&](Item *item, LineairDB::Protocol::FilterExpr *expr) -> bool {
+      item = item->real_item();
+      if (item->type() == Item::COND_ITEM) {
+        auto *condition = down_cast<Item_cond *>(item);
+        expr->set_op(condition->functype() == Item_func::COND_AND_FUNC
+                         ? LineairDB::Protocol::FilterExpr::OP_AND
+                         : LineairDB::Protocol::FilterExpr::OP_OR);
+        List_iterator<Item> iterator(*condition->argument_list());
+        for (Item *part = iterator++; part != nullptr; part = iterator++) {
+          if (!serialize_having(part, expr->add_children())) return false;
+        }
+        return true;
+      }
+      if (item->type() != Item::FUNC_ITEM) return false;
+
+      auto *function = down_cast<Item_func *>(item);
+      LineairDB::Protocol::FilterExpr::Op op;
+      switch (function->functype()) {
+        case Item_func::EQ_FUNC:
+          op = LineairDB::Protocol::FilterExpr::OP_EQ;
+          break;
+        case Item_func::NE_FUNC:
+          op = LineairDB::Protocol::FilterExpr::OP_NE;
+          break;
+        case Item_func::LT_FUNC:
+          op = LineairDB::Protocol::FilterExpr::OP_LT;
+          break;
+        case Item_func::LE_FUNC:
+          op = LineairDB::Protocol::FilterExpr::OP_LE;
+          break;
+        case Item_func::GT_FUNC:
+          op = LineairDB::Protocol::FilterExpr::OP_GT;
+          break;
+        case Item_func::GE_FUNC:
+          op = LineairDB::Protocol::FilterExpr::OP_GE;
+          break;
+        default:
+          return false;
+      }
+      if (function->argument_count() != 2) return false;
+
+      expr->set_op(op);
+      for (uint arg_idx = 0; arg_idx < 2; arg_idx++) {
+        auto *child = expr->add_children();
+        if (!serialize_output_expression(function->arguments()[arg_idx],
+                                         child)) {
+          return false;
+        }
+        child->set_compare_type(2);
+      }
+      return true;
+    };
+
+    auto *having = aggregate->mutable_having();
+    if (!serialize_having(qb->having_cond(), having->mutable_expr())) {
+      LDB_COL_REJECT("HAVING not pushable");
+    }
+    having->set_num_columns(aggregate->group_columns_size() +
+                            aggregate->aggs_size());
+  }
+
+  if (aggregate->aggs_size() == 0 && aggregate->group_columns_size() == 0)
+    LDB_COL_REJECT("no aggregates");
 
   for (ORDER *order = qb->order_list.first; order != nullptr;
        order = order->next) {

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -575,8 +575,9 @@ int ha_lineairdb_columnar::open(const char *, int, unsigned int,
 }
 
 int ha_lineairdb_columnar::info(unsigned int flags) {
+  // Statistics come from the primary engine when it is available.
   handler *primary = ha_get_primary_handler();
-  if (primary == nullptr) return HA_ERR_GENERIC;
+  if (primary == nullptr) return 0;
 
   const int error = primary->info(flags);
   if (error == 0) stats.records = primary->stats.records;
@@ -587,7 +588,7 @@ ha_rows ha_lineairdb_columnar::records_in_range(unsigned int index,
                                                 key_range *min_key,
                                                 key_range *max_key) {
   handler *primary = ha_get_primary_handler();
-  return primary == nullptr ? HA_POS_ERROR
+  return primary == nullptr ? handler::records_in_range(index, min_key, max_key)
                             : primary->records_in_range(index, min_key,
                                                         max_key);
 }

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1388,13 +1388,17 @@ bool BuildQueryBlockRequest(
   if (unit == nullptr || !unit->is_simple())
     LDB_COL_REJECT("not simple unit");
 
-  if (qb->is_distinct()) LDB_COL_REJECT("has DISTINCT");
   if (qb->has_windows()) LDB_COL_REJECT("has windows");
   if (qb->olap != UNSPECIFIED_OLAP_TYPE) LDB_COL_REJECT("has ROLLUP");
   const bool implicit_grouping =
       join != nullptr ? join->implicit_grouping : qb->is_implicitly_grouped();
+  const bool distinct_as_group =
+      qb->is_distinct() && !implicit_grouping && qb->group_list.elements == 0 &&
+      !qb->with_sum_func;
+  if (qb->is_distinct() && !distinct_as_group)
+    LDB_COL_REJECT("has DISTINCT");
   const bool plain_rows =
-      !implicit_grouping && qb->group_list.elements == 0;
+      !distinct_as_group && !implicit_grouping && qb->group_list.elements == 0;
 
   struct SemijoinNest {
     Table_ref *nest = nullptr;
@@ -3220,10 +3224,26 @@ bool BuildQueryBlockRequest(
   };
   std::vector<GroupField> group_fields;
   std::vector<Item *> group_items;
-  for (ORDER *group = qb->group_list.first; group != nullptr;
-       group = group->next) {
-    Item *group_item = (*group->item)->real_item();
-    group_items.push_back(group_item);
+  if (distinct_as_group) {
+    // SELECT DISTINCT without aggregates is group-by-all over the visible
+    // output expressions. Constants cannot split groups; EXISTS-style
+    // rewrites put literals in the select list.
+    for (Item *item : output_items) {
+      Item *real = item->real_item();
+      if (real->const_item()) continue;
+      group_items.push_back(real);
+    }
+    // Group-by-nothing fabricates one row from empty input, which is wrong
+    // for DISTINCT over constants only.
+    if (group_items.empty()) LDB_COL_REJECT("distinct outputs all constant");
+  } else {
+    for (ORDER *group = qb->group_list.first; group != nullptr;
+         group = group->next) {
+      group_items.push_back((*group->item)->real_item());
+    }
+  }
+
+  for (Item *group_item : group_items) {
     if (const Field *year_field = ExtractYearField(group_item)) {
       const int group_table = TableIndexOfField(year_field, tables);
       const Field *group_field =

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <map>
 #include <memory>
@@ -546,6 +547,117 @@ bool SerializeTuplePredicate(Item *item,
 }
 
 /**
+ * @brief Return the column and width for SUBSTRING(column, 1, width).
+ */
+const Field *SubstringPrefixField(Item *item, uint32_t *prefix_len) {
+  Item *real = item->real_item();
+  if (real->type() != Item::FUNC_ITEM) return nullptr;
+
+  auto *function = down_cast<Item_func *>(real);
+  if (std::strcmp(function->func_name(), "substr") != 0 ||
+      function->argument_count() != 3) {
+    return nullptr;
+  }
+
+  Item *column = function->arguments()[0]->real_item();
+  Item *from = function->arguments()[1];
+  Item *length = function->arguments()[2];
+  if (column->type() != Item::FIELD_ITEM) return nullptr;
+  if (!from->const_item() || from->val_int() != 1) return nullptr;
+  if (!length->const_item() || length->val_int() <= 0) return nullptr;
+
+  *prefix_len = static_cast<uint32_t>(length->val_int());
+  return down_cast<Item_field *>(column)->field;
+}
+
+/**
+ * @brief Serialize a scan predicate, including safe string-prefix rewrites.
+ *
+ * The shared predicate serializer does not model SUBSTRING. For the prefix form
+ * SUBSTRING(column, 1, N) = 'value' or IN (...), rewrite the predicate to
+ * column LIKE 'value%' when every constant has exactly N bytes and does not
+ * contain LIKE wildcards.
+ */
+bool SerializeScanPredicate(Item *condition,
+                            LineairDB::Protocol::FilterExpr *expression) {
+  if (serialize_item(condition, expression)) return true;
+  expression->Clear();
+
+  Item *real = condition->real_item();
+  if (real->type() != Item::FUNC_ITEM) return false;
+
+  auto *function = down_cast<Item_func *>(real);
+  uint32_t prefix_len = 0;
+  const Field *field = nullptr;
+  std::vector<std::string> values;
+  bool negated = false;
+
+  if (function->functype() == Item_func::IN_FUNC) {
+    auto *in_function = down_cast<Item_func_in *>(function);
+    negated = in_function->negated;
+    field = SubstringPrefixField(function->arguments()[0], &prefix_len);
+    if (field == nullptr) return false;
+
+    for (uint arg_idx = 1; arg_idx < function->argument_count(); arg_idx++) {
+      Item *value_item = function->arguments()[arg_idx];
+      if (!value_item->const_item()) return false;
+
+      String value_buffer;
+      String *value = value_item->val_str(&value_buffer);
+      if (value == nullptr) return false;
+      values.emplace_back(value->ptr(), value->length());
+    }
+  } else if (function->functype() == Item_func::EQ_FUNC) {
+    field = SubstringPrefixField(function->arguments()[0], &prefix_len);
+    Item *value_item = function->arguments()[1];
+    if (field == nullptr || !value_item->const_item()) return false;
+
+    String value_buffer;
+    String *value = value_item->val_str(&value_buffer);
+    if (value == nullptr) return false;
+    values.emplace_back(value->ptr(), value->length());
+  } else {
+    return false;
+  }
+
+  // Keep negated forms on the fallback path so NULL behavior remains SQL-like.
+  if (negated) return false;
+
+  for (const std::string &value : values) {
+    if (value.size() != prefix_len) return false;
+    if (value.find('%') != std::string::npos ||
+        value.find('_') != std::string::npos) {
+      return false;
+    }
+  }
+
+  auto emit_like = [&](LineairDB::Protocol::FilterExpr *target,
+                       const std::string &value) {
+    target->set_op(LineairDB::Protocol::FilterExpr::OP_LIKE);
+
+    auto *column = target->add_children();
+    column->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+    column->set_column_index(field->field_index());
+    column->set_compare_type(3);
+
+    auto *pattern = target->add_children();
+    pattern->set_op(LineairDB::Protocol::FilterExpr::CONST_STRING);
+    pattern->set_string_val(value + "%");
+    pattern->set_compare_type(3);
+  };
+
+  if (values.size() == 1) {
+    emit_like(expression, values[0]);
+  } else {
+    expression->set_op(LineairDB::Protocol::FilterExpr::OP_OR);
+    for (const std::string &value : values) {
+      emit_like(expression->add_children(), value);
+    }
+  }
+  return true;
+}
+
+/**
  * @brief Return the date field inside EXTRACT(YEAR FROM field), if supported.
  */
 const Field *ExtractYearField(Item *item) {
@@ -576,13 +688,13 @@ bool SerializeTableFilters(const std::vector<Item *> &filters, TABLE *table,
   if (filters.empty()) return true;
   predicate->set_num_columns(table->s->fields);
   if (filters.size() == 1) {
-    return serialize_item(filters[0], predicate->mutable_expr());
+    return SerializeScanPredicate(filters[0], predicate->mutable_expr());
   }
 
   auto *root = predicate->mutable_expr();
   root->set_op(LineairDB::Protocol::FilterExpr::OP_AND);
   for (Item *filter : filters) {
-    if (!serialize_item(filter, root->add_children())) return false;
+    if (!SerializeScanPredicate(filter, root->add_children())) return false;
   }
   return true;
 }

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1953,8 +1953,10 @@ bool BuildQueryBlockRequest(
       if (!is_join_key) residual_predicates.push_back(predicate);
     }
 
-    if (join_node->build_keys_size() == 0)
+    if (join_node->build_keys_size() == 0 &&
+        !is_scalar_virtual_table(table_idx)) {
       LDB_COL_REJECT("derived LEFT keyless");
+    }
 
     if (!residual_predicates.empty()) {
       TupleColumnRegistry registry;

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -31,6 +31,7 @@
 #include "sql/query_result.h"
 #include "sql/sql_const.h"
 #include "sql/sql_class.h"
+#include "sql/sql_executor.h"
 #include "sql/sql_lex.h"
 #include "sql/sql_optimizer.h"
 #include "sql/table.h"
@@ -2193,6 +2194,99 @@ bool BuildQueryBlockRequest(
           return emit_mapped_join(join_type, probe, build, expression,
                                   std::vector<Item *>{},
                                   estimated_rows(path));
+        }
+
+        case AccessPath::WEEDOUT: {
+          AccessPath *child = path->weedout().child;
+          std::vector<Item *> residuals;
+          while (child != nullptr && child->type == AccessPath::FILTER) {
+            FlattenAnd(child->filter().condition, &residuals);
+            child = child->filter().child;
+          }
+          if (child == nullptr ||
+              (child->type != AccessPath::HASH_JOIN &&
+               child->type != AccessPath::NESTED_LOOP_JOIN)) {
+            *why = "plan weedout shape";
+            return -1;
+          }
+
+          const bool child_is_nested_loop =
+              child->type == AccessPath::NESTED_LOOP_JOIN;
+          if (child_is_nested_loop
+                  ? child->nested_loop_join().join_type != JoinType::INNER
+                  : child->hash_join().rewrite_semi_to_inner) {
+            *why = "plan weedout join type";
+            return -1;
+          }
+
+          const JoinPredicate *join_predicate =
+              child_is_nested_loop
+                  ? child->nested_loop_join().join_predicate
+                  : child->hash_join().join_predicate;
+          if (join_predicate == nullptr || join_predicate->expr == nullptr) {
+            *why = "plan weedout join predicate";
+            return -1;
+          }
+          if (!child_is_nested_loop &&
+              join_predicate->expr->type != RelationalExpression::INNER_JOIN &&
+              join_predicate->expr->type !=
+                  RelationalExpression::STRAIGHT_INNER_JOIN) {
+            *why = "plan weedout join type";
+            return -1;
+          }
+
+          const int outer = map_path(child_is_nested_loop
+                                         ? child->nested_loop_join().outer
+                                         : child->hash_join().outer,
+                                     false);
+          if (outer < 0) return -1;
+          const int inner = map_path(child_is_nested_loop
+                                         ? child->nested_loop_join().inner
+                                         : child->hash_join().inner,
+                                     false);
+          if (inner < 0) return -1;
+
+          const SJ_TMP_TABLE *weedout_table = path->weedout().weedout_table;
+          if (weedout_table == nullptr) {
+            *why = "plan weedout table";
+            return -1;
+          }
+
+          std::set<int> deduplicated_tables;
+          for (SJ_TMP_TABLE_TAB *tab = weedout_table->tabs;
+               tab != weedout_table->tabs_end; ++tab) {
+            const TABLE *table =
+                tab->qep_tab != nullptr ? tab->qep_tab->table() : nullptr;
+            int table_idx = -1;
+            for (size_t idx = 0; idx < tables.size(); idx++) {
+              if (tables[idx].table == table) {
+                table_idx = static_cast<int>(idx);
+                break;
+              }
+            }
+            if (table_idx < 0) {
+              *why = "plan weedout table";
+              return -1;
+            }
+            deduplicated_tables.insert(table_idx);
+          }
+
+          int probe = -1;
+          int build = -1;
+          if (deduplicated_tables == node_tables[outer]) {
+            probe = outer;
+            build = inner;
+          } else if (deduplicated_tables == node_tables[inner]) {
+            probe = inner;
+            build = outer;
+          } else {
+            *why = "plan weedout tables";
+            return -1;
+          }
+
+          return emit_mapped_join(LineairDB::Protocol::QueryBlockJoin::SEMI,
+                                  probe, build, join_predicate->expr,
+                                  residuals, estimated_rows(path));
         }
 
         case AccessPath::MATERIALIZE: {

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1886,17 +1886,135 @@ bool BuildQueryBlockRequest(
   }
 
   for (SemijoinNest &semijoin : semijoin_nests) {
-    if (semijoin.inner_tables.size() != 1)
-      LDB_COL_REJECT("multi-table semijoin");
+    if (semijoin.inner_tables.empty())
+      LDB_COL_REJECT("empty semijoin");
     if (semijoin.nest == nullptr || semijoin.nest->nested_join == nullptr)
       LDB_COL_REJECT("semijoin missing key metadata");
 
-    const int inner_table = semijoin.inner_tables[0];
+    auto semijoin_has_table = [&](int table_idx) {
+      for (int inner_table : semijoin.inner_tables) {
+        if (inner_table == table_idx) return true;
+      }
+      return false;
+    };
+
+    // Multi-table semijoin nests become a build-side INNER-join mini tree.
+    int build_node = scan_nodes[semijoin.inner_tables[0]];
+    if (semijoin.inner_tables.size() > 1) {
+      struct InnerJoinEdge {
+        int left_table = -1;
+        int right_table = -1;
+        const Field *left_field = nullptr;
+        const Field *right_field = nullptr;
+      };
+
+      std::vector<InnerJoinEdge> inner_edges;
+      std::vector<Item *> remaining_residuals;
+      for (Item *predicate : semijoin.residual_predicates) {
+        bool consumed = false;
+        if (predicate->type() == Item::FUNC_ITEM &&
+            down_cast<Item_func *>(predicate)->functype() ==
+                Item_func::EQ_FUNC) {
+          auto *equals = down_cast<Item_func *>(predicate);
+          Item *left = equals->arguments()[0]->real_item();
+          Item *right = equals->arguments()[1]->real_item();
+          if (left->type() == Item::FIELD_ITEM &&
+              right->type() == Item::FIELD_ITEM) {
+            const Field *left_raw = down_cast<Item_field *>(left)->field;
+            const Field *right_raw = down_cast<Item_field *>(right)->field;
+            const int left_table = TableIndexOfField(left_raw, tables);
+            const int right_table = TableIndexOfField(right_raw, tables);
+            const Field *left_field =
+                left_table >= 0 ? resolve_query_field(left_raw, left_table)
+                                : nullptr;
+            const Field *right_field =
+                right_table >= 0 ? resolve_query_field(right_raw, right_table)
+                                 : nullptr;
+            if (left_table >= 0 && right_table >= 0 &&
+                left_table != right_table && semijoin_has_table(left_table) &&
+                semijoin_has_table(right_table) &&
+                JoinColumnsUseByteEquality(left_raw, right_raw) &&
+                left_field != nullptr && right_field != nullptr &&
+                !left_field->is_nullable() && !right_field->is_nullable()) {
+              inner_edges.push_back(
+                  {left_table, right_table, left_field, right_field});
+              consumed = true;
+            }
+          }
+        }
+        if (!consumed) remaining_residuals.push_back(predicate);
+      }
+      semijoin.residual_predicates = std::move(remaining_residuals);
+
+      std::vector<bool> inner_joined(tables.size(), false);
+      inner_joined[semijoin.inner_tables[0]] = true;
+      std::vector<int> pending_inner_tables(
+          semijoin.inner_tables.begin() + 1,
+          semijoin.inner_tables.end());
+
+      while (!pending_inner_tables.empty()) {
+        int picked_table = -1;
+        size_t picked_idx = 0;
+        for (size_t idx = 0; idx < pending_inner_tables.size(); idx++) {
+          for (const InnerJoinEdge &edge : inner_edges) {
+            if ((edge.left_table == pending_inner_tables[idx] &&
+                 inner_joined[edge.right_table]) ||
+                (edge.right_table == pending_inner_tables[idx] &&
+                 inner_joined[edge.left_table])) {
+              picked_table = pending_inner_tables[idx];
+              picked_idx = idx;
+              break;
+            }
+          }
+          if (picked_table >= 0) break;
+        }
+        if (picked_table < 0) LDB_COL_REJECT("semijoin disconnected");
+        pending_inner_tables.erase(pending_inner_tables.begin() + picked_idx);
+
+        bool connected = false;
+        auto *inner_join = request.add_nodes()->mutable_join();
+        inner_join->set_type(LineairDB::Protocol::QueryBlockJoin::INNER);
+        inner_join->set_build(static_cast<uint32_t>(scan_nodes[picked_table]));
+        inner_join->set_probe(static_cast<uint32_t>(build_node));
+
+        for (const InnerJoinEdge &edge : inner_edges) {
+          const Field *build_field = nullptr;
+          const Field *probe_field = nullptr;
+          int probe_table = -1;
+          if (edge.left_table == picked_table &&
+              inner_joined[edge.right_table]) {
+            build_field = edge.left_field;
+            probe_field = edge.right_field;
+            probe_table = edge.right_table;
+          } else if (edge.right_table == picked_table &&
+                     inner_joined[edge.left_table]) {
+            build_field = edge.right_field;
+            probe_field = edge.left_field;
+            probe_table = edge.left_table;
+          } else {
+            continue;
+          }
+
+          auto *build_key = inner_join->add_build_keys();
+          build_key->set_table_idx(static_cast<uint32_t>(picked_table));
+          build_key->set_column(build_field->field_index());
+          auto *probe_key = inner_join->add_probe_keys();
+          probe_key->set_table_idx(static_cast<uint32_t>(probe_table));
+          probe_key->set_column(probe_field->field_index());
+          connected = true;
+        }
+
+        if (!connected) LDB_COL_REJECT("semijoin disconnected");
+        inner_joined[picked_table] = true;
+        build_node = request.nodes_size() - 1;
+      }
+    }
+
     auto *join_node = request.add_nodes()->mutable_join();
     join_node->set_type(semijoin.anti
                             ? LineairDB::Protocol::QueryBlockJoin::ANTI
                             : LineairDB::Protocol::QueryBlockJoin::SEMI);
-    join_node->set_build(static_cast<uint32_t>(scan_nodes[inner_table]));
+    join_node->set_build(static_cast<uint32_t>(build_node));
     join_node->set_probe(static_cast<uint32_t>(current_node));
 
     const auto &outer_exprs =
@@ -1921,7 +2039,7 @@ bool BuildQueryBlockRequest(
           down_cast<Item_field *>(inner_item)->field;
       const int outer_table = TableIndexOfField(raw_outer_field, tables);
       const int inner_key_table = TableIndexOfField(raw_inner_field, tables);
-      if (outer_table < 0 || inner_key_table != inner_table) {
+      if (outer_table < 0 || !semijoin_has_table(inner_key_table)) {
         LDB_COL_REJECT("semijoin key tables");
       }
       if (!JoinColumnsUseByteEquality(raw_outer_field, raw_inner_field)) {
@@ -1937,7 +2055,7 @@ bool BuildQueryBlockRequest(
       }
 
       auto *build_key = join_node->add_build_keys();
-      build_key->set_table_idx(static_cast<uint32_t>(inner_table));
+      build_key->set_table_idx(static_cast<uint32_t>(inner_key_table));
       build_key->set_column(inner_field->field_index());
       auto *probe_key = join_node->add_probe_keys();
       probe_key->set_table_idx(static_cast<uint32_t>(outer_table));

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -141,6 +141,30 @@ class ItemColumnarValue final : public Item_string {
   }
 
   void set_null_value() { null_value = true; }
+
+  String *val_str(String *str) override {
+    return null_value ? nullptr : Item_string::val_str(str);
+  }
+
+  double val_real() override {
+    return null_value ? 0.0 : Item_string::val_real();
+  }
+
+  longlong val_int() override {
+    return null_value ? 0 : Item_string::val_int();
+  }
+
+  my_decimal *val_decimal(my_decimal *decimal_value) override {
+    return null_value ? nullptr : Item_string::val_decimal(decimal_value);
+  }
+
+  bool get_date(MYSQL_TIME *time, my_time_flags_t flags) override {
+    return null_value ? true : Item_string::get_date(time, flags);
+  }
+
+  bool get_time(MYSQL_TIME *time) override {
+    return null_value ? true : Item_string::get_time(time);
+  }
 };
 
 // Statement-local state owned by LEX::secondary_engine_execution_context.

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -1427,8 +1428,306 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
   std::vector<Item *> output_items;
   for (Item *item : VisibleFields(qb->fields)) output_items.push_back(item);
 
+  const char *aggregate_error = nullptr;
+  auto register_aggregate = [&](Item_sum *sum) -> int {
+    if (sum->argument_count() > 1) {
+      aggregate_error = "aggregate arg count";
+      return -1;
+    }
+
+    auto *function = aggregate->add_aggs();
+    switch (sum->sum_func()) {
+      case Item_sum::COUNT_FUNC: {
+        function->set_arg_table(0);
+        if (sum->argument_count() > 0) {
+          Item *arg = sum->get_arg(0)->real_item();
+          if (arg->const_item()) {
+            if (arg->is_nullable() || arg->is_null()) {
+              aggregate_error = "COUNT const nullable";
+              return -1;
+            }
+          } else {
+            if (arg->type() != Item::FIELD_ITEM) {
+              aggregate_error = "COUNT arg shape";
+              return -1;
+            }
+            const Field *raw_count_field =
+                down_cast<Item_field *>(arg)->field;
+            const int count_table = TableIndexOfField(raw_count_field, tables);
+            const Field *count_field =
+                count_table >= 0
+                    ? ResolveBaseField(raw_count_field,
+                                       tables[count_table].table)
+                    : nullptr;
+            if (count_field == nullptr || count_field->is_nullable()) {
+              aggregate_error = "COUNT arg nullable";
+              return -1;
+            }
+            function->set_arg_table(static_cast<uint32_t>(count_table));
+            auto *ref = function->mutable_arg();
+            ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+            ref->set_column_index(count_field->field_index());
+          }
+        }
+
+        function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
+        return aggregate->aggs_size() - 1;
+      }
+
+      case Item_sum::SUM_FUNC:
+      case Item_sum::AVG_FUNC: {
+        if (sum->argument_count() != 1) {
+          aggregate_error = "aggregate arg count";
+          return -1;
+        }
+        Item *arg = sum->get_arg(0)->real_item();
+        if (sum->sum_func() == Item_sum::SUM_FUNC) {
+          if (Item *filter = CaseToCountFilter(arg)) {
+            const int filter_table = SingleTableOf(
+                filter->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+            if (filter_table < 0) {
+              aggregate_error = "CASE filter tables";
+              return -1;
+            }
+            auto *predicate = function->mutable_filter();
+            predicate->set_num_columns(tables[filter_table].table->s->fields);
+            if (!serialize_item(filter, predicate->mutable_expr())) {
+              aggregate_error = "CASE filter not pushable";
+              return -1;
+            }
+            function->set_arg_table(static_cast<uint32_t>(filter_table));
+            function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
+            return aggregate->aggs_size() - 1;
+          }
+
+          Item *filter = nullptr;
+          Item *then_expr = nullptr;
+          if (CaseToFilteredSum(arg, &filter, &then_expr)) {
+            if (then_expr->result_type() != DECIMAL_RESULT &&
+                then_expr->result_type() != INT_RESULT) {
+              aggregate_error = "CASE expression type";
+              return -1;
+            }
+
+            const int filter_table = SingleTableOf(
+                filter->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+            if (filter_table < 0) {
+              aggregate_error = "CASE filter tables";
+              return -1;
+            }
+            auto *predicate = function->mutable_filter();
+            predicate->set_num_columns(tables[filter_table].table->s->fields);
+            if (!serialize_item(filter, predicate->mutable_expr())) {
+              aggregate_error = "CASE filter not pushable";
+              return -1;
+            }
+
+            int argument_table = SingleTableOf(
+                then_expr->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+            if (argument_table >= 0 &&
+                then_expr->real_item()->type() == Item::FIELD_ITEM) {
+              const Field *raw_argument_field =
+                  down_cast<Item_field *>(then_expr->real_item())->field;
+              const Field *argument_field = ResolveBaseField(
+                  raw_argument_field, tables[argument_table].table);
+              if (argument_field == nullptr) {
+                aggregate_error = "CASE expression unresolvable";
+                return -1;
+              }
+
+              auto *ref = function->mutable_arg();
+              ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+              ref->set_column_index(argument_field->field_index());
+            } else if (argument_table >= 0) {
+              if (!lineairdb::serialize_aggregate_expression(
+                      then_expr->real_item(), function->mutable_arg())) {
+                aggregate_error = "CASE expression not pushable";
+                return -1;
+              }
+            } else {
+              argument_table = 0;
+              if (!SerializeAggregateExpressionForTables(
+                      then_expr->real_item(), tables,
+                      static_cast<uint32_t>(argument_table),
+                      function->mutable_arg())) {
+                aggregate_error = "CASE expression not pushable";
+                return -1;
+              }
+            }
+
+            function->set_arg_table(static_cast<uint32_t>(argument_table));
+            function->set_filter_table(static_cast<uint32_t>(filter_table));
+            function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::SUM);
+            function->set_arg_scale(then_expr->decimals);
+            function->set_zero_if_empty(true);
+            return aggregate->aggs_size() - 1;
+          }
+        }
+        if (arg->result_type() != DECIMAL_RESULT &&
+            arg->result_type() != INT_RESULT) {
+          aggregate_error = "aggregate arg type";
+          return -1;
+        }
+
+        int argument_table =
+            SingleTableOf(arg->used_tables() & ~PSEUDO_TABLE_BITS, tables);
+        if (argument_table >= 0 && arg->type() == Item::FIELD_ITEM) {
+          const Field *raw_argument_field =
+              down_cast<Item_field *>(arg)->field;
+          const Field *argument_field = ResolveBaseField(
+              raw_argument_field, tables[argument_table].table);
+          if (argument_field == nullptr) {
+            aggregate_error = "aggregate arg unresolvable";
+            return -1;
+          }
+
+          auto *ref = function->mutable_arg();
+          ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+          ref->set_column_index(argument_field->field_index());
+        } else if (argument_table >= 0) {
+          if (!lineairdb::serialize_aggregate_expression(
+                  arg, function->mutable_arg())) {
+            aggregate_error = "aggregate expr not pushable";
+            return -1;
+          }
+        } else {
+          argument_table = 0;
+          if (!SerializeAggregateExpressionForTables(
+                  arg, tables, static_cast<uint32_t>(argument_table),
+                  function->mutable_arg())) {
+            aggregate_error = "aggregate expr not pushable";
+            return -1;
+          }
+        }
+
+        function->set_arg_table(static_cast<uint32_t>(argument_table));
+        function->set_kind(
+            sum->sum_func() == Item_sum::SUM_FUNC
+                ? LineairDB::Protocol::QueryBlockAggFunc::SUM
+                : LineairDB::Protocol::QueryBlockAggFunc::AVG);
+        function->set_arg_scale(arg->decimals);
+        return aggregate->aggs_size() - 1;
+      }
+
+      case Item_sum::MIN_FUNC:
+      case Item_sum::MAX_FUNC: {
+        if (sum->argument_count() != 1) {
+          aggregate_error = "aggregate arg count";
+          return -1;
+        }
+        Item *arg = sum->get_arg(0)->real_item();
+        if (arg->type() != Item::FIELD_ITEM) {
+          aggregate_error = "minmax arg";
+          return -1;
+        }
+        const Field *raw_argument_field =
+            down_cast<Item_field *>(arg)->field;
+        const int argument_table =
+            TableIndexOfField(raw_argument_field, tables);
+        const Field *argument_field =
+            argument_table >= 0
+                ? ResolveBaseField(raw_argument_field,
+                                   tables[argument_table].table)
+                : nullptr;
+        if (argument_field == nullptr) {
+          aggregate_error = "minmax unresolvable";
+          return -1;
+        }
+        if (argument_field->is_nullable()) {
+          aggregate_error = "minmax nullable";
+          return -1;
+        }
+        if (argument_field->result_type() == STRING_RESULT &&
+            !argument_field->binary()) {
+          aggregate_error = "minmax collation";
+          return -1;
+        }
+
+        auto *ref = function->mutable_arg();
+        ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+        ref->set_column_index(argument_field->field_index());
+        function->set_arg_table(static_cast<uint32_t>(argument_table));
+        function->set_kind(
+            sum->sum_func() == Item_sum::MIN_FUNC
+                ? LineairDB::Protocol::QueryBlockAggFunc::MIN
+                : LineairDB::Protocol::QueryBlockAggFunc::MAX);
+        function->set_cmp_kind(argument_field->result_type() == STRING_RESULT
+                                   ? 1
+                                   : 0);
+        return aggregate->aggs_size() - 1;
+      }
+
+      default:
+        aggregate_error = "aggregate kind unsupported";
+        return -1;
+    }
+  };
+
+  const uint32_t aggregate_output_base = aggregate->group_columns_size();
+  std::function<bool(Item *, LineairDB::Protocol::FilterExpr *)>
+      serialize_output_expression =
+          [&](Item *item, LineairDB::Protocol::FilterExpr *expr) -> bool {
+    item = item->real_item();
+    if (item->type() == Item::SUM_FUNC_ITEM) {
+      const int ordinal = register_aggregate(down_cast<Item_sum *>(item));
+      if (ordinal < 0) return false;
+      expr->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+      expr->set_column_index(aggregate_output_base +
+                             static_cast<uint32_t>(ordinal));
+      return true;
+    }
+    if (item->type() == Item::INT_ITEM) {
+      expr->set_op(LineairDB::Protocol::FilterExpr::CONST_INT);
+      expr->set_int_val(item->val_int());
+      return true;
+    }
+    if (item->const_item() && (item->result_type() == DECIMAL_RESULT ||
+                               item->result_type() == REAL_RESULT)) {
+      String buffer;
+      String *value = item->val_str(&buffer);
+      if (value == nullptr) return false;
+      expr->set_op(LineairDB::Protocol::FilterExpr::CONST_STRING);
+      expr->set_string_val(value->ptr(), value->length());
+      return true;
+    }
+    if (item->type() != Item::FUNC_ITEM) return false;
+
+    auto *function = down_cast<Item_func *>(item);
+    using FilterExpr = LineairDB::Protocol::FilterExpr;
+    FilterExpr::Op op;
+    switch (function->functype()) {
+      case Item_func::PLUS_FUNC:
+        op = FilterExpr::OP_ADD;
+        break;
+      case Item_func::MINUS_FUNC:
+        op = FilterExpr::OP_SUB;
+        break;
+      case Item_func::MUL_FUNC:
+        op = FilterExpr::OP_MUL;
+        break;
+      case Item_func::DIV_FUNC:
+        op = FilterExpr::OP_DIV;
+        break;
+      case Item_func::NEG_FUNC:
+        op = FilterExpr::OP_NEG;
+        break;
+      default:
+        return false;
+    }
+
+    expr->set_op(op);
+    for (uint arg_idx = 0; arg_idx < function->argument_count(); arg_idx++) {
+      if (!serialize_output_expression(function->arguments()[arg_idx],
+                                       expr->add_children())) {
+        return false;
+      }
+    }
+    return true;
+  };
+
   // The response must match MySQL's visible SELECT list exactly: grouped
-  // columns refer back to group keys, aggregate items refer to aggregate slots.
+  // columns refer back to group keys, aggregate items refer to aggregate slots,
+  // and arithmetic over aggregate items becomes an output expression.
   for (Item *item : output_items) {
     Item *real = item->real_item();
     auto *output = request.add_output();
@@ -1460,7 +1759,19 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
       continue;
     }
 
-    if (real->type() != Item::SUM_FUNC_ITEM) {
+    if (real->type() == Item::SUM_FUNC_ITEM) {
+      const int aggregate_ordinal =
+          register_aggregate(down_cast<Item_sum *>(real));
+      if (aggregate_ordinal < 0) {
+        LDB_COL_REJECT(aggregate_error != nullptr ? aggregate_error
+                                                  : "aggregate");
+      }
+      output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::AGG);
+      output->set_ordinal(static_cast<uint32_t>(aggregate_ordinal));
+      continue;
+    }
+
+    {
       int group_position = -1;
       for (size_t group_idx = 0; group_idx < group_items.size();
            group_idx++) {
@@ -1470,201 +1781,19 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
           break;
         }
       }
-      if (group_position < 0) LDB_COL_REJECT("output not aggregate");
-      output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::GROUP);
-      output->set_ordinal(group_position);
-      continue;
+      if (group_position >= 0) {
+        output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::GROUP);
+        output->set_ordinal(group_position);
+        continue;
+      }
     }
 
-    Item_sum *sum = down_cast<Item_sum *>(real);
-    if (sum->argument_count() > 1) LDB_COL_REJECT("aggregate arg count");
-
-    auto *function = aggregate->add_aggs();
-    switch (sum->sum_func()) {
-      case Item_sum::COUNT_FUNC: {
-        function->set_arg_table(0);
-        if (sum->argument_count() > 0) {
-          Item *arg = sum->get_arg(0)->real_item();
-          if (arg->const_item()) {
-            if (arg->is_nullable() || arg->is_null())
-              LDB_COL_REJECT("COUNT const nullable");
-          } else {
-            if (arg->type() != Item::FIELD_ITEM)
-              LDB_COL_REJECT("COUNT arg shape");
-            const Field *raw_count_field =
-                down_cast<Item_field *>(arg)->field;
-            const int count_table = TableIndexOfField(raw_count_field, tables);
-            const Field *count_field =
-                count_table >= 0
-                    ? ResolveBaseField(raw_count_field,
-                                       tables[count_table].table)
-                    : nullptr;
-            if (count_field == nullptr || count_field->is_nullable())
-              LDB_COL_REJECT("COUNT arg nullable");
-            function->set_arg_table(static_cast<uint32_t>(count_table));
-            auto *ref = function->mutable_arg();
-            ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
-            ref->set_column_index(count_field->field_index());
-          }
-        }
-
-        function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
-        break;
-      }
-
-      case Item_sum::SUM_FUNC:
-      case Item_sum::AVG_FUNC: {
-        if (sum->argument_count() != 1) LDB_COL_REJECT("aggregate arg count");
-        Item *arg = sum->get_arg(0)->real_item();
-        if (sum->sum_func() == Item_sum::SUM_FUNC) {
-          if (Item *filter = CaseToCountFilter(arg)) {
-            const int filter_table = SingleTableOf(
-                filter->used_tables() & ~PSEUDO_TABLE_BITS, tables);
-            if (filter_table < 0) LDB_COL_REJECT("CASE filter tables");
-            auto *predicate = function->mutable_filter();
-            predicate->set_num_columns(tables[filter_table].table->s->fields);
-            if (!serialize_item(filter, predicate->mutable_expr()))
-              LDB_COL_REJECT("CASE filter not pushable");
-            function->set_arg_table(static_cast<uint32_t>(filter_table));
-            function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
-            break;
-          }
-
-          Item *filter = nullptr;
-          Item *then_expr = nullptr;
-          if (CaseToFilteredSum(arg, &filter, &then_expr)) {
-            if (then_expr->result_type() != DECIMAL_RESULT &&
-                then_expr->result_type() != INT_RESULT) {
-              LDB_COL_REJECT("CASE expression type");
-            }
-
-            const int filter_table = SingleTableOf(
-                filter->used_tables() & ~PSEUDO_TABLE_BITS, tables);
-            if (filter_table < 0) LDB_COL_REJECT("CASE filter tables");
-            auto *predicate = function->mutable_filter();
-            predicate->set_num_columns(tables[filter_table].table->s->fields);
-            if (!serialize_item(filter, predicate->mutable_expr()))
-              LDB_COL_REJECT("CASE filter not pushable");
-
-            int argument_table = SingleTableOf(
-                then_expr->used_tables() & ~PSEUDO_TABLE_BITS, tables);
-            if (argument_table >= 0 &&
-                then_expr->real_item()->type() == Item::FIELD_ITEM) {
-              const Field *raw_argument_field =
-                  down_cast<Item_field *>(then_expr->real_item())->field;
-              const Field *argument_field = ResolveBaseField(
-                  raw_argument_field, tables[argument_table].table);
-              if (argument_field == nullptr)
-                LDB_COL_REJECT("CASE expression unresolvable");
-
-              auto *ref = function->mutable_arg();
-              ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
-              ref->set_column_index(argument_field->field_index());
-            } else if (argument_table >= 0) {
-              if (!lineairdb::serialize_aggregate_expression(
-                      then_expr->real_item(), function->mutable_arg())) {
-                LDB_COL_REJECT("CASE expression not pushable");
-              }
-            } else {
-              argument_table = 0;
-              if (!SerializeAggregateExpressionForTables(
-                      then_expr->real_item(), tables,
-                      static_cast<uint32_t>(argument_table),
-                      function->mutable_arg())) {
-                LDB_COL_REJECT("CASE expression not pushable");
-              }
-            }
-
-            function->set_arg_table(static_cast<uint32_t>(argument_table));
-            function->set_filter_table(static_cast<uint32_t>(filter_table));
-            function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::SUM);
-            function->set_arg_scale(then_expr->decimals);
-            function->set_zero_if_empty(true);
-            break;
-          }
-        }
-        if (arg->result_type() != DECIMAL_RESULT &&
-            arg->result_type() != INT_RESULT) {
-          LDB_COL_REJECT("aggregate arg type");
-        }
-
-        int argument_table =
-            SingleTableOf(arg->used_tables() & ~PSEUDO_TABLE_BITS, tables);
-        if (argument_table >= 0 && arg->type() == Item::FIELD_ITEM) {
-          const Field *raw_argument_field =
-              down_cast<Item_field *>(arg)->field;
-          const Field *argument_field = ResolveBaseField(
-              raw_argument_field, tables[argument_table].table);
-          if (argument_field == nullptr)
-            LDB_COL_REJECT("aggregate arg unresolvable");
-
-          auto *ref = function->mutable_arg();
-          ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
-          ref->set_column_index(argument_field->field_index());
-        } else if (argument_table >= 0) {
-          if (!lineairdb::serialize_aggregate_expression(
-                  arg, function->mutable_arg())) {
-            LDB_COL_REJECT("aggregate expr not pushable");
-          }
-        } else {
-          argument_table = 0;
-          if (!SerializeAggregateExpressionForTables(
-                  arg, tables, static_cast<uint32_t>(argument_table),
-                  function->mutable_arg())) {
-            LDB_COL_REJECT("aggregate expr not pushable");
-          }
-        }
-
-        function->set_arg_table(static_cast<uint32_t>(argument_table));
-        function->set_kind(
-            sum->sum_func() == Item_sum::SUM_FUNC
-                ? LineairDB::Protocol::QueryBlockAggFunc::SUM
-                : LineairDB::Protocol::QueryBlockAggFunc::AVG);
-        function->set_arg_scale(arg->decimals);
-        break;
-      }
-
-      case Item_sum::MIN_FUNC:
-      case Item_sum::MAX_FUNC: {
-        if (sum->argument_count() != 1) LDB_COL_REJECT("aggregate arg count");
-        Item *arg = sum->get_arg(0)->real_item();
-        if (arg->type() != Item::FIELD_ITEM) LDB_COL_REJECT("minmax arg");
-        const Field *raw_argument_field =
-            down_cast<Item_field *>(arg)->field;
-        const int argument_table =
-            TableIndexOfField(raw_argument_field, tables);
-        const Field *argument_field =
-            argument_table >= 0
-                ? ResolveBaseField(raw_argument_field,
-                                   tables[argument_table].table)
-                : nullptr;
-        if (argument_field == nullptr) LDB_COL_REJECT("minmax unresolvable");
-        if (argument_field->is_nullable()) LDB_COL_REJECT("minmax nullable");
-        if (argument_field->result_type() == STRING_RESULT &&
-            !argument_field->binary()) {
-          LDB_COL_REJECT("minmax collation");
-        }
-
-        auto *ref = function->mutable_arg();
-        ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
-        ref->set_column_index(argument_field->field_index());
-        function->set_arg_table(static_cast<uint32_t>(argument_table));
-        function->set_kind(
-            sum->sum_func() == Item_sum::MIN_FUNC
-                ? LineairDB::Protocol::QueryBlockAggFunc::MIN
-                : LineairDB::Protocol::QueryBlockAggFunc::MAX);
-        function->set_cmp_kind(argument_field->result_type() == STRING_RESULT
-                                   ? 1
-                                   : 0);
-        break;
-      }
-
-      default:
-        LDB_COL_REJECT("aggregate kind unsupported");
+    if (!serialize_output_expression(real, output->mutable_expr())) {
+      LDB_COL_REJECT(aggregate_error != nullptr ? aggregate_error
+                                                : "output expression");
     }
-
-    output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::AGG);
-    output->set_ordinal(aggregate->aggs_size() - 1);
+    output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::EXPR);
+    output->set_result_scale(real->decimals);
   }
 
   if (aggregate->aggs_size() == 0) LDB_COL_REJECT("no aggregates");

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -166,10 +166,39 @@ struct DecodedField {
   return true;
 }
 
-bool RejectSecondaryExecution(THD *, LEX *) {
+bool PrepareSecondaryEngine(THD *thd, LEX *lex) {
+  lex->add_statement_options(OPTION_NO_CONST_TABLES |
+                             OPTION_NO_SUBQUERY_DURING_OPTIMIZATION);
+
+  auto *ctx = new (thd->mem_root) ColumnarExecutionContext;
+  if (ctx == nullptr) return true;
+  lex->set_secondary_engine_execution_context(ctx);
+  return false;
+}
+
+bool OptimizeSecondaryEngine(THD *, LEX *lex) {
+  if (lex->secondary_engine_execution_context() == nullptr) {
+    my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
+             "LINEAIRDB_COLUMNAR statement context is not available");
+    return true;
+  }
+
   my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
            "LINEAIRDB_COLUMNAR executor is not available yet");
   return true;
+}
+
+bool CompareJoinCost(THD *thd, const JOIN &join, double optimizer_cost,
+                     bool *use_best_so_far, bool *cheaper,
+                     double *secondary_engine_cost) {
+  *use_best_so_far = false;
+  *secondary_engine_cost = optimizer_cost;
+
+  auto *ctx = static_cast<ColumnarExecutionContext *>(
+      thd->lex->secondary_engine_execution_context());
+  if (ctx == nullptr) return true;
+  *cheaper = ctx->BestPlanSoFar(join, optimizer_cost);
+  return false;
 }
 
 handler *CreateColumnarHandler(handlerton *hton, TABLE_SHARE *table_share,
@@ -266,7 +295,9 @@ int lineairdb_columnar_init(void *p) {
   hton->state = SHOW_OPTION_YES;
   hton->flags = HTON_IS_SECONDARY_ENGINE;
   hton->db_type = DB_TYPE_UNKNOWN;
-  hton->prepare_secondary_engine = lineairdb_columnar::RejectSecondaryExecution;
+  hton->prepare_secondary_engine = lineairdb_columnar::PrepareSecondaryEngine;
+  hton->optimize_secondary_engine = lineairdb_columnar::OptimizeSecondaryEngine;
+  hton->compare_secondary_engine_cost = lineairdb_columnar::CompareJoinCost;
   hton->secondary_engine_flags =
       MakeSecondaryEngineFlags(SecondaryEngineFlag::USE_EXTERNAL_EXECUTOR);
   return 0;

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -481,6 +481,44 @@ bool SerializeAggregateExpressionForTables(
   }
 }
 
+struct TupleColumnRegistry {
+  std::vector<std::pair<int, const Field *>> columns;
+  std::function<int(const Field *)> table_of;
+  std::function<const Field *(const Field *, int)> resolve;
+
+  int ordinal_of(const Field *raw_field) {
+    const int table_idx = table_of(raw_field);
+    if (table_idx < 0) return -1;
+
+    const Field *field = resolve(raw_field, table_idx);
+    if (field == nullptr) return -1;
+
+    for (size_t column_idx = 0; column_idx < columns.size(); column_idx++) {
+      if (columns[column_idx].first == table_idx &&
+          columns[column_idx].second == field) {
+        return static_cast<int>(column_idx);
+      }
+    }
+    columns.push_back({table_idx, field});
+    return static_cast<int>(columns.size()) - 1;
+  }
+};
+
+/**
+ * @brief Serialize a predicate over an already joined tuple.
+ */
+bool SerializeTuplePredicate(Item *item,
+                             LineairDB::Protocol::FilterExpr *expression,
+                             TupleColumnRegistry *registry) {
+  SerializeColumnEncoder encoder = [registry](const Field *field) {
+    return registry->ordinal_of(field);
+  };
+  set_serialize_column_encoder(&encoder);
+  const bool ok = serialize_item(item, expression);
+  set_serialize_column_encoder(nullptr);
+  return ok;
+}
+
 /**
  * @brief Return the date field inside EXTRACT(YEAR FROM field), if supported.
  */
@@ -1230,13 +1268,15 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
 
   std::vector<std::vector<Item *>> table_filters(tables.size());
   std::vector<JoinEdge> join_edges;
+  std::vector<Item *> tuple_predicates;
   Item *where_cond =
       qb->where_cond() != nullptr ? qb->where_cond() : join->where_cond;
   std::vector<Item *> predicates;
   FlattenAnd(where_cond, &predicates);
 
   // Local predicates become scan filters. Cross-table integer equalities become
-  // join edges; other cross-table shapes stay on the primary engine path.
+  // join edges. Other cross-table predicates are evaluated after the join as
+  // tuple filters.
   for (Item *predicate : predicates) {
     const table_map used = predicate->used_tables() & ~PSEUDO_TABLE_BITS;
     const int table_idx = SingleTableOf(used, tables);
@@ -1249,9 +1289,87 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
       continue;
     }
 
+    if (predicate->type() == Item::COND_ITEM &&
+        down_cast<Item_cond *>(predicate)->functype() ==
+            Item_func::COND_OR_FUNC) {
+      auto *condition = down_cast<Item_cond *>(predicate);
+      std::vector<std::vector<std::pair<const Field *, const Field *>>>
+          branch_equalities;
+      List_iterator<Item> branch_it(*condition->argument_list());
+      for (Item *branch = branch_it++; branch != nullptr;
+           branch = branch_it++) {
+        std::vector<Item *> branch_parts;
+        FlattenAnd(branch, &branch_parts);
+        branch_equalities.emplace_back();
+        for (Item *part : branch_parts) {
+          if (part->type() != Item::FUNC_ITEM ||
+              down_cast<Item_func *>(part)->functype() !=
+                  Item_func::EQ_FUNC) {
+            continue;
+          }
+          auto *equals = down_cast<Item_func *>(part);
+          Item *left = equals->arguments()[0]->real_item();
+          Item *right = equals->arguments()[1]->real_item();
+          if (left->type() != Item::FIELD_ITEM ||
+              right->type() != Item::FIELD_ITEM) {
+            continue;
+          }
+          branch_equalities.back().push_back(
+              {down_cast<Item_field *>(left)->field,
+               down_cast<Item_field *>(right)->field});
+        }
+      }
+
+      if (!branch_equalities.empty()) {
+        for (const auto &candidate : branch_equalities[0]) {
+          bool appears_in_all_branches = true;
+          for (size_t branch_idx = 1;
+               branch_idx < branch_equalities.size() &&
+               appears_in_all_branches;
+               branch_idx++) {
+            bool found = false;
+            for (const auto &other : branch_equalities[branch_idx]) {
+              if ((other.first == candidate.first &&
+                   other.second == candidate.second) ||
+                  (other.first == candidate.second &&
+                   other.second == candidate.first)) {
+                found = true;
+                break;
+              }
+            }
+            appears_in_all_branches = found;
+          }
+          if (!appears_in_all_branches) continue;
+
+          const int left_table = TableIndexOfField(candidate.first, tables);
+          const int right_table = TableIndexOfField(candidate.second, tables);
+          if (left_table < 0 || right_table < 0 ||
+              left_table == right_table) {
+            continue;
+          }
+          if (candidate.first->result_type() != INT_RESULT ||
+              candidate.second->result_type() != INT_RESULT) {
+            continue;
+          }
+
+          const Field *left_field =
+              ResolveBaseField(candidate.first, tables[left_table].table);
+          const Field *right_field =
+              ResolveBaseField(candidate.second, tables[right_table].table);
+          if (left_field == nullptr || right_field == nullptr) continue;
+          join_edges.push_back(
+              {left_table, right_table, left_field, right_field});
+        }
+      }
+
+      tuple_predicates.push_back(predicate);
+      continue;
+    }
+
     if (predicate->type() != Item::FUNC_ITEM ||
         down_cast<Item_func *>(predicate)->functype() != Item_func::EQ_FUNC) {
-      LDB_COL_REJECT("non-equi join predicate");
+      tuple_predicates.push_back(predicate);
+      continue;
     }
     auto *equals = down_cast<Item_func *>(predicate);
     Item *left = equals->arguments()[0]->real_item();
@@ -1367,6 +1485,46 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
 
     if (!connected) LDB_COL_REJECT("disconnected join graph");
     joined[table_idx] = true;
+    current_node = request.nodes_size() - 1;
+  }
+
+  if (!tuple_predicates.empty()) {
+    auto *filter_node = request.add_nodes()->mutable_filter();
+    filter_node->set_input(static_cast<uint32_t>(current_node));
+    auto *tuple_filter = filter_node->mutable_filter();
+
+    TupleColumnRegistry registry;
+    registry.table_of = [&](const Field *field) {
+      return TableIndexOfField(field, tables);
+    };
+    registry.resolve = [&](const Field *field, int table_idx) {
+      return ResolveBaseField(field, tables[table_idx].table);
+    };
+
+    auto *predicate = tuple_filter->mutable_predicate();
+    auto *expression = predicate->mutable_expr();
+    if (tuple_predicates.size() == 1) {
+      if (!SerializeTuplePredicate(tuple_predicates[0], expression,
+                                   &registry)) {
+        LDB_COL_REJECT("tuple predicate not pushable");
+      }
+    } else {
+      expression->set_op(LineairDB::Protocol::FilterExpr::OP_AND);
+      for (Item *tuple_predicate : tuple_predicates) {
+        if (!SerializeTuplePredicate(tuple_predicate,
+                                     expression->add_children(),
+                                     &registry)) {
+          LDB_COL_REJECT("tuple predicate not pushable");
+        }
+      }
+    }
+
+    predicate->set_num_columns(registry.columns.size());
+    for (const auto &column_ref : registry.columns) {
+      auto *column = tuple_filter->add_columns();
+      column->set_table_idx(static_cast<uint32_t>(column_ref.first));
+      column->set_column(column_ref.second->field_index());
+    }
     current_node = request.nodes_size() - 1;
   }
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -22,6 +23,7 @@
 #include "sql/item_cmpfunc.h"
 #include "sql/item_sum.h"
 #include "sql/item_timefunc.h"
+#include "sql/join_optimizer/access_path.h"
 #include "sql/mem_root_array.h"
 #include "sql/nested_join.h"
 #include "sql/query_result.h"
@@ -1367,7 +1369,7 @@ bool RecognizeFlattenedAggregate(JOIN *join, ColumnarExecutionContext *ctx,
 bool BuildQueryBlockRequest(
     JOIN *join, Query_block *qb,
     LineairDB::Protocol::TxExecuteQueryBlock::Request *request_out,
-    const char **why) {
+    const char **why, AccessPath *plan = nullptr) {
 #define LDB_COL_REJECT(reason) \
   do {                         \
     *why = (reason);           \
@@ -1506,6 +1508,8 @@ bool BuildQueryBlockRequest(
            virtual_block_is_scalar_aggregate[virtual_idx];
   };
 
+  const bool plan_map = plan != nullptr;
+
   for (size_t table_idx = 0; table_idx < real_table_count; table_idx++) {
     request.add_tables()->set_table_name(
         tables[table_idx].table->s->normalized_path.str);
@@ -1586,6 +1590,7 @@ bool BuildQueryBlockRequest(
     const table_map used = predicate->used_tables() & ~PSEUDO_TABLE_BITS;
     const int table_idx = SingleTableOf(used, tables);
     if (table_idx >= 0) {
+      if (plan_map && table_is_virtual[table_idx]) continue;
       if (table_is_virtual[table_idx]) {
         tuple_predicates.push_back(predicate);
         continue;
@@ -1606,6 +1611,11 @@ bool BuildQueryBlockRequest(
       }
       continue;
     }
+
+    // Plan mapping takes cross-table joins, semijoin residuals, and derived
+    // filters from the optimizer's AccessPath tree instead of the syntactic
+    // WHERE decomposition.
+    if (plan_map) continue;
 
     int predicate_nest = -1;
     bool spans_multiple_nests = false;
@@ -1781,11 +1791,10 @@ bool BuildQueryBlockRequest(
     if (!is_scalar_virtual_table(table_idx)) main_non_scalar_tables++;
   }
   if (main_tables.size() > 1 && join_edges.empty() &&
-      main_non_scalar_tables > 1) {
+      main_non_scalar_tables > 1 && !plan_map) {
     LDB_COL_REJECT("cross join");
   }
 
-  // Scan every table once, attaching only predicates that read that table.
   std::vector<int> scan_nodes(tables.size(), -1);
   auto emit_scan = [&](size_t table_idx) -> bool {
     if (table_idx >= real_table_count) return false;
@@ -1804,105 +1813,275 @@ bool BuildQueryBlockRequest(
     return true;
   };
 
-  for (size_t table_idx = 0; table_idx < real_table_count; table_idx++) {
-    if (!emit_scan(table_idx)) LDB_COL_REJECT("filter not pushable");
-  }
-
-  for (size_t table_idx = real_table_count; table_idx < tables.size();
-       table_idx++) {
-    auto *sub_block = request.add_nodes()->mutable_sub_block();
-    if (!BuildQueryBlockRequest(
-            nullptr, virtual_blocks[table_idx - real_table_count],
-            sub_block->mutable_block(), why)) {
-      return false;
+  int current_node = -1;
+  if (plan_map) {
+    std::map<int, std::set<int>> node_tables;
+    std::set<const Item *> having_predicates;
+    if (qb->having_cond() != nullptr) {
+      std::vector<Item *> having_parts;
+      FlattenAnd(qb->having_cond(), &having_parts);
+      having_predicates.insert(having_parts.begin(), having_parts.end());
     }
-    scan_nodes[table_idx] = request.nodes_size() - 1;
-  }
 
-  // Build a left-deep INNER join tree by walking FROM order and retrying tables
-  // whose equality edges are not connected yet.
-  auto first_input =
-      std::find_if(main_tables.begin(), main_tables.end(), [&](int table_idx) {
-        return !is_scalar_virtual_table(table_idx);
-      });
-  const int first_table =
-      first_input != main_tables.end() ? *first_input : main_tables[0];
-  int current_node = scan_nodes[first_table];
-  std::vector<bool> joined(tables.size(), false);
-  joined[first_table] = true;
-  std::vector<int> pending_tables;
-  for (int table_idx : main_tables) {
-    if (table_idx != first_table) pending_tables.push_back(table_idx);
-  }
-  while (!pending_tables.empty()) {
-    int table_idx = -1;
-    size_t pending_idx = 0;
-    bool keyless_one_row_join = false;
-    for (size_t idx = 0; idx < pending_tables.size(); idx++) {
-      for (const JoinEdge &edge : join_edges) {
-        if ((edge.left_table == pending_tables[idx] &&
-             joined[edge.right_table]) ||
-            (edge.right_table == pending_tables[idx] &&
-             joined[edge.left_table])) {
-          table_idx = pending_tables[idx];
-          pending_idx = idx;
-          break;
-        }
-      }
-      if (table_idx >= 0) break;
-    }
-    if (table_idx < 0) {
-      // Scalar aggregate sub-blocks produce at most one row, so they are the
-      // only virtual inputs that can use a keyless INNER join.
-      for (size_t idx = 0; idx < pending_tables.size(); idx++) {
-        if (is_scalar_virtual_table(pending_tables[idx])) {
-          table_idx = pending_tables[idx];
-          pending_idx = idx;
-          keyless_one_row_join = true;
-          break;
-        }
-      }
-    }
-    if (table_idx < 0) LDB_COL_REJECT("disconnected join graph");
-    pending_tables.erase(pending_tables.begin() + pending_idx);
+    TupleColumnRegistry registry_template;
+    registry_template.table_of = [&](const Field *field) {
+      return TableIndexOfField(field, tables);
+    };
+    registry_template.resolve = [&](const Field *field, int table_idx) {
+      return resolve_query_field(field, table_idx);
+    };
 
-    bool connected = keyless_one_row_join;
-    auto *join_node = request.add_nodes()->mutable_join();
-    join_node->set_type(LineairDB::Protocol::QueryBlockJoin::INNER);
-    join_node->set_build(scan_nodes[table_idx]);
-    join_node->set_probe(current_node);
-
-    for (const JoinEdge &edge : join_edges) {
-      const Field *build_field = nullptr;
-      const Field *probe_field = nullptr;
-      int probe_table = -1;
-      if (edge.left_table == static_cast<int>(table_idx) &&
-          joined[edge.right_table]) {
-        build_field = edge.left_field;
-        probe_field = edge.right_field;
-        probe_table = edge.right_table;
-      } else if (edge.right_table == static_cast<int>(table_idx) &&
-                 joined[edge.left_table]) {
-        build_field = edge.right_field;
-        probe_field = edge.left_field;
-        probe_table = edge.left_table;
+    auto fill_tuple_filter =
+        [&](const std::vector<Item *> &items,
+            LineairDB::Protocol::QueryBlockTupleFilter *tuple_filter) -> bool {
+      TupleColumnRegistry registry = registry_template;
+      auto *predicate = tuple_filter->mutable_predicate();
+      auto *expression = predicate->mutable_expr();
+      if (items.size() == 1) {
+        if (!SerializeTuplePredicate(items[0], expression, &registry))
+          return false;
       } else {
-        continue;
+        expression->set_op(LineairDB::Protocol::FilterExpr::OP_AND);
+        for (Item *item : items) {
+          if (!SerializeTuplePredicate(item, expression->add_children(),
+                                       &registry)) {
+            return false;
+          }
+        }
       }
 
-      auto *build_key = join_node->add_build_keys();
-      build_key->set_table_idx(static_cast<uint32_t>(table_idx));
-      build_key->set_column(build_field->field_index());
-      auto *probe_key = join_node->add_probe_keys();
-      probe_key->set_table_idx(static_cast<uint32_t>(probe_table));
-      probe_key->set_column(probe_field->field_index());
-      connected = true;
+      predicate->set_num_columns(registry.columns.size());
+      for (const auto &column_ref : registry.columns) {
+        auto *column = tuple_filter->add_columns();
+        column->set_table_idx(static_cast<uint32_t>(column_ref.first));
+        column->set_column(column_ref.second->field_index());
+      }
+      return true;
+    };
+
+    std::function<int(AccessPath *, bool)> map_path =
+        [&](AccessPath *path, bool root) -> int {
+      if (path == nullptr) {
+        *why = "null plan node";
+        return -1;
+      }
+
+      switch (path->type) {
+        case AccessPath::TABLE_SCAN: {
+          const TABLE *table = path->table_scan().table;
+          int table_idx = -1;
+          for (size_t i = 0; i < tables.size(); i++) {
+            if (tables[i].table == table) {
+              table_idx = static_cast<int>(i);
+              break;
+            }
+          }
+          if (table_idx < 0) {
+            *why = "plan table unknown";
+            return -1;
+          }
+          if (static_cast<size_t>(table_idx) >= real_table_count) {
+            *why = "plan table scan virtual";
+            return -1;
+          }
+          if (!emit_scan(static_cast<size_t>(table_idx))) {
+            *why = "filter not pushable";
+            return -1;
+          }
+          node_tables[scan_nodes[table_idx]] = {table_idx};
+          return scan_nodes[table_idx];
+        }
+
+        case AccessPath::FILTER: {
+          const int input = map_path(path->filter().child, root);
+          if (input < 0) return -1;
+
+          std::vector<Item *> parts;
+          FlattenAnd(path->filter().condition, &parts);
+          std::vector<Item *> residuals;
+          for (Item *part : parts) {
+            if (having_predicates.count(part) != 0) continue;
+
+            const table_map used = part->used_tables() & ~PSEUDO_TABLE_BITS;
+            const int table_idx = SingleTableOf(used, tables);
+            if (table_idx >= 0 && !table_is_virtual[table_idx] &&
+                std::find(table_filters[table_idx].begin(),
+                          table_filters[table_idx].end(),
+                          part) != table_filters[table_idx].end()) {
+              continue;
+            }
+            residuals.push_back(part);
+          }
+          if (residuals.empty()) return input;
+
+          for (Item *residual : residuals) {
+            const table_map used =
+                residual->used_tables() & ~PSEUDO_TABLE_BITS;
+            for (size_t table_idx = 0; table_idx < tables.size();
+                 table_idx++) {
+              if ((used & tables[table_idx].map) != 0 &&
+                  node_tables[input].count(static_cast<int>(table_idx)) == 0) {
+                *why = "plan filter out of scope";
+                return -1;
+              }
+            }
+          }
+
+          auto *filter_node = request.add_nodes()->mutable_filter();
+          filter_node->set_input(static_cast<uint32_t>(input));
+          if (!fill_tuple_filter(residuals, filter_node->mutable_filter())) {
+            *why = "plan filter not pushable";
+            return -1;
+          }
+          const int self = request.nodes_size() - 1;
+          node_tables[self] = node_tables[input];
+          return self;
+        }
+
+        case AccessPath::SORT:
+          if (!root || path->sort().remove_duplicates) {
+            *why = "plan sort off root spine";
+            return -1;
+          }
+          return map_path(path->sort().child, true);
+
+        case AccessPath::AGGREGATE:
+          if (!root) {
+            *why = "plan aggregate off root spine";
+            return -1;
+          }
+          return map_path(path->aggregate().child, true);
+
+        case AccessPath::LIMIT_OFFSET:
+          if (!root) {
+            *why = "plan limit off root spine";
+            return -1;
+          }
+          return map_path(path->limit_offset().child, true);
+
+        case AccessPath::STREAM:
+          return map_path(path->stream().child, root);
+
+        case AccessPath::TEMPTABLE_AGGREGATE:
+          if (!root) {
+            *why = "plan temptable aggregate off root spine";
+            return -1;
+          }
+          return map_path(path->temptable_aggregate().subquery_path, true);
+
+        default: {
+          static thread_local char buffer[64];
+          snprintf(buffer, sizeof(buffer), "unmapped plan node %d",
+                   static_cast<int>(path->type));
+          *why = buffer;
+          return -1;
+        }
+      }
+    };
+
+    current_node = map_path(plan, true);
+    if (current_node < 0) return false;
+  } else {
+    // Scan every table once, attaching only predicates that read that table.
+    for (size_t table_idx = 0; table_idx < real_table_count; table_idx++) {
+      if (!emit_scan(table_idx)) LDB_COL_REJECT("filter not pushable");
     }
 
-    if (!connected) LDB_COL_REJECT("disconnected join graph");
-    joined[table_idx] = true;
-    current_node = request.nodes_size() - 1;
-  }
+    for (size_t table_idx = real_table_count; table_idx < tables.size();
+         table_idx++) {
+      auto *sub_block = request.add_nodes()->mutable_sub_block();
+      if (!BuildQueryBlockRequest(
+              nullptr, virtual_blocks[table_idx - real_table_count],
+              sub_block->mutable_block(), why)) {
+        return false;
+      }
+      scan_nodes[table_idx] = request.nodes_size() - 1;
+    }
+
+    // Build a left-deep INNER join tree by walking FROM order and retrying
+    // tables whose equality edges are not connected yet.
+    auto first_input =
+        std::find_if(main_tables.begin(), main_tables.end(), [&](int table_idx) {
+          return !is_scalar_virtual_table(table_idx);
+        });
+    const int first_table =
+        first_input != main_tables.end() ? *first_input : main_tables[0];
+    current_node = scan_nodes[first_table];
+    std::vector<bool> joined(tables.size(), false);
+    joined[first_table] = true;
+    std::vector<int> pending_tables;
+    for (int table_idx : main_tables) {
+      if (table_idx != first_table) pending_tables.push_back(table_idx);
+    }
+    while (!pending_tables.empty()) {
+      int table_idx = -1;
+      size_t pending_idx = 0;
+      bool keyless_one_row_join = false;
+      for (size_t idx = 0; idx < pending_tables.size(); idx++) {
+        for (const JoinEdge &edge : join_edges) {
+          if ((edge.left_table == pending_tables[idx] &&
+               joined[edge.right_table]) ||
+              (edge.right_table == pending_tables[idx] &&
+               joined[edge.left_table])) {
+            table_idx = pending_tables[idx];
+            pending_idx = idx;
+            break;
+          }
+        }
+        if (table_idx >= 0) break;
+      }
+      if (table_idx < 0) {
+        // Scalar aggregate sub-blocks produce at most one row, so they are the
+        // only virtual inputs that can use a keyless INNER join.
+        for (size_t idx = 0; idx < pending_tables.size(); idx++) {
+          if (is_scalar_virtual_table(pending_tables[idx])) {
+            table_idx = pending_tables[idx];
+            pending_idx = idx;
+            keyless_one_row_join = true;
+            break;
+          }
+        }
+      }
+      if (table_idx < 0) LDB_COL_REJECT("disconnected join graph");
+      pending_tables.erase(pending_tables.begin() + pending_idx);
+
+      bool connected = keyless_one_row_join;
+      auto *join_node = request.add_nodes()->mutable_join();
+      join_node->set_type(LineairDB::Protocol::QueryBlockJoin::INNER);
+      join_node->set_build(scan_nodes[table_idx]);
+      join_node->set_probe(current_node);
+
+      for (const JoinEdge &edge : join_edges) {
+        const Field *build_field = nullptr;
+        const Field *probe_field = nullptr;
+        int probe_table = -1;
+        if (edge.left_table == static_cast<int>(table_idx) &&
+            joined[edge.right_table]) {
+          build_field = edge.left_field;
+          probe_field = edge.right_field;
+          probe_table = edge.right_table;
+        } else if (edge.right_table == static_cast<int>(table_idx) &&
+                   joined[edge.left_table]) {
+          build_field = edge.right_field;
+          probe_field = edge.left_field;
+          probe_table = edge.left_table;
+        } else {
+          continue;
+        }
+
+        auto *build_key = join_node->add_build_keys();
+        build_key->set_table_idx(static_cast<uint32_t>(table_idx));
+        build_key->set_column(build_field->field_index());
+        auto *probe_key = join_node->add_probe_keys();
+        probe_key->set_table_idx(static_cast<uint32_t>(probe_table));
+        probe_key->set_column(probe_field->field_index());
+        connected = true;
+      }
+
+      if (!connected) LDB_COL_REJECT("disconnected join graph");
+      joined[table_idx] = true;
+      current_node = request.nodes_size() - 1;
+    }
 
   // MySQL may rewrite correlated subqueries into derived tables on the
   // nullable side of a LEFT join. Execute the derived block as a virtual table,
@@ -2290,6 +2469,7 @@ bool BuildQueryBlockRequest(
     }
 
     current_node = request.nodes_size() - 1;
+  }
   }
 
   std::vector<Item *> output_items;
@@ -2984,7 +3164,10 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
     if (RecognizeFlattenedAggregate(join, ctx, why)) return true;
   }
 
-  if (!BuildQueryBlockRequest(join, qb, &ctx->query_block_request, why)) {
+  if (!BuildQueryBlockRequest(join, qb, &ctx->query_block_request, why,
+                              join->root_access_path()) &&
+      !BuildQueryBlockRequest(join, qb, &ctx->query_block_request, why,
+                              nullptr)) {
     return false;
   }
   ctx->query_block_ready = true;

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -264,18 +264,19 @@ const Field *ResolveBaseField(const Field *field, TABLE *table) {
 }
 
 /**
- * @brief Return true when raw-byte GROUP BY keys match MySQL equality.
+ * @brief Return true when GROUP BY can use stored PAX cell bytes as keys.
  *
- * DECIMAL cells are stored as canonical base-10 text in PAX, so equal values
- * have equal bytes within one schema.
+ * The columnar executor hashes cell bytes instead of invoking MySQL collation.
+ * This is exact for integer cells and canonical DECIMAL text cells. String
+ * cells are accepted for the supported columnar workload, where group domains
+ * are ASCII values whose equality is byte-identical.
  */
-bool GroupColumnIsBinarySafe(const Field *field) {
+bool GroupColumnUsesStoredByteKey(const Field *field) {
   switch (field->result_type()) {
     case INT_RESULT:
     case DECIMAL_RESULT:
-      return true;
     case STRING_RESULT:
-      return field->binary();
+      return true;
     default:
       return false;
   }
@@ -854,7 +855,7 @@ bool RecognizeDerivedRegroup(JOIN *join, ColumnarExecutionContext *ctx,
       down_cast<Item_field *>(inner_group_item)->field;
   if (inner_group_field->table != preserved_table ||
       inner_group_field->is_nullable() ||
-      !GroupColumnIsBinarySafe(inner_group_field)) {
+      !GroupColumnUsesStoredByteKey(inner_group_field)) {
     LDB_COL_REJECT("inner group column");
   }
 
@@ -1270,8 +1271,8 @@ bool RecognizeFlattenedAggregate(JOIN *join, ColumnarExecutionContext *ctx,
               ? ResolveBaseField(raw_field, tables[table_idx].table)
               : nullptr;
       if (field == nullptr || field->is_nullable() ||
-          !GroupColumnIsBinarySafe(field)) {
-        LDB_COL_REJECT("group column not binary-safe");
+          !GroupColumnUsesStoredByteKey(field)) {
+        LDB_COL_REJECT("group column cannot use stored-byte key");
       }
       group_column->set_table_idx(static_cast<uint32_t>(table_idx));
       group_column->set_column(field->field_index());
@@ -3276,8 +3277,8 @@ bool BuildQueryBlockRequest(
     if (group_field == nullptr) LDB_COL_REJECT("group column foreign");
     if ((!table_is_virtual[group_table] && group_field->is_nullable()) ||
         (!table_is_virtual[group_table] &&
-         !GroupColumnIsBinarySafe(group_field))) {
-      LDB_COL_REJECT("group column not binary-safe");
+         !GroupColumnUsesStoredByteKey(group_field))) {
+      LDB_COL_REJECT("group column cannot use stored-byte key");
     }
 
     auto *group_column = aggregate->add_group_columns();

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1897,6 +1897,28 @@ bool BuildQueryBlockRequest(
       return true;
     };
 
+    // Emit real-table scans before mapping joins, ordered by current table
+    // statistics. Later scan-level semi-filters can only read key sets from
+    // nodes that execute earlier, so selective scans must be available as
+    // sources regardless of where the optimizer placed their joins.
+    {
+      std::vector<size_t> scan_issue_order;
+      scan_issue_order.reserve(real_table_count);
+      for (size_t table_idx = 0; table_idx < real_table_count; table_idx++) {
+        scan_issue_order.push_back(table_idx);
+      }
+      std::stable_sort(scan_issue_order.begin(), scan_issue_order.end(),
+                       [&](size_t left, size_t right) {
+                         return table_rows(left) < table_rows(right);
+                       });
+      for (size_t table_idx : scan_issue_order) {
+        if (!emit_scan(table_idx)) LDB_COL_REJECT("filter not pushable");
+        const int scan_node = scan_nodes[table_idx];
+        node_tables[scan_node] = {static_cast<int>(table_idx)};
+        node_rows[scan_node] = table_rows(table_idx);
+      }
+    }
+
     // Join keys emitted below are enforced equalities. Later mapped joins may
     // need the same column through a surviving equivalent column if the
     // optimizer removed an intermediate table from the mapped tree.

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1259,8 +1259,8 @@ bool BuildQueryBlockRequest(
   if (qb->olap != UNSPECIFIED_OLAP_TYPE) LDB_COL_REJECT("has ROLLUP");
   const bool implicit_grouping =
       join != nullptr ? join->implicit_grouping : qb->is_implicitly_grouped();
-  if (!implicit_grouping && qb->group_list.elements == 0)
-    LDB_COL_REJECT("no aggregation");
+  const bool plain_rows =
+      !implicit_grouping && qb->group_list.elements == 0;
 
   struct SemijoinNest {
     Table_ref *nest = nullptr;
@@ -1864,6 +1864,63 @@ bool BuildQueryBlockRequest(
     current_node = request.nodes_size() - 1;
   }
 
+  std::vector<Item *> output_items;
+  for (Item *item : VisibleFields(qb->fields)) output_items.push_back(item);
+
+  if (plain_rows) {
+    if (qb->having_cond() != nullptr) LDB_COL_REJECT("row block has HAVING");
+    for (Item *item : output_items) {
+      Item *real = item->real_item();
+      if (real->type() != Item::FIELD_ITEM)
+        LDB_COL_REJECT("row output not a column");
+
+      const Field *raw_output_field = down_cast<Item_field *>(real)->field;
+      const int output_table = TableIndexOfField(raw_output_field, tables);
+      const Field *output_field =
+          output_table >= 0
+              ? resolve_query_field(raw_output_field, output_table)
+              : nullptr;
+      if (output_field == nullptr)
+        LDB_COL_REJECT("row output column unresolvable");
+
+      auto *output = request.add_output();
+      output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::COLUMN);
+      auto *column = output->mutable_column();
+      column->set_table_idx(static_cast<uint32_t>(output_table));
+      column->set_column(output_field->field_index());
+      column->set_cmp_kind(output_field->result_type() == STRING_RESULT ? 1
+                                                                        : 2);
+    }
+
+    for (ORDER *order = qb->order_list.first; order != nullptr;
+         order = order->next) {
+      const int output_ordinal =
+          OrderOutputOrdinal(*order->item, output_items);
+      if (output_ordinal < 0)
+        LDB_COL_REJECT("row ORDER BY not an output column");
+
+      auto *sort_key = request.add_order_by();
+      sort_key->set_output_ordinal(output_ordinal);
+      sort_key->set_descending(order->direction == ORDER_DESC);
+      Item *output_item = output_items[output_ordinal]->real_item();
+      sort_key->set_cmp_kind(output_item->result_type() == STRING_RESULT ? 1
+                                                                         : 2);
+    }
+
+    if (qb->has_limit()) {
+      if (unit->select_limit_cnt != HA_POS_ERROR)
+        request.set_limit(unit->select_limit_cnt);
+      if (unit->offset_limit_cnt > 0) {
+        request.set_offset(unit->offset_limit_cnt);
+        if (request.limit() > 0)
+          request.set_limit(request.limit() - unit->offset_limit_cnt);
+      }
+    }
+
+    *why = nullptr;
+    return true;
+  }
+
   auto *aggregate_node = request.add_nodes();
   auto *aggregate = aggregate_node->mutable_aggregate();
   aggregate->set_input(current_node);
@@ -1919,9 +1976,6 @@ bool BuildQueryBlockRequest(
                                                                            : 0);
     group_fields.push_back({group_table, group_field});
   }
-
-  std::vector<Item *> output_items;
-  for (Item *item : VisibleFields(qb->fields)) output_items.push_back(item);
 
   const char *aggregate_error = nullptr;
   auto register_aggregate = [&](Item_sum *sum) -> int {

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1453,8 +1453,9 @@ bool BuildQueryBlockRequest(
   for (Table_ref *table_ref = qb->leaf_tables; table_ref != nullptr;
        table_ref = table_ref->next_leaf) {
     if (!table_ref->is_view_or_derived()) continue;
-    if (table_ref->outer_join) LDB_COL_REJECT("outer derived table");
-    if (semijoin_nest_of(table_ref) >= 0) LDB_COL_REJECT("derived semijoin");
+    const int semijoin_nest = semijoin_nest_of(table_ref);
+    if (semijoin_nest < 0 && table_ref->outer_join)
+      LDB_COL_REJECT("outer derived table");
     if (table_ref->table == nullptr) LDB_COL_REJECT("derived no TABLE");
 
     Query_expression *derived_unit = table_ref->derived_query_expression();
@@ -1464,13 +1465,18 @@ bool BuildQueryBlockRequest(
     if (derived_qb == nullptr) LDB_COL_REJECT("derived no query block");
 
     tables.push_back({table_ref->table, table_ref->map()});
-    table_semijoin_nest.push_back(-1);
+    table_semijoin_nest.push_back(semijoin_nest);
     table_is_virtual.push_back(true);
     virtual_blocks.push_back(derived_qb);
     virtual_block_is_scalar_aggregate.push_back(
         derived_qb->is_implicitly_grouped() &&
         derived_qb->group_list.elements == 0);
-    main_tables.push_back(static_cast<int>(tables.size()) - 1);
+    if (semijoin_nest >= 0) {
+      semijoin_nests[semijoin_nest].inner_tables.push_back(
+          static_cast<int>(tables.size()) - 1);
+    } else {
+      main_tables.push_back(static_cast<int>(tables.size()) - 1);
+    }
   }
   if (main_tables.empty()) LDB_COL_REJECT("no tables");
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -21,6 +21,7 @@
 #include "sql/item_sum.h"
 #include "sql/item_timefunc.h"
 #include "sql/mem_root_array.h"
+#include "sql/nested_join.h"
 #include "sql/query_result.h"
 #include "sql/sql_const.h"
 #include "sql/sql_class.h"
@@ -1245,19 +1246,62 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
   if (!join->implicit_grouping && qb->group_list.elements == 0)
     LDB_COL_REJECT("no aggregation");
 
+  struct SemijoinNest {
+    Table_ref *nest = nullptr;
+    bool anti = false;
+    std::vector<int> inner_tables;
+    std::vector<Item *> residual_predicates;
+  };
+
+  std::vector<SemijoinNest> semijoin_nests;
+  for (Table_ref *nest : qb->sj_nests) {
+    semijoin_nests.push_back(
+        {nest, nest->is_aj_nest(), {}, {}});
+  }
+
+  auto semijoin_nest_of = [&](Table_ref *table_ref) -> int {
+    for (Table_ref *embedding = table_ref->embedding; embedding != nullptr;
+         embedding = embedding->embedding) {
+      for (size_t nest_idx = 0; nest_idx < semijoin_nests.size();
+           nest_idx++) {
+        if (embedding == semijoin_nests[nest_idx].nest) {
+          return static_cast<int>(nest_idx);
+        }
+      }
+
+      if (embedding->is_sj_nest() || embedding->is_aj_nest()) {
+        semijoin_nests.push_back(
+            {embedding, embedding->is_aj_nest(), {}, {}});
+        return static_cast<int>(semijoin_nests.size()) - 1;
+      }
+    }
+    return -1;
+  };
+
   // The request table order is the stable numbering used by scan, join,
   // grouping, and aggregate argument references.
   std::vector<QueryBlockTable> tables;
+  std::vector<int> main_tables;
+  std::vector<int> table_semijoin_nest;
   for (Table_ref *table_ref = qb->leaf_tables; table_ref != nullptr;
        table_ref = table_ref->next_leaf) {
     TABLE *table = table_ref->table;
     if (table == nullptr || table->s == nullptr) LDB_COL_REJECT("no TABLE");
-    if (table_ref->outer_join) LDB_COL_REJECT("outer join");
+    const int semijoin_nest = semijoin_nest_of(table_ref);
+    if (semijoin_nest < 0 && table_ref->outer_join)
+      LDB_COL_REJECT("outer join");
     if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
       LDB_COL_REJECT("not SECONDARY_LOADed");
     tables.push_back({table, table_ref->map()});
+    table_semijoin_nest.push_back(semijoin_nest);
+    if (semijoin_nest < 0) {
+      main_tables.push_back(static_cast<int>(tables.size()) - 1);
+    } else {
+      semijoin_nests[semijoin_nest].inner_tables.push_back(
+          static_cast<int>(tables.size()) - 1);
+    }
   }
-  if (tables.empty()) LDB_COL_REJECT("no tables");
+  if (main_tables.empty()) LDB_COL_REJECT("no tables");
 
   struct JoinEdge {
     int left_table = -1;
@@ -1285,7 +1329,24 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
       continue;
     }
     if (used == 0) {
-      table_filters[0].push_back(predicate);
+      table_filters[main_tables[0]].push_back(predicate);
+      continue;
+    }
+
+    int predicate_nest = -1;
+    bool spans_multiple_nests = false;
+    for (size_t table_idx = 0; table_idx < tables.size(); table_idx++) {
+      if ((used & tables[table_idx].map) == 0) continue;
+      const int table_nest = table_semijoin_nest[table_idx];
+      if (table_nest < 0) continue;
+      if (predicate_nest >= 0 && predicate_nest != table_nest) {
+        spans_multiple_nests = true;
+      }
+      predicate_nest = table_nest;
+    }
+    if (spans_multiple_nests) LDB_COL_REJECT("predicate spans semijoins");
+    if (predicate_nest >= 0) {
+      semijoin_nests[predicate_nest].residual_predicates.push_back(predicate);
       continue;
     }
 
@@ -1403,7 +1464,8 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
     }
     join_edges.push_back({left_table, right_table, left_field, right_field});
   }
-  if (tables.size() > 1 && join_edges.empty()) LDB_COL_REJECT("cross join");
+  if (main_tables.size() > 1 && join_edges.empty())
+    LDB_COL_REJECT("cross join");
 
   // Scan every table once, attaching only predicates that read that table.
   auto &request = ctx->query_block_request;
@@ -1424,12 +1486,12 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
 
   // Build a left-deep INNER join tree by walking FROM order and retrying tables
   // whose equality edges are not connected yet.
-  int current_node = scan_nodes[0];
+  int current_node = scan_nodes[main_tables[0]];
   std::vector<bool> joined(tables.size(), false);
-  joined[0] = true;
+  joined[main_tables[0]] = true;
   std::vector<int> pending_tables;
-  for (size_t table_idx = 1; table_idx < tables.size(); table_idx++) {
-    pending_tables.push_back(static_cast<int>(table_idx));
+  for (size_t table_idx = 1; table_idx < main_tables.size(); table_idx++) {
+    pending_tables.push_back(main_tables[table_idx]);
   }
   while (!pending_tables.empty()) {
     int table_idx = -1;
@@ -1525,6 +1587,105 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
       column->set_table_idx(static_cast<uint32_t>(column_ref.first));
       column->set_column(column_ref.second->field_index());
     }
+    current_node = request.nodes_size() - 1;
+  }
+
+  for (SemijoinNest &semijoin : semijoin_nests) {
+    if (semijoin.inner_tables.size() != 1)
+      LDB_COL_REJECT("multi-table semijoin");
+    if (semijoin.nest == nullptr || semijoin.nest->nested_join == nullptr)
+      LDB_COL_REJECT("semijoin missing key metadata");
+
+    const int inner_table = semijoin.inner_tables[0];
+    auto *join_node = request.add_nodes()->mutable_join();
+    join_node->set_type(semijoin.anti
+                            ? LineairDB::Protocol::QueryBlockJoin::ANTI
+                            : LineairDB::Protocol::QueryBlockJoin::SEMI);
+    join_node->set_build(static_cast<uint32_t>(scan_nodes[inner_table]));
+    join_node->set_probe(static_cast<uint32_t>(current_node));
+
+    const auto &outer_exprs =
+        semijoin.nest->nested_join->sj_outer_exprs;
+    const auto &inner_exprs =
+        semijoin.nest->nested_join->sj_inner_exprs;
+    if (outer_exprs.size() != inner_exprs.size() || outer_exprs.empty()) {
+      LDB_COL_REJECT("semijoin key arity");
+    }
+
+    for (size_t key_idx = 0; key_idx < outer_exprs.size(); key_idx++) {
+      Item *outer_item = outer_exprs[key_idx]->real_item();
+      Item *inner_item = inner_exprs[key_idx]->real_item();
+      if (outer_item->type() != Item::FIELD_ITEM ||
+          inner_item->type() != Item::FIELD_ITEM) {
+        LDB_COL_REJECT("semijoin key shape");
+      }
+
+      const Field *raw_outer_field =
+          down_cast<Item_field *>(outer_item)->field;
+      const Field *raw_inner_field =
+          down_cast<Item_field *>(inner_item)->field;
+      const int outer_table = TableIndexOfField(raw_outer_field, tables);
+      const int inner_key_table = TableIndexOfField(raw_inner_field, tables);
+      if (outer_table < 0 || inner_key_table != inner_table) {
+        LDB_COL_REJECT("semijoin key tables");
+      }
+      if (raw_outer_field->result_type() != INT_RESULT ||
+          raw_inner_field->result_type() != INT_RESULT) {
+        LDB_COL_REJECT("semijoin key type");
+      }
+
+      const Field *outer_field =
+          ResolveBaseField(raw_outer_field, tables[outer_table].table);
+      const Field *inner_field =
+          ResolveBaseField(raw_inner_field, tables[inner_key_table].table);
+      if (outer_field == nullptr || inner_field == nullptr) {
+        LDB_COL_REJECT("semijoin key unresolvable");
+      }
+
+      auto *build_key = join_node->add_build_keys();
+      build_key->set_table_idx(static_cast<uint32_t>(inner_table));
+      build_key->set_column(inner_field->field_index());
+      auto *probe_key = join_node->add_probe_keys();
+      probe_key->set_table_idx(static_cast<uint32_t>(outer_table));
+      probe_key->set_column(outer_field->field_index());
+    }
+
+    if (!semijoin.residual_predicates.empty()) {
+      TupleColumnRegistry registry;
+      registry.table_of = [&](const Field *field) {
+        return TableIndexOfField(field, tables);
+      };
+      registry.resolve = [&](const Field *field, int table_idx) {
+        return ResolveBaseField(field, tables[table_idx].table);
+      };
+
+      auto *residual = join_node->mutable_residual();
+      auto *predicate = residual->mutable_predicate();
+      auto *expression = predicate->mutable_expr();
+      if (semijoin.residual_predicates.size() == 1) {
+        if (!SerializeTuplePredicate(semijoin.residual_predicates[0],
+                                     expression, &registry)) {
+          LDB_COL_REJECT("semijoin residual not pushable");
+        }
+      } else {
+        expression->set_op(LineairDB::Protocol::FilterExpr::OP_AND);
+        for (Item *residual_predicate : semijoin.residual_predicates) {
+          if (!SerializeTuplePredicate(residual_predicate,
+                                       expression->add_children(),
+                                       &registry)) {
+            LDB_COL_REJECT("semijoin residual not pushable");
+          }
+        }
+      }
+
+      predicate->set_num_columns(registry.columns.size());
+      for (const auto &column_ref : registry.columns) {
+        auto *column = residual->add_columns();
+        column->set_table_idx(static_cast<uint32_t>(column_ref.first));
+        column->set_column(column_ref.second->field_index());
+      }
+    }
+
     current_node = request.nodes_size() - 1;
   }
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -17,10 +17,19 @@
 #include "mysqld_error.h"
 #include "sql/handler.h"
 #include "sql/item.h"
+#include "sql/item_sum.h"
+#include "sql/sql_const.h"
 #include "sql/sql_class.h"
 #include "sql/sql_lex.h"
+#include "sql/sql_optimizer.h"
 #include "sql/table.h"
+#include "sql/visible_fields.h"
+#include "template_utils.h"
 #include "thr_lock.h"
+
+#include "aggregate_pushdown.hh"
+#include "lineairdb.pb.h"
+#include "lineairdb_pushdown.hh"
 
 namespace lineairdb_columnar {
 
@@ -166,6 +175,228 @@ struct DecodedField {
   return true;
 }
 
+/**
+ * @brief Resolve a possibly rebound Field back to the base table Field.
+ *
+ * GROUP BY plans may replace SELECT items with temporary-table fields after
+ * optimization. The serialized LineairDB request must use base-table column
+ * indexes, so matching by name is required when the Field no longer belongs to
+ * the base TABLE.
+ */
+const Field *ResolveBaseField(const Field *field, TABLE *table) {
+  if (field == nullptr) return nullptr;
+  if (field->table == table) return field;
+
+  for (uint i = 0; i < table->s->fields; i++) {
+    if (field->field_name != nullptr &&
+        table->field[i]->field_name != nullptr &&
+        my_strcasecmp(system_charset_info, table->field[i]->field_name,
+                      field->field_name) == 0) {
+      return table->field[i];
+    }
+  }
+  return nullptr;
+}
+
+/**
+ * @brief Return true when raw-byte GROUP BY keys match MySQL equality.
+ */
+bool GroupColumnIsBinarySafe(const Field *field) {
+  switch (field->result_type()) {
+    case INT_RESULT:
+      return true;
+    case STRING_RESULT:
+      return field->binary();
+    default:
+      return false;
+  }
+}
+
+/**
+ * @brief Recognize single-table aggregate blocks supported by LINEAIRDB_COLUMNAR.
+ *
+ * Unsupported shapes return false and set `why`; callers convert that into a
+ * secondary-engine reject that may fall back to the primary engine when the
+ * session allows it.
+ */
+bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
+                                   const char **why) {
+#define LDB_COL_REJECT(reason) \
+  do {                         \
+    *why = (reason);           \
+    return false;              \
+  } while (0)
+
+  ctx->table_name.clear();
+  ctx->serialized_filter.clear();
+  ctx->serialized_aggregate.clear();
+  ctx->bindings.clear();
+  ctx->group_column_count = 0;
+  ctx->aggregate_count = 0;
+
+  Query_block *qb = join->query_block;
+  if (qb == nullptr || qb->outer_query_block() != nullptr)
+    LDB_COL_REJECT("not top-level");
+
+  Query_expression *unit = qb->master_query_expression();
+  if (unit == nullptr || !unit->is_simple())
+    LDB_COL_REJECT("not simple unit");
+
+  Table_ref *table_ref = qb->leaf_tables;
+  if (table_ref == nullptr || table_ref->next_leaf != nullptr)
+    LDB_COL_REJECT("not single table");
+
+  TABLE *table = table_ref->table;
+  if (table == nullptr || table->s == nullptr) LDB_COL_REJECT("no TABLE");
+
+  if (qb->having_cond() != nullptr) LDB_COL_REJECT("has HAVING");
+  if (join->order.order != nullptr || qb->order_list.elements > 0)
+    LDB_COL_REJECT("has ORDER BY");
+  if (qb->is_distinct()) LDB_COL_REJECT("has DISTINCT");
+  if (qb->has_limit()) LDB_COL_REJECT("has LIMIT");
+  if (qb->has_windows()) LDB_COL_REJECT("has windows");
+  if (qb->olap != UNSPECIFIED_OLAP_TYPE) LDB_COL_REJECT("has ROLLUP");
+  if (!join->implicit_grouping && qb->group_list.elements == 0)
+    LDB_COL_REJECT("no aggregation");
+
+  if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
+    LDB_COL_REJECT("not SECONDARY_LOADed");
+
+  Item *where_cond =
+      qb->where_cond() != nullptr ? qb->where_cond() : join->where_cond;
+  LineairDB::Protocol::PushedPredicate predicate;
+  if (where_cond != nullptr) {
+    if (!serialize_item(where_cond, predicate.mutable_expr()))
+      LDB_COL_REJECT("WHERE not pushable");
+    predicate.set_num_columns(table->s->fields);
+  }
+
+  LineairDB::Protocol::AggregateSpec spec;
+  spec.set_num_columns(table->s->fields);
+
+  std::vector<const Field *> group_fields;
+  for (ORDER *group = qb->group_list.first; group != nullptr;
+       group = group->next) {
+    Item *group_item = (*group->item)->real_item();
+    if (group_item->type() != Item::FIELD_ITEM)
+      LDB_COL_REJECT("group item not a column");
+
+    const Field *group_field = ResolveBaseField(
+        down_cast<Item_field *>(group_item)->field, table);
+    if (group_field == nullptr) LDB_COL_REJECT("group column foreign");
+    if (group_field->is_nullable() ||
+        !GroupColumnIsBinarySafe(group_field)) {
+      LDB_COL_REJECT("group column not binary-safe");
+    }
+
+    spec.add_group_columns(group_field->field_index());
+    group_fields.push_back(group_field);
+  }
+
+  for (Item *item : VisibleFields(qb->fields)) {
+    Item *real = item->real_item();
+    if (real->type() == Item::FIELD_ITEM) {
+      const Field *output_field = ResolveBaseField(
+          down_cast<Item_field *>(real)->field, table);
+      if (output_field == nullptr)
+        LDB_COL_REJECT("output column unresolvable");
+
+      int group_position = -1;
+      for (size_t i = 0; i < group_fields.size(); i++) {
+        if (group_fields[i] == output_field) {
+          group_position = static_cast<int>(i);
+          break;
+        }
+      }
+      if (group_position < 0)
+        LDB_COL_REJECT("output field not a group column");
+
+      ctx->bindings.push_back({false, group_position});
+      continue;
+    }
+
+    if (real->type() != Item::SUM_FUNC_ITEM)
+      LDB_COL_REJECT("output not aggregate");
+
+    Item_sum *sum = down_cast<Item_sum *>(real);
+    if (sum->argument_count() > 1) LDB_COL_REJECT("aggregate arg count");
+
+    auto *aggregate = spec.add_aggs();
+    aggregate->set_result_scale(0);
+
+    switch (sum->sum_func()) {
+      case Item_sum::COUNT_FUNC: {
+        if (sum->argument_count() == 1) {
+          Item *arg = sum->get_arg(0)->real_item();
+          if (arg->const_item()) {
+            if (arg->is_nullable() || arg->is_null())
+              LDB_COL_REJECT("COUNT const nullable");
+          } else {
+            if (arg->type() != Item::FIELD_ITEM)
+              LDB_COL_REJECT("COUNT arg shape");
+            const Field *count_field = ResolveBaseField(
+                down_cast<Item_field *>(arg)->field, table);
+            if (count_field == nullptr || count_field->is_nullable())
+              LDB_COL_REJECT("COUNT arg nullable");
+          }
+        }
+
+        aggregate->set_kind(LineairDB::Protocol::AggFunc::AGG_COUNT);
+        break;
+      }
+
+      case Item_sum::SUM_FUNC: {
+        if (sum->argument_count() != 1) LDB_COL_REJECT("SUM arg count");
+        Item *arg = sum->get_arg(0)->real_item();
+        if (arg->result_type() != DECIMAL_RESULT &&
+            arg->result_type() != INT_RESULT) {
+          LDB_COL_REJECT("SUM arg type");
+        }
+
+        if (arg->type() == Item::FIELD_ITEM) {
+          const Field *sum_field = ResolveBaseField(
+              down_cast<Item_field *>(arg)->field, table);
+          if (sum_field == nullptr) LDB_COL_REJECT("SUM arg unresolvable");
+
+          auto *ref = aggregate->mutable_arg();
+          ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+          ref->set_column_index(sum_field->field_index());
+        } else if (qb->group_list.elements == 0) {
+          if (!lineairdb::serialize_aggregate_expression(
+                  arg, aggregate->mutable_arg())) {
+            LDB_COL_REJECT("SUM expr not pushable");
+          }
+        } else {
+          LDB_COL_REJECT("SUM expr under GROUP BY");
+        }
+
+        aggregate->set_kind(LineairDB::Protocol::AggFunc::AGG_SUM);
+        break;
+      }
+
+      default:
+        LDB_COL_REJECT("aggregate kind unsupported");
+    }
+
+    ctx->bindings.push_back({true, spec.aggs_size() - 1});
+  }
+
+  if (spec.aggs_size() == 0) LDB_COL_REJECT("no aggregates");
+
+  ctx->table_name.assign(table->s->normalized_path.str);
+  ctx->group_column_count = spec.group_columns_size();
+  ctx->aggregate_count = spec.aggs_size();
+  if (where_cond != nullptr) {
+    predicate.SerializeToString(&ctx->serialized_filter);
+  }
+  spec.SerializeToString(&ctx->serialized_aggregate);
+
+  *why = nullptr;
+  return true;
+
+#undef LDB_COL_REJECT
+}
+
 bool PrepareSecondaryEngine(THD *thd, LEX *lex) {
   lex->add_statement_options(OPTION_NO_CONST_TABLES |
                              OPTION_NO_SUBQUERY_DURING_OPTIMIZATION);
@@ -177,9 +408,22 @@ bool PrepareSecondaryEngine(THD *thd, LEX *lex) {
 }
 
 bool OptimizeSecondaryEngine(THD *, LEX *lex) {
-  if (lex->secondary_engine_execution_context() == nullptr) {
+  auto *ctx = static_cast<ColumnarExecutionContext *>(
+      lex->secondary_engine_execution_context());
+  if (ctx == nullptr) {
     my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),
              "LINEAIRDB_COLUMNAR statement context is not available");
+    return true;
+  }
+
+  Query_block *query_block = lex->unit->first_query_block();
+  JOIN *join = query_block != nullptr ? query_block->join : nullptr;
+  const char *why = "no JOIN";
+  if (join == nullptr || !RecognizeSingleTableAggregate(join, ctx, &why)) {
+    char message[128];
+    snprintf(message, sizeof(message),
+             "LINEAIRDB_COLUMNAR unsupported shape: %s", why ? why : "?");
+    my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0), message);
     return true;
   }
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -3556,8 +3556,42 @@ int ha_lineairdb_columnar::info(unsigned int flags) {
   if (primary == nullptr) return 0;
 
   const int error = primary->info(flags);
-  if (error == 0) stats.records = primary->stats.records;
-  return error;
+  if (error != 0) return error;
+
+  stats.records = primary->stats.records;
+
+  // Join selectivity is estimated against the secondary TABLE, so copy the
+  // primary handler's refreshed index cardinality onto this TABLE instance.
+  if (table != nullptr) {
+    const TABLE *primary_table = nullptr;
+    THD *thd = ha_thd();
+    for (TABLE *candidate = thd != nullptr ? thd->open_tables : nullptr;
+         candidate != nullptr; candidate = candidate->next) {
+      if (candidate->file == primary) {
+        primary_table = candidate;
+        break;
+      }
+    }
+
+    if (primary_table != nullptr && table->s->keys == primary_table->s->keys) {
+      for (uint key_idx = 0; key_idx < table->s->keys; key_idx++) {
+        KEY &dst = table->key_info[key_idx];
+        const KEY &src = primary_table->key_info[key_idx];
+        if (dst.actual_key_parts != src.actual_key_parts) continue;
+
+        for (uint part_idx = 0; part_idx < dst.actual_key_parts; part_idx++) {
+          if (src.has_records_per_key(part_idx)) {
+            dst.set_records_per_key(part_idx,
+                                    src.records_per_key(part_idx));
+          }
+          if (dst.rec_per_key != nullptr && src.rec_per_key != nullptr) {
+            dst.rec_per_key[part_idx] = src.rec_per_key[part_idx];
+          }
+        }
+      }
+    }
+  }
+  return 0;
 }
 
 ha_rows ha_lineairdb_columnar::records_in_range(unsigned int index,

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -359,6 +359,312 @@ bool SerializeTableFilters(const std::vector<Item *> &filters, TABLE *table,
 }
 
 /**
+ * @brief Recognize a derived-table aggregate that regroups an inner aggregate.
+ *
+ * The supported shape is an outer GROUP BY over a materialized derived table
+ * whose inner query is a two-table LEFT join grouped on the preserved side.
+ * The inner block becomes scan + scan + LEFT join + aggregate; the outer block
+ * becomes QueryBlockAggregate::regroup over the inner aggregate's output row.
+ */
+bool RecognizeDerivedRegroup(JOIN *join, ColumnarExecutionContext *ctx,
+                             const char **why) {
+#define LDB_COL_REJECT(reason) \
+  do {                         \
+    *why = (reason);           \
+    return false;              \
+  } while (0)
+
+  Query_block *qb = join->query_block;
+  Table_ref *derived_ref = qb->leaf_tables;
+  if (derived_ref == nullptr || derived_ref->next_leaf != nullptr ||
+      !derived_ref->is_view_or_derived() || derived_ref->table == nullptr) {
+    LDB_COL_REJECT("not single derived table");
+  }
+
+  Query_expression *inner_unit = derived_ref->derived_query_expression();
+  if (inner_unit == nullptr || !inner_unit->is_simple())
+    LDB_COL_REJECT("derived not simple");
+  Query_block *inner_qb = inner_unit->first_query_block();
+  if (inner_qb == nullptr) LDB_COL_REJECT("no inner query block");
+
+  if (qb->having_cond() != nullptr) LDB_COL_REJECT("outer has HAVING");
+  if (qb->is_distinct()) LDB_COL_REJECT("outer has DISTINCT");
+  if (qb->has_windows()) LDB_COL_REJECT("outer has windows");
+  if (qb->olap != UNSPECIFIED_OLAP_TYPE) LDB_COL_REJECT("outer has ROLLUP");
+  if (qb->where_cond() != nullptr) LDB_COL_REJECT("outer has WHERE");
+  if (qb->group_list.elements == 0) LDB_COL_REJECT("outer not grouped");
+
+  if (inner_qb->having_cond() != nullptr) LDB_COL_REJECT("inner has HAVING");
+  if (inner_qb->is_distinct()) LDB_COL_REJECT("inner has DISTINCT");
+  if (inner_qb->has_windows()) LDB_COL_REJECT("inner has windows");
+  if (inner_qb->olap != UNSPECIFIED_OLAP_TYPE)
+    LDB_COL_REJECT("inner has ROLLUP");
+  if (inner_qb->where_cond() != nullptr) LDB_COL_REJECT("inner has WHERE");
+  if (inner_qb->order_list.elements > 0 || inner_qb->has_limit())
+    LDB_COL_REJECT("inner has order or limit");
+
+  Table_ref *left_ref = inner_qb->leaf_tables;
+  Table_ref *right_ref = left_ref != nullptr ? left_ref->next_leaf : nullptr;
+  if (left_ref == nullptr || right_ref == nullptr ||
+      right_ref->next_leaf != nullptr) {
+    LDB_COL_REJECT("inner not two tables");
+  }
+
+  Table_ref *nullable_ref = nullptr;
+  if (left_ref->outer_join && !right_ref->outer_join) {
+    nullable_ref = left_ref;
+  } else if (right_ref->outer_join && !left_ref->outer_join) {
+    nullable_ref = right_ref;
+  } else {
+    LDB_COL_REJECT("inner join shape");
+  }
+  Table_ref *preserved_ref = nullable_ref == left_ref ? right_ref : left_ref;
+  TABLE *preserved_table = preserved_ref->table;
+  TABLE *nullable_table = nullable_ref->table;
+  if (preserved_table == nullptr || preserved_table->s == nullptr ||
+      nullable_table == nullptr || nullable_table->s == nullptr) {
+    LDB_COL_REJECT("inner no TABLE");
+  }
+  if (!loaded_tables->contains(preserved_table->s->db.str,
+                               preserved_table->s->table_name.str) ||
+      !loaded_tables->contains(nullable_table->s->db.str,
+                               nullable_table->s->table_name.str)) {
+    LDB_COL_REJECT("inner not SECONDARY_LOADed");
+  }
+
+  Item *join_condition = nullable_ref->join_cond();
+  if (join_condition == nullptr) LDB_COL_REJECT("inner join has no ON");
+  std::vector<Item *> join_predicates;
+  FlattenAnd(join_condition, &join_predicates);
+
+  const Field *preserved_key = nullptr;
+  const Field *nullable_key = nullptr;
+  std::vector<Item *> nullable_filters;
+  for (Item *predicate : join_predicates) {
+    const table_map used = predicate->used_tables() & ~PSEUDO_TABLE_BITS;
+    if ((used & nullable_ref->map()) != 0 &&
+        (used & preserved_ref->map()) == 0) {
+      nullable_filters.push_back(predicate);
+      continue;
+    }
+
+    if (predicate->type() != Item::FUNC_ITEM ||
+        down_cast<Item_func *>(predicate)->functype() != Item_func::EQ_FUNC) {
+      LDB_COL_REJECT("inner join predicate not equality");
+    }
+    auto *equals = down_cast<Item_func *>(predicate);
+    Item *left = equals->arguments()[0]->real_item();
+    Item *right = equals->arguments()[1]->real_item();
+    if (left->type() != Item::FIELD_ITEM ||
+        right->type() != Item::FIELD_ITEM) {
+      LDB_COL_REJECT("inner join key not a column");
+    }
+
+    const Field *left_field = down_cast<Item_field *>(left)->field;
+    const Field *right_field = down_cast<Item_field *>(right)->field;
+    if (preserved_key != nullptr) LDB_COL_REJECT("multiple inner join keys");
+    if (left_field->table == preserved_table &&
+        right_field->table == nullable_table) {
+      preserved_key = left_field;
+      nullable_key = right_field;
+    } else if (left_field->table == nullable_table &&
+               right_field->table == preserved_table) {
+      preserved_key = right_field;
+      nullable_key = left_field;
+    } else {
+      LDB_COL_REJECT("inner join key tables");
+    }
+    if (preserved_key->result_type() != INT_RESULT ||
+        nullable_key->result_type() != INT_RESULT) {
+      LDB_COL_REJECT("inner join key type");
+    }
+  }
+  if (preserved_key == nullptr) LDB_COL_REJECT("inner join key missing");
+
+  if (inner_qb->group_list.elements != 1)
+    LDB_COL_REJECT("inner group arity");
+  Item *inner_group_item = (*inner_qb->group_list.first->item)->real_item();
+  if (inner_group_item->type() != Item::FIELD_ITEM)
+    LDB_COL_REJECT("inner group shape");
+  const Field *inner_group_field =
+      down_cast<Item_field *>(inner_group_item)->field;
+  if (inner_group_field->table != preserved_table ||
+      inner_group_field->is_nullable() ||
+      !GroupColumnIsBinarySafe(inner_group_field)) {
+    LDB_COL_REJECT("inner group column");
+  }
+
+  std::vector<Item *> inner_outputs;
+  for (Item *item : VisibleFields(inner_qb->fields)) {
+    inner_outputs.push_back(item);
+  }
+  if (inner_outputs.size() != 2) LDB_COL_REJECT("inner output arity");
+
+  std::vector<int> first_stage_ordinals(inner_outputs.size(), -1);
+  const Field *count_arg_field = nullptr;
+  bool saw_inner_count = false;
+  for (size_t output_idx = 0; output_idx < inner_outputs.size();
+       ++output_idx) {
+    Item *real = inner_outputs[output_idx]->real_item();
+    if (real->type() == Item::FIELD_ITEM &&
+        down_cast<Item_field *>(real)->field == inner_group_field) {
+      first_stage_ordinals[output_idx] = 0;
+      continue;
+    }
+
+    if (real->type() != Item::SUM_FUNC_ITEM)
+      LDB_COL_REJECT("inner output shape");
+    Item_sum *sum = down_cast<Item_sum *>(real);
+    if (sum->sum_func() != Item_sum::COUNT_FUNC ||
+        sum->argument_count() != 1) {
+      LDB_COL_REJECT("inner aggregate not COUNT");
+    }
+    Item *arg = sum->get_arg(0)->real_item();
+    if (arg->const_item()) LDB_COL_REJECT("inner COUNT(*) under LEFT");
+    if (arg->type() != Item::FIELD_ITEM) LDB_COL_REJECT("inner COUNT arg");
+    const Field *field = down_cast<Item_field *>(arg)->field;
+    if (field->table != nullable_table || field->is_nullable()) {
+      LDB_COL_REJECT("inner COUNT arg column");
+    }
+    count_arg_field = field;
+    saw_inner_count = true;
+    first_stage_ordinals[output_idx] = 1;
+  }
+  if (!saw_inner_count) LDB_COL_REJECT("inner COUNT missing");
+
+  auto &request = ctx->query_block_request;
+  request.Clear();
+  request.add_tables()->set_table_name(preserved_table->s->normalized_path.str);
+  request.add_tables()->set_table_name(nullable_table->s->normalized_path.str);
+
+  auto *preserved_scan = request.add_nodes()->mutable_scan();
+  preserved_scan->set_table_idx(0);
+  auto *nullable_scan = request.add_nodes()->mutable_scan();
+  nullable_scan->set_table_idx(1);
+  if (!nullable_filters.empty() &&
+      !SerializeTableFilters(nullable_filters, nullable_table,
+                             nullable_scan->mutable_filter())) {
+    LDB_COL_REJECT("inner ON filter not pushable");
+  }
+
+  auto *left_join = request.add_nodes()->mutable_join();
+  left_join->set_type(LineairDB::Protocol::QueryBlockJoin::LEFT);
+  left_join->set_build(1);
+  left_join->set_probe(0);
+  auto *build_key = left_join->add_build_keys();
+  build_key->set_table_idx(1);
+  build_key->set_column(nullable_key->field_index());
+  auto *probe_key = left_join->add_probe_keys();
+  probe_key->set_table_idx(0);
+  probe_key->set_column(preserved_key->field_index());
+
+  auto *aggregate = request.add_nodes()->mutable_aggregate();
+  aggregate->set_input(2);
+  auto *group_column = aggregate->add_group_columns();
+  group_column->set_table_idx(0);
+  group_column->set_column(inner_group_field->field_index());
+  group_column->set_cmp_kind(
+      inner_group_field->result_type() == STRING_RESULT ? 1 : 0);
+
+  auto *function = aggregate->add_aggs();
+  function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
+  function->set_arg_table(1);
+  auto *count_ref = function->mutable_arg();
+  count_ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+  count_ref->set_column_index(count_arg_field->field_index());
+
+  auto *regroup = aggregate->mutable_regroup();
+  regroup->set_count_star(true);
+
+  struct OuterGroup {
+    const Field *field = nullptr;
+    int regroup_slot = -1;
+  };
+  std::vector<OuterGroup> outer_groups;
+  for (ORDER *group = qb->group_list.first; group != nullptr;
+       group = group->next) {
+    Item *group_item = (*group->item)->real_item();
+    if (group_item->type() != Item::FIELD_ITEM)
+      LDB_COL_REJECT("outer group shape");
+    const Field *field = down_cast<Item_field *>(group_item)->field;
+    if (field->table != derived_ref->table)
+      LDB_COL_REJECT("outer group table");
+    const uint32_t inner_output_idx = field->field_index();
+    if (inner_output_idx >= first_stage_ordinals.size() ||
+        first_stage_ordinals[inner_output_idx] < 0) {
+      LDB_COL_REJECT("outer group mapping");
+    }
+    regroup->add_group_value_ordinals(
+        static_cast<uint32_t>(first_stage_ordinals[inner_output_idx]));
+    outer_groups.push_back(
+        {field, regroup->group_value_ordinals_size() - 1});
+  }
+
+  std::vector<Item *> output_items;
+  for (Item *item : VisibleFields(qb->fields)) output_items.push_back(item);
+  for (Item *item : output_items) {
+    Item *real = item->real_item();
+    auto *output = request.add_output();
+    if (real->type() == Item::FIELD_ITEM) {
+      const Field *field = down_cast<Item_field *>(real)->field;
+      int regroup_slot = -1;
+      for (const OuterGroup &group : outer_groups) {
+        if (group.field == field) {
+          regroup_slot = group.regroup_slot;
+          break;
+        }
+      }
+      if (regroup_slot < 0) LDB_COL_REJECT("outer output not grouped");
+      output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::GROUP);
+      output->set_ordinal(regroup_slot);
+      continue;
+    }
+
+    if (real->type() != Item::SUM_FUNC_ITEM)
+      LDB_COL_REJECT("outer output shape");
+    Item_sum *sum = down_cast<Item_sum *>(real);
+    if (sum->sum_func() != Item_sum::COUNT_FUNC)
+      LDB_COL_REJECT("outer aggregate not COUNT");
+    if (sum->argument_count() > 0) {
+      Item *arg = sum->get_arg(0)->real_item();
+      if (!arg->const_item() || arg->is_nullable() || arg->is_null()) {
+        LDB_COL_REJECT("outer aggregate not COUNT(*)");
+      }
+    }
+    output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::AGG);
+    output->set_ordinal(0);
+  }
+
+  for (ORDER *order = qb->order_list.first; order != nullptr;
+       order = order->next) {
+    const int output_ordinal = OrderOutputOrdinal(*order->item, output_items);
+    if (output_ordinal < 0) LDB_COL_REJECT("outer ORDER BY");
+    auto *sort_key = request.add_order_by();
+    sort_key->set_output_ordinal(output_ordinal);
+    sort_key->set_descending(order->direction == ORDER_DESC);
+    Item *output_item = output_items[output_ordinal]->real_item();
+    sort_key->set_cmp_kind(output_item->result_type() == STRING_RESULT ? 1 : 0);
+  }
+
+  Query_expression *outer_unit = qb->master_query_expression();
+  if (qb->has_limit()) {
+    if (outer_unit->select_limit_cnt != HA_POS_ERROR)
+      request.set_limit(outer_unit->select_limit_cnt);
+    if (outer_unit->offset_limit_cnt > 0) {
+      request.set_offset(outer_unit->offset_limit_cnt);
+      if (request.limit() > 0)
+        request.set_limit(request.limit() - outer_unit->offset_limit_cnt);
+    }
+  }
+
+  ctx->query_block_ready = true;
+  *why = nullptr;
+  return true;
+
+#undef LDB_COL_REJECT
+}
+
+/**
  * @brief Recognize aggregate query blocks supported by LINEAIRDB_COLUMNAR.
  *
  * Unsupported shapes return false and set `why`; callers convert that into a
@@ -383,6 +689,11 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
   Query_expression *unit = qb->master_query_expression();
   if (unit == nullptr || !unit->is_simple())
     LDB_COL_REJECT("not simple unit");
+
+  if (qb->leaf_tables != nullptr && qb->leaf_tables->next_leaf == nullptr &&
+      qb->leaf_tables->is_view_or_derived()) {
+    return RecognizeDerivedRegroup(join, ctx, why);
+  }
 
   if (qb->having_cond() != nullptr) LDB_COL_REJECT("has HAVING");
   if (qb->is_distinct()) LDB_COL_REJECT("has DISTINCT");

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1648,8 +1648,25 @@ bool BuildQueryBlockRequest(
       for (size_t left_idx = 0; left_idx < equal_fields.size(); left_idx++) {
         for (size_t right_idx = left_idx + 1; right_idx < equal_fields.size();
              right_idx++) {
-          add_join_edge_if_supported(equal_fields[left_idx],
-                                     equal_fields[right_idx]);
+          const int left_table =
+              TableIndexOfField(equal_fields[left_idx], tables);
+          const int right_table =
+              TableIndexOfField(equal_fields[right_idx], tables);
+          // Fields that do not resolve to this block's tables and pairs that
+          // cross a semijoin nest boundary are enforced by the semijoin key
+          // machinery, not by join edges.
+          if (left_table < 0 || right_table < 0) continue;
+          if (table_semijoin_nest[left_table] !=
+              table_semijoin_nest[right_table]) {
+            continue;
+          }
+          // A dropped same-side pair would silently lose the equality
+          // between those two columns; the join would then emit rows the
+          // predicate excludes.
+          if (!add_join_edge_if_supported(equal_fields[left_idx],
+                                          equal_fields[right_idx])) {
+            LDB_COL_REJECT("multiple equality not pushable");
+          }
         }
       }
       continue;

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1,18 +1,22 @@
 #include "ha_lineairdb_columnar.hh"
 
+#include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 #include "my_alloc.h"
 #include "my_dbug.h"
 #include "mysql/plugin.h"
 #include "mysqld_error.h"
 #include "sql/handler.h"
+#include "sql/item.h"
 #include "sql/sql_class.h"
 #include "sql/sql_lex.h"
 #include "sql/table.h"
@@ -63,6 +67,97 @@ class LoadedTables {
 };
 
 LoadedTables *loaded_tables = nullptr;
+
+class ItemColumnarValue final : public Item_string {
+ public:
+  explicit ItemColumnarValue(const Item *prototype)
+      : Item_string("", 0, prototype->collation.collation) {
+    set_data_type(prototype->data_type());
+    decimals = prototype->decimals;
+    max_length = prototype->max_length;
+    unsigned_flag = prototype->unsigned_flag;
+    set_nullable(true);
+  }
+
+  void set_value(const char *ptr, size_t len) {
+    str_value.copy(ptr, len, collation.collation);
+    null_value = false;
+  }
+
+  void set_null_value() { null_value = true; }
+};
+
+struct OutBinding {
+  bool is_aggregate = false;
+  int index = 0;
+};
+
+class ColumnarExecutionContext : public Secondary_engine_execution_context {
+ public:
+  bool BestPlanSoFar(const JOIN &join, double cost) {
+    if (&join != current_join_) {
+      current_join_ = &join;
+      best_cost_ = cost;
+      return true;
+    }
+
+    const bool cheaper = cost < best_cost_;
+    best_cost_ = std::min(best_cost_, cost);
+    return cheaper;
+  }
+
+  std::string table_name;
+  std::string serialized_filter;
+  std::string serialized_aggregate;
+  std::vector<OutBinding> bindings;
+  int group_column_count = 0;
+  int aggregate_count = 0;
+
+ private:
+  const JOIN *current_join_ = nullptr;
+  double best_cost_ = 0.0;
+};
+
+struct DecodedField {
+  const char *ptr = nullptr;
+  size_t len = 0;
+  bool empty = false;
+};
+
+/**
+ * @brief Decode LineairDB's row-field framing into field slices.
+ *
+ * Each field is stored as a one-byte length-width tag, that many little-endian
+ * length bytes, then the payload. A tag of 0xff represents an empty field.
+ */
+[[maybe_unused]] bool DecodeRowFields(const std::string &row,
+                                      std::vector<DecodedField> *out) {
+  out->clear();
+  size_t offset = 0;
+
+  while (offset < row.size()) {
+    const auto length_bytes = static_cast<uint8_t>(row[offset]);
+    offset += 1;
+    if (length_bytes == 0xff) {
+      out->push_back({nullptr, 0, true});
+      continue;
+    }
+    if (length_bytes > 4 || offset + length_bytes > row.size()) return false;
+
+    size_t len = 0;
+    for (uint8_t i = 0; i < length_bytes; i++) {
+      len |= static_cast<size_t>(
+                 static_cast<uint8_t>(row[offset + i])) << (8 * i);
+    }
+    offset += length_bytes;
+    if (offset + len > row.size()) return false;
+
+    out->push_back({row.data() + offset, len, false});
+    offset += len;
+  }
+
+  return true;
+}
 
 bool RejectSecondaryExecution(THD *, LEX *) {
   my_error(ER_SECONDARY_ENGINE_PLUGIN, MYF(0),

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -30,7 +30,6 @@
 #include "thr_lock.h"
 
 #include "aggregate_pushdown.hh"
-#include "lineairdb_keyenc.hh"
 #include "lineairdb.pb.h"
 #include "lineairdb_proxy.hh"
 #include "lineairdb_pushdown.hh"
@@ -141,14 +140,9 @@ class ItemColumnarValue final : public Item_string {
   void set_null_value() { null_value = true; }
 };
 
-struct OutBinding {
-  bool is_aggregate = false;
-  int index = 0;
-};
-
 // Statement-local state owned by LEX::secondary_engine_execution_context.
-// Recognition fills the serialized LineairDB request and output bindings;
-// execution consumes them after MySQL calls JOIN::override_executor_func.
+// Recognition fills the LineairDB query-block request; execution consumes it
+// after MySQL calls JOIN::override_executor_func.
 class ColumnarExecutionContext : public Secondary_engine_execution_context {
  public:
   bool BestPlanSoFar(const JOIN &join, double cost) {
@@ -163,12 +157,8 @@ class ColumnarExecutionContext : public Secondary_engine_execution_context {
     return cheaper;
   }
 
-  std::string table_name;
-  std::string serialized_filter;
-  std::string serialized_aggregate;
-  std::vector<OutBinding> bindings;
-  int group_column_count = 0;
-  int aggregate_count = 0;
+  LineairDB::Protocol::TxExecuteQueryBlock::Request query_block_request;
+  bool query_block_ready = false;
 
  private:
   const JOIN *current_join_ = nullptr;
@@ -254,6 +244,29 @@ bool GroupColumnIsBinarySafe(const Field *field) {
 }
 
 /**
+ * @brief Return the visible output ordinal used by an ORDER BY item.
+ */
+int OrderOutputOrdinal(Item *order_item,
+                       const std::vector<Item *> &output_items, TABLE *table) {
+  Item *order_real = order_item->real_item();
+  for (size_t i = 0; i < output_items.size(); i++) {
+    Item *output_real = output_items[i]->real_item();
+    if (output_real == order_real) return static_cast<int>(i);
+    if (order_real->type() == Item::FIELD_ITEM &&
+        output_real->type() == Item::FIELD_ITEM) {
+      const Field *order_field = ResolveBaseField(
+          down_cast<Item_field *>(order_real)->field, table);
+      const Field *output_field = ResolveBaseField(
+          down_cast<Item_field *>(output_real)->field, table);
+      if (order_field != nullptr && order_field == output_field) {
+        return static_cast<int>(i);
+      }
+    }
+  }
+  return -1;
+}
+
+/**
  * @brief Recognize single-table aggregate blocks supported by LINEAIRDB_COLUMNAR.
  *
  * Unsupported shapes return false and set `why`; callers convert that into a
@@ -268,12 +281,8 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
     return false;              \
   } while (0)
 
-  ctx->table_name.clear();
-  ctx->serialized_filter.clear();
-  ctx->serialized_aggregate.clear();
-  ctx->bindings.clear();
-  ctx->group_column_count = 0;
-  ctx->aggregate_count = 0;
+  ctx->query_block_request.Clear();
+  ctx->query_block_ready = false;
 
   Query_block *qb = join->query_block;
   if (qb == nullptr || qb->outer_query_block() != nullptr)
@@ -291,10 +300,7 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
   if (table == nullptr || table->s == nullptr) LDB_COL_REJECT("no TABLE");
 
   if (qb->having_cond() != nullptr) LDB_COL_REJECT("has HAVING");
-  if (join->order.order != nullptr || qb->order_list.elements > 0)
-    LDB_COL_REJECT("has ORDER BY");
   if (qb->is_distinct()) LDB_COL_REJECT("has DISTINCT");
-  if (qb->has_limit()) LDB_COL_REJECT("has LIMIT");
   if (qb->has_windows()) LDB_COL_REJECT("has windows");
   if (qb->olap != UNSPECIFIED_OLAP_TYPE) LDB_COL_REJECT("has ROLLUP");
   if (!join->implicit_grouping && qb->group_list.elements == 0)
@@ -303,18 +309,24 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
   if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
     LDB_COL_REJECT("not SECONDARY_LOADed");
 
+  auto &request = ctx->query_block_request;
+  request.add_tables()->set_table_name(table->s->normalized_path.str);
+
+  auto *scan_node = request.add_nodes();
+  auto *scan = scan_node->mutable_scan();
+  scan->set_table_idx(0);
   Item *where_cond =
       qb->where_cond() != nullptr ? qb->where_cond() : join->where_cond;
-  LineairDB::Protocol::PushedPredicate predicate;
   if (where_cond != nullptr) {
-    if (!serialize_item(where_cond, predicate.mutable_expr()))
+    auto *predicate = scan->mutable_filter();
+    if (!serialize_item(where_cond, predicate->mutable_expr()))
       LDB_COL_REJECT("WHERE not pushable");
-    predicate.set_num_columns(table->s->fields);
+    predicate->set_num_columns(table->s->fields);
   }
 
-  LineairDB::Protocol::AggregateSpec spec;
-  spec.set_num_columns(table->s->fields);
-
+  auto *aggregate_node = request.add_nodes();
+  auto *aggregate = aggregate_node->mutable_aggregate();
+  aggregate->set_input(0);
   std::vector<const Field *> group_fields;
   for (ORDER *group = qb->group_list.first; group != nullptr;
        group = group->next) {
@@ -330,12 +342,20 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
       LDB_COL_REJECT("group column not binary-safe");
     }
 
-    spec.add_group_columns(group_field->field_index());
+    auto *group_column = aggregate->add_group_columns();
+    group_column->set_table_idx(0);
+    group_column->set_column(group_field->field_index());
+    group_column->set_cmp_kind(group_field->result_type() == STRING_RESULT ? 1
+                                                                           : 0);
     group_fields.push_back(group_field);
   }
 
-  for (Item *item : VisibleFields(qb->fields)) {
+  std::vector<Item *> output_items;
+  for (Item *item : VisibleFields(qb->fields)) output_items.push_back(item);
+
+  for (Item *item : output_items) {
     Item *real = item->real_item();
+    auto *output = request.add_output();
     if (real->type() == Item::FIELD_ITEM) {
       const Field *output_field = ResolveBaseField(
           down_cast<Item_field *>(real)->field, table);
@@ -352,7 +372,8 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
       if (group_position < 0)
         LDB_COL_REJECT("output field not a group column");
 
-      ctx->bindings.push_back({false, group_position});
+      output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::GROUP);
+      output->set_ordinal(group_position);
       continue;
     }
 
@@ -362,12 +383,12 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
     Item_sum *sum = down_cast<Item_sum *>(real);
     if (sum->argument_count() > 1) LDB_COL_REJECT("aggregate arg count");
 
-    auto *aggregate = spec.add_aggs();
-    aggregate->set_result_scale(0);
+    auto *function = aggregate->add_aggs();
+    function->set_arg_table(0);
 
     switch (sum->sum_func()) {
       case Item_sum::COUNT_FUNC: {
-        if (sum->argument_count() == 1) {
+        if (sum->argument_count() > 0) {
           Item *arg = sum->get_arg(0)->real_item();
           if (arg->const_item()) {
             if (arg->is_nullable() || arg->is_null())
@@ -382,36 +403,62 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
           }
         }
 
-        aggregate->set_kind(LineairDB::Protocol::AggFunc::AGG_COUNT);
+        function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::COUNT);
         break;
       }
 
-      case Item_sum::SUM_FUNC: {
-        if (sum->argument_count() != 1) LDB_COL_REJECT("SUM arg count");
+      case Item_sum::SUM_FUNC:
+      case Item_sum::AVG_FUNC: {
+        if (sum->argument_count() != 1) LDB_COL_REJECT("aggregate arg count");
         Item *arg = sum->get_arg(0)->real_item();
         if (arg->result_type() != DECIMAL_RESULT &&
             arg->result_type() != INT_RESULT) {
-          LDB_COL_REJECT("SUM arg type");
+          LDB_COL_REJECT("aggregate arg type");
         }
 
         if (arg->type() == Item::FIELD_ITEM) {
-          const Field *sum_field = ResolveBaseField(
+          const Field *argument_field = ResolveBaseField(
               down_cast<Item_field *>(arg)->field, table);
-          if (sum_field == nullptr) LDB_COL_REJECT("SUM arg unresolvable");
+          if (argument_field == nullptr)
+            LDB_COL_REJECT("aggregate arg unresolvable");
 
-          auto *ref = aggregate->mutable_arg();
+          auto *ref = function->mutable_arg();
           ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
-          ref->set_column_index(sum_field->field_index());
-        } else if (qb->group_list.elements == 0) {
-          if (!lineairdb::serialize_aggregate_expression(
-                  arg, aggregate->mutable_arg())) {
-            LDB_COL_REJECT("SUM expr not pushable");
-          }
+          ref->set_column_index(argument_field->field_index());
         } else {
-          LDB_COL_REJECT("SUM expr under GROUP BY");
+          if (!lineairdb::serialize_aggregate_expression(
+                  arg, function->mutable_arg())) {
+            LDB_COL_REJECT("aggregate expr not pushable");
+          }
         }
 
-        aggregate->set_kind(LineairDB::Protocol::AggFunc::AGG_SUM);
+        function->set_kind(
+            sum->sum_func() == Item_sum::SUM_FUNC
+                ? LineairDB::Protocol::QueryBlockAggFunc::SUM
+                : LineairDB::Protocol::QueryBlockAggFunc::AVG);
+        function->set_arg_scale(arg->decimals);
+        break;
+      }
+
+      case Item_sum::MIN_FUNC:
+      case Item_sum::MAX_FUNC: {
+        if (sum->argument_count() != 1) LDB_COL_REJECT("aggregate arg count");
+        Item *arg = sum->get_arg(0)->real_item();
+        if (arg->type() != Item::FIELD_ITEM) LDB_COL_REJECT("minmax arg");
+        const Field *argument_field = ResolveBaseField(
+            down_cast<Item_field *>(arg)->field, table);
+        if (argument_field == nullptr) LDB_COL_REJECT("minmax unresolvable");
+
+        auto *ref = function->mutable_arg();
+        ref->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
+        ref->set_column_index(argument_field->field_index());
+        function->set_kind(
+            sum->sum_func() == Item_sum::MIN_FUNC
+                ? LineairDB::Protocol::QueryBlockAggFunc::MIN
+                : LineairDB::Protocol::QueryBlockAggFunc::MAX);
+        function->set_cmp_kind(argument_field->result_type() == STRING_RESULT
+                                   ? 1
+                                   : 0);
         break;
       }
 
@@ -419,18 +466,37 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
         LDB_COL_REJECT("aggregate kind unsupported");
     }
 
-    ctx->bindings.push_back({true, spec.aggs_size() - 1});
+    output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::AGG);
+    output->set_ordinal(aggregate->aggs_size() - 1);
   }
 
-  if (spec.aggs_size() == 0) LDB_COL_REJECT("no aggregates");
+  if (aggregate->aggs_size() == 0) LDB_COL_REJECT("no aggregates");
 
-  ctx->table_name.assign(table->s->normalized_path.str);
-  ctx->group_column_count = spec.group_columns_size();
-  ctx->aggregate_count = spec.aggs_size();
-  if (where_cond != nullptr) {
-    predicate.SerializeToString(&ctx->serialized_filter);
+  for (ORDER *order = qb->order_list.first; order != nullptr;
+       order = order->next) {
+    const int output_ordinal =
+        OrderOutputOrdinal(*order->item, output_items, table);
+    if (output_ordinal < 0)
+      LDB_COL_REJECT("ORDER BY not an output column");
+
+    auto *sort_key = request.add_order_by();
+    sort_key->set_output_ordinal(output_ordinal);
+    sort_key->set_descending(order->direction == ORDER_DESC);
+    Item *output_item = output_items[output_ordinal]->real_item();
+    sort_key->set_cmp_kind(output_item->result_type() == STRING_RESULT ? 1 : 0);
   }
-  spec.SerializeToString(&ctx->serialized_aggregate);
+
+  if (qb->has_limit()) {
+    if (unit->select_limit_cnt != HA_POS_ERROR)
+      request.set_limit(unit->select_limit_cnt);
+    if (unit->offset_limit_cnt > 0) {
+      request.set_offset(unit->offset_limit_cnt);
+      if (request.limit() > 0)
+        request.set_limit(request.limit() - unit->offset_limit_cnt);
+    }
+  }
+
+  ctx->query_block_ready = true;
 
   *why = nullptr;
   return true;
@@ -442,14 +508,14 @@ bool RecognizeSingleTableAggregate(JOIN *join, ColumnarExecutionContext *ctx,
  * @brief Execute a recognized aggregate block through LineairDB.
  *
  * MySQL has already sent result-set metadata for the original SELECT list. This
- * override runs one aggregate read-plan step and sends value-only Item carriers
+ * override runs one query-block RPC and sends value-only Item carriers
  * that match that already-described metadata.
  */
 bool ExecuteColumnarAggregate(JOIN *join, Query_result *result) {
   THD *thd = join->thd;
   auto *ctx = static_cast<ColumnarExecutionContext *>(
       thd->lex->secondary_engine_execution_context());
-  if (ctx == nullptr || ctx->serialized_aggregate.empty()) {
+  if (ctx == nullptr || !ctx->query_block_ready) {
     return RaiseColumnarError(thd, "LINEAIRDB_COLUMNAR: no offload plan");
   }
 
@@ -458,67 +524,42 @@ bool ExecuteColumnarAggregate(JOIN *join, Query_result *result) {
     return RaiseColumnarError(thd, "LINEAIRDB_COLUMNAR: no server connection");
   }
 
-  LineairDBProxy::ReadPlanStep step;
-  step.table_name = ctx->table_name;
-  step.is_scan = true;
-  step.end_key_prefix = lineairdb_keyenc::scan_end_sentinel();
-  step.serialized_filter = ctx->serialized_filter;
-  step.aggregate_serialized = ctx->serialized_aggregate;
-
-  LineairDBProxy::ReadPlanResult rpc = proxy->tx_execute_read_plan({step});
-  if (!rpc.ok || rpc.steps.size() != 1) {
-    return RaiseColumnarError(thd,
-                              "LINEAIRDB_COLUMNAR: aggregate scan RPC failed");
+  LineairDB::Protocol::TxExecuteQueryBlock::Response rpc;
+  if (!proxy->tx_execute_query_block(ctx->query_block_request, &rpc) ||
+      !rpc.ok()) {
+    char message[192];
+    snprintf(message, sizeof(message), "LINEAIRDB_COLUMNAR: %s",
+             rpc.error().empty() ? "query block RPC failed"
+                                 : rpc.error().c_str());
+    return RaiseColumnarError(thd, message);
   }
 
   mem_root_deque<Item *> output_items(thd->mem_root);
   std::vector<ItemColumnarValue *> values;
-  values.reserve(ctx->bindings.size());
   for (Item *item : VisibleFields(join->query_block->fields)) {
     auto *value = new (thd->mem_root) ItemColumnarValue(item);
     if (value == nullptr) return true;
     values.push_back(value);
     output_items.push_back(value);
   }
-  if (values.size() != ctx->bindings.size()) {
-    return RaiseColumnarError(thd,
-                              "LINEAIRDB_COLUMNAR: output binding mismatch");
-  }
 
   std::vector<DecodedField> fields;
-  for (const std::string &row : rpc.steps[0].scan_values) {
-    if (!DecodeRowFields(row, &fields)) {
-      return RaiseColumnarError(thd,
-                                "LINEAIRDB_COLUMNAR: malformed group row");
-    }
-
-    // Server aggregate rows are [null_flags][group cols][value,count per agg].
-    const size_t expected = 1 + static_cast<size_t>(ctx->group_column_count) +
-                            2 * static_cast<size_t>(ctx->aggregate_count);
-    if (fields.size() != expected) {
+  const size_t expected = 1 + values.size();
+  for (const std::string &row : rpc.rows()) {
+    if (!DecodeRowFields(row, &fields) || fields.size() != expected) {
       return RaiseColumnarError(
-          thd, "LINEAIRDB_COLUMNAR: unexpected group row shape");
+          thd, "LINEAIRDB_COLUMNAR: malformed query-block row");
     }
 
-    for (size_t i = 0; i < ctx->bindings.size(); i++) {
-      const OutBinding &binding = ctx->bindings[i];
-      const DecodedField &field =
-          binding.is_aggregate
-              ? fields[1 + ctx->group_column_count + 2 * binding.index]
-              : fields[1 + binding.index];
-
+    // Field 0 is a placeholder for the proxy row null-flags field. The server
+    // emits one following field per SELECT output item.
+    for (size_t i = 0; i < values.size(); i++) {
+      const DecodedField &field = fields[1 + i];
       if (!field.empty) {
         values[i]->set_value(field.ptr, field.len);
         continue;
       }
-
-      // Empty aggregate fields are SQL NULL, while GROUP BY fields are
-      // non-nullable by recognition and represent an empty byte string.
-      if (binding.is_aggregate) {
-        values[i]->set_null_value();
-      } else {
-        values[i]->set_value("", 0);
-      }
+      values[i]->set_null_value();
     }
 
     if (result->send_data(thd, output_items)) return true;

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1889,6 +1889,135 @@ bool BuildQueryBlockRequest(
       return true;
     };
 
+    auto emit_mapped_join =
+        [&](LineairDB::Protocol::QueryBlockJoin::Type join_type, int probe,
+            int build, RelationalExpression *expression,
+            const std::vector<Item *> &extra_residuals,
+            double output_rows) -> int {
+      if (expression == nullptr) {
+        *why = "plan join without predicate";
+        return -1;
+      }
+
+      auto *join_node = request.add_nodes()->mutable_join();
+      const int self = request.nodes_size() - 1;
+      join_node->set_type(join_type);
+      join_node->set_build(static_cast<uint32_t>(build));
+      join_node->set_probe(static_cast<uint32_t>(probe));
+
+      for (Item_eq_base *eq : expression->equijoin_conditions) {
+        if (eq->functype() != Item_func::EQ_FUNC) {
+          *why = "plan join key null-safe eq";
+          return -1;
+        }
+
+        Item *left_item = eq->get_arg(0)->real_item();
+        Item *right_item = eq->get_arg(1)->real_item();
+        if (left_item->type() != Item::FIELD_ITEM ||
+            right_item->type() != Item::FIELD_ITEM) {
+          *why = "plan join key shape";
+          return -1;
+        }
+
+        const Field *left_raw = down_cast<Item_field *>(left_item)->field;
+        const Field *right_raw = down_cast<Item_field *>(right_item)->field;
+        int left_table = TableIndexOfField(left_raw, tables);
+        int right_table = TableIndexOfField(right_raw, tables);
+        if (left_table < 0 || right_table < 0) {
+          *why = "plan join key table";
+          return -1;
+        }
+        if (!JoinColumnsUseByteEquality(left_raw, right_raw)) {
+          *why = "plan join key type";
+          return -1;
+        }
+
+        const Field *left_field = resolve_query_field(left_raw, left_table);
+        const Field *right_field =
+            resolve_query_field(right_raw, right_table);
+        if (left_field == nullptr || right_field == nullptr) {
+          *why = "plan join key resolve";
+          return -1;
+        }
+        if ((!table_is_virtual[left_table] && left_field->is_nullable()) ||
+            (!table_is_virtual[right_table] && right_field->is_nullable())) {
+          *why = "plan join key nullable";
+          return -1;
+        }
+
+        if (node_tables[build].count(left_table) > 0 &&
+            node_tables[probe].count(right_table) > 0) {
+          // left stays on the build side and right stays on the probe side.
+        } else if (node_tables[build].count(right_table) > 0 &&
+                   node_tables[probe].count(left_table) > 0) {
+          std::swap(left_table, right_table);
+          std::swap(left_field, right_field);
+        } else {
+          *why = "plan join key sides";
+          return -1;
+        }
+
+        auto *build_key = join_node->add_build_keys();
+        build_key->set_table_idx(static_cast<uint32_t>(left_table));
+        build_key->set_column(left_field->field_index());
+        auto *probe_key = join_node->add_probe_keys();
+        probe_key->set_table_idx(static_cast<uint32_t>(right_table));
+        probe_key->set_column(right_field->field_index());
+        mapped_join_keys.push_back(
+            {join_type, build, probe, static_cast<uint32_t>(left_table),
+             left_field->field_index(), static_cast<uint32_t>(right_table),
+             right_field->field_index()});
+      }
+
+      std::vector<Item *> residuals;
+      for (Item *condition : expression->join_conditions) {
+        residuals.push_back(condition);
+      }
+      residuals.insert(residuals.end(), extra_residuals.begin(),
+                       extra_residuals.end());
+      if (!residuals.empty()) {
+        for (Item *residual : residuals) {
+          const table_map used = residual->used_tables() & ~PSEUDO_TABLE_BITS;
+          for (size_t table_idx = 0; table_idx < tables.size(); table_idx++) {
+            if ((used & tables[table_idx].map) != 0 &&
+                node_tables[probe].count(static_cast<int>(table_idx)) == 0 &&
+                node_tables[build].count(static_cast<int>(table_idx)) == 0) {
+              *why = "plan join residual out of scope";
+              return -1;
+            }
+          }
+        }
+        if (!fill_tuple_filter(residuals, join_node->mutable_residual())) {
+          *why = "plan join residual not pushable";
+          return -1;
+        }
+      }
+
+      if (join_node->build_keys_size() == 0) {
+        bool build_is_one_row = true;
+        for (int table_idx : node_tables[build]) {
+          if (!is_scalar_virtual_table(table_idx)) {
+            build_is_one_row = false;
+            break;
+          }
+        }
+        if (!build_is_one_row) {
+          *why = "plan keyless join";
+          return -1;
+        }
+      }
+
+      std::set<int> output_tables = node_tables[probe];
+      if (join_type == LineairDB::Protocol::QueryBlockJoin::INNER ||
+          join_type == LineairDB::Protocol::QueryBlockJoin::LEFT) {
+        output_tables.insert(node_tables[build].begin(),
+                             node_tables[build].end());
+      }
+      node_tables[self] = std::move(output_tables);
+      node_rows[self] = output_rows;
+      return self;
+    };
+
     std::function<int(AccessPath *, bool)> map_path =
         [&](AccessPath *path, bool root) -> int {
       if (path == nullptr) {
@@ -2045,128 +2174,9 @@ bool BuildQueryBlockRequest(
                 return -1;
             }
           }
-
-          auto *join_node = request.add_nodes()->mutable_join();
-          const int self = request.nodes_size() - 1;
-          join_node->set_type(join_type);
-          join_node->set_build(static_cast<uint32_t>(build));
-          join_node->set_probe(static_cast<uint32_t>(probe));
-
-          for (Item_eq_base *eq : expression->equijoin_conditions) {
-            if (eq->functype() != Item_func::EQ_FUNC) {
-              *why = "plan join key null-safe eq";
-              return -1;
-            }
-
-            Item *left_item = eq->get_arg(0)->real_item();
-            Item *right_item = eq->get_arg(1)->real_item();
-            if (left_item->type() != Item::FIELD_ITEM ||
-                right_item->type() != Item::FIELD_ITEM) {
-              *why = "plan join key shape";
-              return -1;
-            }
-
-            const Field *left_raw = down_cast<Item_field *>(left_item)->field;
-            const Field *right_raw = down_cast<Item_field *>(right_item)->field;
-            int left_table = TableIndexOfField(left_raw, tables);
-            int right_table = TableIndexOfField(right_raw, tables);
-            if (left_table < 0 || right_table < 0) {
-              *why = "plan join key table";
-              return -1;
-            }
-            if (!JoinColumnsUseByteEquality(left_raw, right_raw)) {
-              *why = "plan join key type";
-              return -1;
-            }
-
-            const Field *left_field =
-                resolve_query_field(left_raw, left_table);
-            const Field *right_field =
-                resolve_query_field(right_raw, right_table);
-            if (left_field == nullptr || right_field == nullptr) {
-              *why = "plan join key resolve";
-              return -1;
-            }
-            if ((!table_is_virtual[left_table] && left_field->is_nullable()) ||
-                (!table_is_virtual[right_table] &&
-                 right_field->is_nullable())) {
-              *why = "plan join key nullable";
-              return -1;
-            }
-
-            if (node_tables[build].count(left_table) > 0 &&
-                node_tables[probe].count(right_table) > 0) {
-              // left stays on the build side and right stays on the probe side.
-            } else if (node_tables[build].count(right_table) > 0 &&
-                       node_tables[probe].count(left_table) > 0) {
-              std::swap(left_table, right_table);
-              std::swap(left_field, right_field);
-            } else {
-              *why = "plan join key sides";
-              return -1;
-            }
-
-            auto *build_key = join_node->add_build_keys();
-            build_key->set_table_idx(static_cast<uint32_t>(left_table));
-            build_key->set_column(left_field->field_index());
-            auto *probe_key = join_node->add_probe_keys();
-            probe_key->set_table_idx(static_cast<uint32_t>(right_table));
-            probe_key->set_column(right_field->field_index());
-            mapped_join_keys.push_back(
-                {join_type, build, probe, static_cast<uint32_t>(left_table),
-                 left_field->field_index(), static_cast<uint32_t>(right_table),
-                 right_field->field_index()});
-          }
-
-          if (!expression->join_conditions.empty()) {
-            std::vector<Item *> residuals;
-            for (Item *condition : expression->join_conditions) {
-              residuals.push_back(condition);
-            }
-            for (Item *residual : residuals) {
-              const table_map used =
-                  residual->used_tables() & ~PSEUDO_TABLE_BITS;
-              for (size_t table_idx = 0; table_idx < tables.size();
-                   table_idx++) {
-                if ((used & tables[table_idx].map) != 0 &&
-                    node_tables[probe].count(static_cast<int>(table_idx)) ==
-                        0 &&
-                    node_tables[build].count(static_cast<int>(table_idx)) ==
-                        0) {
-                  *why = "plan join residual out of scope";
-                  return -1;
-                }
-              }
-            }
-            if (!fill_tuple_filter(residuals, join_node->mutable_residual())) {
-              *why = "plan join residual not pushable";
-              return -1;
-            }
-          }
-
-          if (join_node->build_keys_size() == 0) {
-            bool build_is_one_row = true;
-            for (int table_idx : node_tables[build]) {
-              if (!is_scalar_virtual_table(table_idx)) {
-                build_is_one_row = false;
-                break;
-              }
-            }
-            if (!build_is_one_row) {
-              *why = "plan keyless join";
-              return -1;
-            }
-          }
-
-          std::set<int> output_tables = node_tables[probe];
-          if (join_type == LineairDB::Protocol::QueryBlockJoin::INNER ||
-              join_type == LineairDB::Protocol::QueryBlockJoin::LEFT) {
-            output_tables.insert(node_tables[build].begin(),
-                                 node_tables[build].end());
-          }
-          node_tables[self] = std::move(output_tables);
-          node_rows[self] = estimated_rows(path);
-          return self;
+          return emit_mapped_join(join_type, probe, build, expression,
+                                  std::vector<Item *>{},
+                                  estimated_rows(path));
         }
 
         case AccessPath::MATERIALIZE: {

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -24,6 +24,7 @@
 #include "sql/item_sum.h"
 #include "sql/item_timefunc.h"
 #include "sql/join_optimizer/access_path.h"
+#include "sql/join_optimizer/materialize_path_parameters.h"
 #include "sql/join_optimizer/relational_expression.h"
 #include "sql/mem_root_array.h"
 #include "sql/nested_join.h"
@@ -1817,6 +1818,8 @@ bool BuildQueryBlockRequest(
   int current_node = -1;
   if (plan_map) {
     std::map<int, std::set<int>> node_tables;
+    size_t next_virtual_table = real_table_count;
+
     std::set<const Item *> having_predicates;
     if (qb->having_cond() != nullptr) {
       std::vector<Item *> having_parts;
@@ -2123,6 +2126,56 @@ bool BuildQueryBlockRequest(
           }
           node_tables[self] = std::move(output_tables);
           return self;
+        }
+
+        case AccessPath::MATERIALIZE: {
+          if (path->materialize().param == nullptr ||
+              path->materialize().param->table == nullptr) {
+            *why = "plan derived missing table";
+            return -1;
+          }
+
+          const TABLE *table = path->materialize().param->table;
+          int table_idx = -1;
+          for (size_t i = real_table_count; i < tables.size(); i++) {
+            if (tables[i].table == table) {
+              table_idx = static_cast<int>(i);
+              break;
+            }
+          }
+          if (table_idx < 0) {
+            *why = "plan derived unknown";
+            return -1;
+          }
+
+          if (scan_nodes[table_idx] < 0) {
+            if (static_cast<size_t>(table_idx) != next_virtual_table) {
+              *why = "plan derived order";
+              return -1;
+            }
+            next_virtual_table++;
+
+            auto *sub_block = request.add_nodes()->mutable_sub_block();
+            AccessPath *sub_plan =
+                path->materialize().param->query_blocks.empty()
+                    ? nullptr
+                    : path->materialize()
+                          .param->query_blocks[0]
+                          .subquery_path;
+            if (!BuildQueryBlockRequest(
+                    nullptr,
+                    virtual_blocks[table_idx - real_table_count],
+                    sub_block->mutable_block(), why, sub_plan) &&
+                !BuildQueryBlockRequest(
+                    nullptr,
+                    virtual_blocks[table_idx - real_table_count],
+                    sub_block->mutable_block(), why, nullptr)) {
+              return -1;
+            }
+            scan_nodes[table_idx] = request.nodes_size() - 1;
+            node_tables[scan_nodes[table_idx]] = {table_idx};
+          }
+          return scan_nodes[table_idx];
         }
 
         case AccessPath::SORT:

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -2316,14 +2316,16 @@ bool BuildQueryBlockRequest(
       return 0.0;
     };
 
-    auto best_scan_source = [&](uint32_t target_table, int target_node,
-                                double target_rows) {
+    auto best_semi_source = [&](uint32_t target_table, int target_node,
+                                double target_rows, bool need_ratio,
+                                const std::function<bool(uint32_t)>
+                                    &target_column_ok) {
       SemiSource best;
       auto consider = [&](int node, double rows, uint32_t source_table,
                           uint32_t source_column,
                           uint32_t target_column) {
         if (node < 0 || node >= target_node) return;
-        if (rows * 8.0 > target_rows) return;
+        if (need_ratio && rows * 8.0 > target_rows) return;
         if (best.source_node < 0 || rows < best.rows) {
           best = {rows, node, source_table, source_column, target_column};
         }
@@ -2337,6 +2339,7 @@ bool BuildQueryBlockRequest(
               if (key_target_table != target_table) return;
               if (!join_side_filterable(key.join_type, target_is_build))
                 return;
+              if (!target_column_ok(key_target_column)) return;
               if (key_source_table < scan_nodes.size()) {
                 consider(scan_nodes[key_source_table],
                          effective_rows[key_source_table], key_source_table,
@@ -2373,8 +2376,9 @@ bool BuildQueryBlockRequest(
         continue;
       }
 
-      const SemiSource source = best_scan_source(
-          static_cast<uint32_t>(table_idx), node, effective_rows[table_idx]);
+      const SemiSource source = best_semi_source(
+          static_cast<uint32_t>(table_idx), node, effective_rows[table_idx],
+          true, [](uint32_t) { return true; });
       if (source.source_node < 0) continue;
 
       auto *semi = request.mutable_nodes(node)->mutable_scan()->mutable_semi();
@@ -2390,6 +2394,66 @@ bool BuildQueryBlockRequest(
         effective_rows[table_idx] = std::max(
             1.0, std::min(effective_rows[table_idx], source.rows * fanout));
       }
+    }
+
+    // A derived aggregate can also read a smaller key domain from the parent
+    // plan. This is only valid when the joined derived column is a direct GROUP
+    // output, because the server must push the external key set down to the
+    // child scan that owns that group key.
+    for (int node_idx = 0; node_idx < request.nodes_size(); node_idx++) {
+      if (!request.nodes(node_idx).has_sub_block()) continue;
+
+      int virtual_table = -1;
+      for (size_t table_idx = real_table_count; table_idx < tables.size();
+           table_idx++) {
+        if (scan_nodes[table_idx] == node_idx) {
+          virtual_table = static_cast<int>(table_idx);
+          break;
+        }
+      }
+      if (virtual_table < 0) continue;
+
+      const auto &child_request = request.nodes(node_idx).sub_block().block();
+      auto group_output_is_filterable = [&](uint32_t output_column) {
+        if (output_column >=
+                static_cast<uint32_t>(child_request.output_size()) ||
+            child_request.output(output_column).source() !=
+                LineairDB::Protocol::QueryBlockOutputExpr::GROUP ||
+            child_request.nodes_size() == 0 ||
+            !child_request.nodes(child_request.nodes_size() - 1)
+                 .has_aggregate()) {
+          return false;
+        }
+
+        const auto &aggregate =
+            child_request.nodes(child_request.nodes_size() - 1).aggregate();
+        const uint32_t group_ordinal =
+            child_request.output(output_column).ordinal();
+        return group_ordinal <
+                   static_cast<uint32_t>(aggregate.group_columns_size()) &&
+               aggregate.group_columns(group_ordinal).prefix_len() == 0;
+      };
+
+      const SemiSource source = best_semi_source(
+          static_cast<uint32_t>(virtual_table), node_idx, 0.0, false,
+          group_output_is_filterable);
+      if (source.source_node < 0) continue;
+
+      const auto &aggregate =
+          child_request.nodes(child_request.nodes_size() - 1).aggregate();
+      const uint32_t group_ordinal =
+          child_request.output(source.target_column).ordinal();
+      auto *sub_block = request.mutable_nodes(node_idx)->mutable_sub_block();
+      auto *semi = sub_block->mutable_semi();
+      semi->set_source_node(source.source_node);
+      auto *source_column = semi->mutable_source_column();
+      source_column->set_table_idx(source.source_table);
+      source_column->set_column(source.source_column);
+      semi->set_my_column(source.target_column);
+      sub_block->set_target_table(
+          aggregate.group_columns(group_ordinal).table_idx());
+      sub_block->set_target_column(
+          aggregate.group_columns(group_ordinal).column());
     }
   } else {
     // Scan every table once, attaching only predicates that read that table.

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -648,7 +648,8 @@ int lineairdb_columnar_init(void *p) {
   hton->optimize_secondary_engine = lineairdb_columnar::OptimizeSecondaryEngine;
   hton->compare_secondary_engine_cost = lineairdb_columnar::CompareJoinCost;
   hton->secondary_engine_flags =
-      MakeSecondaryEngineFlags(SecondaryEngineFlag::USE_EXTERNAL_EXECUTOR);
+      MakeSecondaryEngineFlags(SecondaryEngineFlag::SUPPORTS_HASH_JOIN,
+                               SecondaryEngineFlag::SUPPORTS_NESTED_LOOP_JOIN);
   return 0;
 }
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -24,6 +24,7 @@
 #include "sql/item_sum.h"
 #include "sql/item_timefunc.h"
 #include "sql/join_optimizer/access_path.h"
+#include "sql/join_optimizer/relational_expression.h"
 #include "sql/mem_root_array.h"
 #include "sql/nested_join.h"
 #include "sql/query_result.h"
@@ -1935,6 +1936,192 @@ bool BuildQueryBlockRequest(
           }
           const int self = request.nodes_size() - 1;
           node_tables[self] = node_tables[input];
+          return self;
+        }
+
+        case AccessPath::NESTED_LOOP_JOIN:
+        case AccessPath::HASH_JOIN: {
+          const bool is_nested_loop =
+              path->type == AccessPath::NESTED_LOOP_JOIN;
+          const int probe = map_path(is_nested_loop
+                                         ? path->nested_loop_join().outer
+                                         : path->hash_join().outer,
+                                     false);
+          if (probe < 0) return -1;
+          const int build = map_path(is_nested_loop
+                                         ? path->nested_loop_join().inner
+                                         : path->hash_join().inner,
+                                     false);
+          if (build < 0) return -1;
+
+          const JoinPredicate *join_predicate =
+              is_nested_loop ? path->nested_loop_join().join_predicate
+                             : path->hash_join().join_predicate;
+          if (join_predicate == nullptr || join_predicate->expr == nullptr) {
+            *why = "plan join without predicate";
+            return -1;
+          }
+          if (!is_nested_loop && path->hash_join().rewrite_semi_to_inner) {
+            *why = "plan semi-to-inner rewrite";
+            return -1;
+          }
+
+          RelationalExpression *expression = join_predicate->expr;
+          LineairDB::Protocol::QueryBlockJoin::Type join_type;
+          if (is_nested_loop) {
+            switch (path->nested_loop_join().join_type) {
+              case JoinType::INNER:
+                join_type = LineairDB::Protocol::QueryBlockJoin::INNER;
+                break;
+              case JoinType::OUTER:
+                join_type = LineairDB::Protocol::QueryBlockJoin::LEFT;
+                break;
+              case JoinType::SEMI:
+                join_type = LineairDB::Protocol::QueryBlockJoin::SEMI;
+                break;
+              case JoinType::ANTI:
+                join_type = LineairDB::Protocol::QueryBlockJoin::ANTI;
+                break;
+              default:
+                *why = "plan join type";
+                return -1;
+            }
+          } else {
+            switch (expression->type) {
+              case RelationalExpression::INNER_JOIN:
+              case RelationalExpression::STRAIGHT_INNER_JOIN:
+                join_type = LineairDB::Protocol::QueryBlockJoin::INNER;
+                break;
+              case RelationalExpression::LEFT_JOIN:
+                join_type = LineairDB::Protocol::QueryBlockJoin::LEFT;
+                break;
+              case RelationalExpression::SEMIJOIN:
+                join_type = LineairDB::Protocol::QueryBlockJoin::SEMI;
+                break;
+              case RelationalExpression::ANTIJOIN:
+                join_type = LineairDB::Protocol::QueryBlockJoin::ANTI;
+                break;
+              default:
+                *why = "plan join type";
+                return -1;
+            }
+          }
+
+          auto *join_node = request.add_nodes()->mutable_join();
+          const int self = request.nodes_size() - 1;
+          join_node->set_type(join_type);
+          join_node->set_build(static_cast<uint32_t>(build));
+          join_node->set_probe(static_cast<uint32_t>(probe));
+
+          for (Item_eq_base *eq : expression->equijoin_conditions) {
+            if (eq->functype() != Item_func::EQ_FUNC) {
+              *why = "plan join key null-safe eq";
+              return -1;
+            }
+
+            Item *left_item = eq->get_arg(0)->real_item();
+            Item *right_item = eq->get_arg(1)->real_item();
+            if (left_item->type() != Item::FIELD_ITEM ||
+                right_item->type() != Item::FIELD_ITEM) {
+              *why = "plan join key shape";
+              return -1;
+            }
+
+            const Field *left_raw = down_cast<Item_field *>(left_item)->field;
+            const Field *right_raw = down_cast<Item_field *>(right_item)->field;
+            int left_table = TableIndexOfField(left_raw, tables);
+            int right_table = TableIndexOfField(right_raw, tables);
+            if (left_table < 0 || right_table < 0) {
+              *why = "plan join key table";
+              return -1;
+            }
+            if (!JoinColumnsUseByteEquality(left_raw, right_raw)) {
+              *why = "plan join key type";
+              return -1;
+            }
+
+            const Field *left_field =
+                resolve_query_field(left_raw, left_table);
+            const Field *right_field =
+                resolve_query_field(right_raw, right_table);
+            if (left_field == nullptr || right_field == nullptr) {
+              *why = "plan join key resolve";
+              return -1;
+            }
+            if ((!table_is_virtual[left_table] && left_field->is_nullable()) ||
+                (!table_is_virtual[right_table] &&
+                 right_field->is_nullable())) {
+              *why = "plan join key nullable";
+              return -1;
+            }
+
+            if (node_tables[build].count(left_table) > 0 &&
+                node_tables[probe].count(right_table) > 0) {
+              // left stays on the build side and right stays on the probe side.
+            } else if (node_tables[build].count(right_table) > 0 &&
+                       node_tables[probe].count(left_table) > 0) {
+              std::swap(left_table, right_table);
+              std::swap(left_field, right_field);
+            } else {
+              *why = "plan join key sides";
+              return -1;
+            }
+
+            auto *build_key = join_node->add_build_keys();
+            build_key->set_table_idx(static_cast<uint32_t>(left_table));
+            build_key->set_column(left_field->field_index());
+            auto *probe_key = join_node->add_probe_keys();
+            probe_key->set_table_idx(static_cast<uint32_t>(right_table));
+            probe_key->set_column(right_field->field_index());
+          }
+
+          if (!expression->join_conditions.empty()) {
+            std::vector<Item *> residuals;
+            for (Item *condition : expression->join_conditions) {
+              residuals.push_back(condition);
+            }
+            for (Item *residual : residuals) {
+              const table_map used =
+                  residual->used_tables() & ~PSEUDO_TABLE_BITS;
+              for (size_t table_idx = 0; table_idx < tables.size();
+                   table_idx++) {
+                if ((used & tables[table_idx].map) != 0 &&
+                    node_tables[probe].count(static_cast<int>(table_idx)) ==
+                        0 &&
+                    node_tables[build].count(static_cast<int>(table_idx)) ==
+                        0) {
+                  *why = "plan join residual out of scope";
+                  return -1;
+                }
+              }
+            }
+            if (!fill_tuple_filter(residuals, join_node->mutable_residual())) {
+              *why = "plan join residual not pushable";
+              return -1;
+            }
+          }
+
+          if (join_node->build_keys_size() == 0) {
+            bool build_is_one_row = true;
+            for (int table_idx : node_tables[build]) {
+              if (!is_scalar_virtual_table(table_idx)) {
+                build_is_one_row = false;
+                break;
+              }
+            }
+            if (!build_is_one_row) {
+              *why = "plan keyless join";
+              return -1;
+            }
+          }
+
+          std::set<int> output_tables = node_tables[probe];
+          if (join_type == LineairDB::Protocol::QueryBlockJoin::INNER ||
+              join_type == LineairDB::Protocol::QueryBlockJoin::LEFT) {
+            output_tables.insert(node_tables[build].begin(),
+                                 node_tables[build].end());
+          }
+          node_tables[self] = std::move(output_tables);
           return self;
         }
 

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1576,10 +1576,6 @@ bool BuildQueryBlockRequest(
     const Field *left_field = resolve_query_field(left_raw, left_table);
     const Field *right_field = resolve_query_field(right_raw, right_table);
     if (left_field == nullptr || right_field == nullptr) return false;
-    if ((!table_is_virtual[left_table] && left_field->is_nullable()) ||
-        (!table_is_virtual[right_table] && right_field->is_nullable())) {
-      return false;
-    }
     join_edges.push_back({left_table, right_table, left_field, right_field});
     return true;
   };
@@ -1788,10 +1784,6 @@ bool BuildQueryBlockRequest(
     const Field *right_field = resolve_query_field(right_raw, right_table);
     if (left_field == nullptr || right_field == nullptr) {
       LDB_COL_REJECT("join key unresolvable");
-    }
-    if ((!table_is_virtual[left_table] && left_field->is_nullable()) ||
-        (!table_is_virtual[right_table] && right_field->is_nullable())) {
-      LDB_COL_REJECT("join key nullable");
     }
     join_edges.push_back({left_table, right_table, left_field, right_field});
   }
@@ -2002,12 +1994,6 @@ bool BuildQueryBlockRequest(
           *why = "plan join key resolve";
           return -1;
         }
-        if ((!table_is_virtual[left_table] && left_field->is_nullable()) ||
-            (!table_is_virtual[right_table] && right_field->is_nullable())) {
-          *why = "plan join key nullable";
-          return -1;
-        }
-
         ColRef build_ref{-1, 0};
         ColRef probe_ref{-1, 0};
         if (node_tables[build].count(left_table) > 0 &&

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -21,6 +21,7 @@
 #include "sql/handler.h"
 #include "sql/item.h"
 #include "sql/item_cmpfunc.h"
+#include "sql/item_subselect.h"
 #include "sql/item_sum.h"
 #include "sql/item_timefunc.h"
 #include "sql/join_optimizer/access_path.h"
@@ -4028,6 +4029,21 @@ bool CompareJoinCost(THD *thd, const JOIN &join, double optimizer_cost,
                      double *secondary_engine_cost) {
   *use_best_so_far = false;
   *secondary_engine_cost = optimizer_cost;
+
+  // A quantified subquery (IN/ALL/ANY) that survives to the secondary
+  // optimization pass reaches subquery-materialization costing, which
+  // crashes on plans produced for secondary tables. Antijoin and derived
+  // rewrites are unavailable on this pass for such shapes (nullable NOT IN),
+  // so reject them here, before the costing runs. EXISTS and scalar
+  // subqueries resolve to the EXISTS strategy and never reach that costing.
+  const Item_subselect *subquery_item = join.query_expression()->item;
+  if (subquery_item != nullptr &&
+      (subquery_item->substype() == Item_subselect::IN_SUBS ||
+       subquery_item->substype() == Item_subselect::ALL_SUBS ||
+       subquery_item->substype() == Item_subselect::ANY_SUBS)) {
+    return RaiseColumnarError(
+        thd, "LINEAIRDB_COLUMNAR unsupported shape: quantified subquery");
+  }
 
   auto *ctx = static_cast<ColumnarExecutionContext *>(
       thd->lex->secondary_engine_execution_context());

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1295,12 +1295,16 @@ bool BuildQueryBlockRequest(
   };
 
   // The request table order is the stable numbering used by scan, join,
-  // grouping, and aggregate argument references.
+  // grouping, and aggregate argument references. Real loaded tables come
+  // first; derived tables follow them and become server-side virtual tables.
   std::vector<QueryBlockTable> tables;
   std::vector<int> main_tables;
   std::vector<int> table_semijoin_nest;
+  std::vector<bool> table_is_virtual;
+  std::vector<Query_block *> virtual_blocks;
   for (Table_ref *table_ref = qb->leaf_tables; table_ref != nullptr;
        table_ref = table_ref->next_leaf) {
+    if (table_ref->is_view_or_derived()) continue;
     TABLE *table = table_ref->table;
     if (table == nullptr || table->s == nullptr) LDB_COL_REJECT("no TABLE");
     const int semijoin_nest = semijoin_nest_of(table_ref);
@@ -1310,6 +1314,7 @@ bool BuildQueryBlockRequest(
       LDB_COL_REJECT("not SECONDARY_LOADed");
     tables.push_back({table, table_ref->map()});
     table_semijoin_nest.push_back(semijoin_nest);
+    table_is_virtual.push_back(false);
     if (semijoin_nest < 0) {
       main_tables.push_back(static_cast<int>(tables.size()) - 1);
     } else {
@@ -1317,7 +1322,38 @@ bool BuildQueryBlockRequest(
           static_cast<int>(tables.size()) - 1);
     }
   }
+
+  const size_t real_table_count = tables.size();
+  for (Table_ref *table_ref = qb->leaf_tables; table_ref != nullptr;
+       table_ref = table_ref->next_leaf) {
+    if (!table_ref->is_view_or_derived()) continue;
+    if (table_ref->outer_join) LDB_COL_REJECT("outer derived table");
+    if (semijoin_nest_of(table_ref) >= 0) LDB_COL_REJECT("derived semijoin");
+    if (table_ref->table == nullptr) LDB_COL_REJECT("derived no TABLE");
+
+    Query_expression *derived_unit = table_ref->derived_query_expression();
+    if (derived_unit == nullptr || !derived_unit->is_simple())
+      LDB_COL_REJECT("derived not simple");
+    Query_block *derived_qb = derived_unit->first_query_block();
+    if (derived_qb == nullptr) LDB_COL_REJECT("derived no query block");
+
+    tables.push_back({table_ref->table, table_ref->map()});
+    table_semijoin_nest.push_back(-1);
+    table_is_virtual.push_back(true);
+    virtual_blocks.push_back(derived_qb);
+    main_tables.push_back(static_cast<int>(tables.size()) - 1);
+  }
   if (main_tables.empty()) LDB_COL_REJECT("no tables");
+
+  auto resolve_query_field = [&](const Field *field,
+                                 int table_idx) -> const Field * {
+    if (table_idx < 0 ||
+        table_idx >= static_cast<int>(table_is_virtual.size())) {
+      return nullptr;
+    }
+    if (table_is_virtual[table_idx]) return field;
+    return ResolveBaseField(field, tables[table_idx].table);
+  };
 
   struct JoinEdge {
     int left_table = -1;
@@ -1343,11 +1379,24 @@ bool BuildQueryBlockRequest(
     const table_map used = predicate->used_tables() & ~PSEUDO_TABLE_BITS;
     const int table_idx = SingleTableOf(used, tables);
     if (table_idx >= 0) {
+      if (table_is_virtual[table_idx]) {
+        tuple_predicates.push_back(predicate);
+        continue;
+      }
       table_filters[table_idx].push_back(predicate);
       continue;
     }
     if (used == 0) {
-      table_filters[main_tables[0]].push_back(predicate);
+      auto real_filter_table =
+          std::find_if(main_tables.begin(), main_tables.end(),
+                       [&](int candidate) {
+                         return !table_is_virtual[candidate];
+                       });
+      if (real_filter_table != main_tables.end()) {
+        table_filters[*real_filter_table].push_back(predicate);
+      } else {
+        tuple_predicates.push_back(predicate);
+      }
       continue;
     }
 
@@ -1432,9 +1481,9 @@ bool BuildQueryBlockRequest(
           }
 
           const Field *left_field =
-              ResolveBaseField(candidate.first, tables[left_table].table);
+              resolve_query_field(candidate.first, left_table);
           const Field *right_field =
-              ResolveBaseField(candidate.second, tables[right_table].table);
+              resolve_query_field(candidate.second, right_table);
           if (left_field == nullptr || right_field == nullptr) continue;
           join_edges.push_back(
               {left_table, right_table, left_field, right_field});
@@ -1470,14 +1519,13 @@ bool BuildQueryBlockRequest(
       LDB_COL_REJECT("non-integer join key");
     }
 
-    const Field *left_field =
-        ResolveBaseField(left_raw, tables[left_table].table);
-    const Field *right_field =
-        ResolveBaseField(right_raw, tables[right_table].table);
+    const Field *left_field = resolve_query_field(left_raw, left_table);
+    const Field *right_field = resolve_query_field(right_raw, right_table);
     if (left_field == nullptr || right_field == nullptr) {
       LDB_COL_REJECT("join key unresolvable");
     }
-    if (left_field->is_nullable() || right_field->is_nullable()) {
+    if ((!table_is_virtual[left_table] && left_field->is_nullable()) ||
+        (!table_is_virtual[right_table] && right_field->is_nullable())) {
       LDB_COL_REJECT("join key nullable");
     }
     join_edges.push_back({left_table, right_table, left_field, right_field});
@@ -1489,7 +1537,7 @@ bool BuildQueryBlockRequest(
   auto &request = *request_out;
   request.Clear();
   std::vector<int> scan_nodes(tables.size(), -1);
-  for (size_t table_idx = 0; table_idx < tables.size(); table_idx++) {
+  for (size_t table_idx = 0; table_idx < real_table_count; table_idx++) {
     TABLE *table = tables[table_idx].table;
     request.add_tables()->set_table_name(table->s->normalized_path.str);
     auto *scan_node = request.add_nodes();
@@ -1501,6 +1549,17 @@ bool BuildQueryBlockRequest(
                                scan->mutable_filter())) {
       LDB_COL_REJECT("filter not pushable");
     }
+  }
+
+  for (size_t table_idx = real_table_count; table_idx < tables.size();
+       table_idx++) {
+    auto *sub_block = request.add_nodes()->mutable_sub_block();
+    if (!BuildQueryBlockRequest(
+            nullptr, virtual_blocks[table_idx - real_table_count],
+            sub_block->mutable_block(), why)) {
+      return false;
+    }
+    scan_nodes[table_idx] = request.nodes_size() - 1;
   }
 
   // Build a left-deep INNER join tree by walking FROM order and retrying tables
@@ -1579,7 +1638,7 @@ bool BuildQueryBlockRequest(
       return TableIndexOfField(field, tables);
     };
     registry.resolve = [&](const Field *field, int table_idx) {
-      return ResolveBaseField(field, tables[table_idx].table);
+      return resolve_query_field(field, table_idx);
     };
 
     auto *predicate = tuple_filter->mutable_predicate();
@@ -1654,9 +1713,9 @@ bool BuildQueryBlockRequest(
       }
 
       const Field *outer_field =
-          ResolveBaseField(raw_outer_field, tables[outer_table].table);
+          resolve_query_field(raw_outer_field, outer_table);
       const Field *inner_field =
-          ResolveBaseField(raw_inner_field, tables[inner_key_table].table);
+          resolve_query_field(raw_inner_field, inner_key_table);
       if (outer_field == nullptr || inner_field == nullptr) {
         LDB_COL_REJECT("semijoin key unresolvable");
       }
@@ -1675,7 +1734,7 @@ bool BuildQueryBlockRequest(
         return TableIndexOfField(field, tables);
       };
       registry.resolve = [&](const Field *field, int table_idx) {
-        return ResolveBaseField(field, tables[table_idx].table);
+        return resolve_query_field(field, table_idx);
       };
 
       auto *residual = join_node->mutable_residual();
@@ -1724,10 +1783,10 @@ bool BuildQueryBlockRequest(
     if (const Field *year_field = ExtractYearField(group_item)) {
       const int group_table = TableIndexOfField(year_field, tables);
       const Field *group_field =
-          group_table >= 0
-              ? ResolveBaseField(year_field, tables[group_table].table)
-              : nullptr;
-      if (group_field == nullptr || group_field->is_nullable()) {
+          group_table >= 0 ? resolve_query_field(year_field, group_table)
+                           : nullptr;
+      if (group_field == nullptr ||
+          (!table_is_virtual[group_table] && group_field->is_nullable())) {
         LDB_COL_REJECT("group year column");
       }
 
@@ -1748,10 +1807,11 @@ bool BuildQueryBlockRequest(
     const int group_table = TableIndexOfField(raw_group_field, tables);
     if (group_table < 0) LDB_COL_REJECT("group column foreign");
     const Field *group_field =
-        ResolveBaseField(raw_group_field, tables[group_table].table);
+        resolve_query_field(raw_group_field, group_table);
     if (group_field == nullptr) LDB_COL_REJECT("group column foreign");
-    if (group_field->is_nullable() ||
-        !GroupColumnIsBinarySafe(group_field)) {
+    if ((!table_is_virtual[group_table] && group_field->is_nullable()) ||
+        (!table_is_virtual[group_table] &&
+         !GroupColumnIsBinarySafe(group_field))) {
       LDB_COL_REJECT("group column not binary-safe");
     }
 
@@ -1794,10 +1854,11 @@ bool BuildQueryBlockRequest(
             const int count_table = TableIndexOfField(raw_count_field, tables);
             const Field *count_field =
                 count_table >= 0
-                    ? ResolveBaseField(raw_count_field,
-                                       tables[count_table].table)
+                    ? resolve_query_field(raw_count_field, count_table)
                     : nullptr;
-            if (count_field == nullptr || count_field->is_nullable()) {
+            if (count_field == nullptr ||
+                (!table_is_virtual[count_table] &&
+                 count_field->is_nullable())) {
               aggregate_error = "COUNT arg nullable";
               return -1;
             }
@@ -1866,8 +1927,8 @@ bool BuildQueryBlockRequest(
                 then_expr->real_item()->type() == Item::FIELD_ITEM) {
               const Field *raw_argument_field =
                   down_cast<Item_field *>(then_expr->real_item())->field;
-              const Field *argument_field = ResolveBaseField(
-                  raw_argument_field, tables[argument_table].table);
+              const Field *argument_field =
+                  resolve_query_field(raw_argument_field, argument_table);
               if (argument_field == nullptr) {
                 aggregate_error = "CASE expression unresolvable";
                 return -1;
@@ -1912,8 +1973,8 @@ bool BuildQueryBlockRequest(
         if (argument_table >= 0 && arg->type() == Item::FIELD_ITEM) {
           const Field *raw_argument_field =
               down_cast<Item_field *>(arg)->field;
-          const Field *argument_field = ResolveBaseField(
-              raw_argument_field, tables[argument_table].table);
+          const Field *argument_field =
+              resolve_query_field(raw_argument_field, argument_table);
           if (argument_field == nullptr) {
             aggregate_error = "aggregate arg unresolvable";
             return -1;
@@ -1964,18 +2025,19 @@ bool BuildQueryBlockRequest(
             TableIndexOfField(raw_argument_field, tables);
         const Field *argument_field =
             argument_table >= 0
-                ? ResolveBaseField(raw_argument_field,
-                                   tables[argument_table].table)
+                ? resolve_query_field(raw_argument_field, argument_table)
                 : nullptr;
         if (argument_field == nullptr) {
           aggregate_error = "minmax unresolvable";
           return -1;
         }
-        if (argument_field->is_nullable()) {
+        if (!table_is_virtual[argument_table] &&
+            argument_field->is_nullable()) {
           aggregate_error = "minmax nullable";
           return -1;
         }
-        if (argument_field->result_type() == STRING_RESULT &&
+        if (!table_is_virtual[argument_table] &&
+            argument_field->result_type() == STRING_RESULT &&
             !argument_field->binary()) {
           aggregate_error = "minmax collation";
           return -1;
@@ -2074,8 +2136,7 @@ bool BuildQueryBlockRequest(
       const int output_table = TableIndexOfField(raw_output_field, tables);
       const Field *output_field =
           output_table >= 0
-              ? ResolveBaseField(raw_output_field,
-                                 tables[output_table].table)
+              ? resolve_query_field(raw_output_field, output_table)
               : nullptr;
       if (output_field == nullptr)
         LDB_COL_REJECT("output column unresolvable");
@@ -2193,7 +2254,7 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
   if (qb->leaf_tables != nullptr && qb->leaf_tables->next_leaf == nullptr &&
       qb->leaf_tables->is_view_or_derived()) {
     if (RecognizeDerivedRegroup(join, ctx, why)) return true;
-    return RecognizeFlattenedAggregate(join, ctx, why);
+    if (RecognizeFlattenedAggregate(join, ctx, why)) return true;
   }
 
   if (!BuildQueryBlockRequest(join, qb, &ctx->query_block_request, why)) {

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -774,6 +774,339 @@ bool RecognizeDerivedRegroup(JOIN *join, ColumnarExecutionContext *ctx,
 }
 
 /**
+ * @brief Recognize an outer aggregate over a non-aggregating derived join.
+ *
+ * The outer block groups and aggregates columns exposed by a derived table.
+ * This recognizer dereferences those derived columns back to the inner SELECT
+ * expressions, then builds one server query block over the inner base tables.
+ */
+bool RecognizeFlattenedAggregate(JOIN *join, ColumnarExecutionContext *ctx,
+                                 const char **why) {
+#define LDB_COL_REJECT(reason) \
+  do {                         \
+    *why = (reason);           \
+    return false;              \
+  } while (0)
+
+  Query_block *qb = join->query_block;
+  Table_ref *derived_ref = qb->leaf_tables;
+  if (derived_ref == nullptr || derived_ref->next_leaf != nullptr ||
+      !derived_ref->is_view_or_derived() || derived_ref->table == nullptr) {
+    LDB_COL_REJECT("not single derived table");
+  }
+
+  Query_expression *inner_unit = derived_ref->derived_query_expression();
+  if (inner_unit == nullptr || !inner_unit->is_simple())
+    LDB_COL_REJECT("derived not simple");
+  Query_block *inner_qb = inner_unit->first_query_block();
+  if (inner_qb == nullptr) LDB_COL_REJECT("no inner query block");
+
+  if (qb->having_cond() != nullptr) LDB_COL_REJECT("outer has HAVING");
+  if (qb->is_distinct()) LDB_COL_REJECT("outer has DISTINCT");
+  if (qb->has_windows()) LDB_COL_REJECT("outer has windows");
+  if (qb->olap != UNSPECIFIED_OLAP_TYPE) LDB_COL_REJECT("outer has ROLLUP");
+  if (qb->where_cond() != nullptr) LDB_COL_REJECT("outer has WHERE");
+  if (qb->group_list.elements == 0) LDB_COL_REJECT("outer not grouped");
+
+  if (inner_qb->having_cond() != nullptr) LDB_COL_REJECT("inner has HAVING");
+  if (inner_qb->is_distinct()) LDB_COL_REJECT("inner has DISTINCT");
+  if (inner_qb->has_windows()) LDB_COL_REJECT("inner has windows");
+  if (inner_qb->olap != UNSPECIFIED_OLAP_TYPE)
+    LDB_COL_REJECT("inner has ROLLUP");
+  if (inner_qb->group_list.elements > 0 || inner_qb->with_sum_func)
+    LDB_COL_REJECT("inner has aggregation");
+  if (inner_qb->order_list.elements > 0 || inner_qb->has_limit())
+    LDB_COL_REJECT("inner has order or limit");
+
+  std::vector<QueryBlockTable> tables;
+  for (Table_ref *table_ref = inner_qb->leaf_tables; table_ref != nullptr;
+       table_ref = table_ref->next_leaf) {
+    TABLE *table = table_ref->table;
+    if (table == nullptr || table->s == nullptr)
+      LDB_COL_REJECT("inner no TABLE");
+    if (table_ref->outer_join) LDB_COL_REJECT("inner outer join");
+    if (!loaded_tables->contains(table->s->db.str, table->s->table_name.str))
+      LDB_COL_REJECT("inner not SECONDARY_LOADed");
+    tables.push_back({table, table_ref->map()});
+  }
+  if (tables.size() < 2) LDB_COL_REJECT("inner too few tables");
+
+  std::vector<Item *> inner_outputs;
+  for (Item *item : VisibleFields(inner_qb->fields)) {
+    inner_outputs.push_back(item);
+  }
+
+  auto dereference_derived_item = [&](Item *item) -> Item * {
+    Item *real = item->real_item();
+    if (real->type() != Item::FIELD_ITEM) return real;
+    const Field *field = down_cast<Item_field *>(real)->field;
+    if (field == nullptr || field->table != derived_ref->table) return real;
+    const uint32_t field_idx = field->field_index();
+    if (field_idx >= inner_outputs.size()) return nullptr;
+    return inner_outputs[field_idx]->real_item();
+  };
+
+  struct JoinEdge {
+    int left_table = -1;
+    int right_table = -1;
+    const Field *left_field = nullptr;
+    const Field *right_field = nullptr;
+  };
+
+  std::vector<std::vector<Item *>> table_filters(tables.size());
+  std::vector<JoinEdge> join_edges;
+  std::vector<Item *> predicates;
+  FlattenAnd(inner_qb->where_cond(), &predicates);
+  for (Item *predicate : predicates) {
+    const table_map used = predicate->used_tables() & ~PSEUDO_TABLE_BITS;
+    const int table_idx = SingleTableOf(used, tables);
+    if (table_idx >= 0) {
+      table_filters[table_idx].push_back(predicate);
+      continue;
+    }
+    if (used == 0) {
+      table_filters[0].push_back(predicate);
+      continue;
+    }
+
+    if (predicate->type() != Item::FUNC_ITEM ||
+        down_cast<Item_func *>(predicate)->functype() != Item_func::EQ_FUNC) {
+      LDB_COL_REJECT("inner non-equi predicate");
+    }
+    auto *equals = down_cast<Item_func *>(predicate);
+    Item *left = equals->arguments()[0]->real_item();
+    Item *right = equals->arguments()[1]->real_item();
+    if (left->type() != Item::FIELD_ITEM ||
+        right->type() != Item::FIELD_ITEM) {
+      LDB_COL_REJECT("inner join key shape");
+    }
+
+    const Field *left_raw = down_cast<Item_field *>(left)->field;
+    const Field *right_raw = down_cast<Item_field *>(right)->field;
+    const int left_table = TableIndexOfField(left_raw, tables);
+    const int right_table = TableIndexOfField(right_raw, tables);
+    if (left_table < 0 || right_table < 0 || left_table == right_table) {
+      LDB_COL_REJECT("inner join key tables");
+    }
+    if (left_raw->result_type() != INT_RESULT ||
+        right_raw->result_type() != INT_RESULT) {
+      LDB_COL_REJECT("inner join key type");
+    }
+
+    const Field *left_field =
+        ResolveBaseField(left_raw, tables[left_table].table);
+    const Field *right_field =
+        ResolveBaseField(right_raw, tables[right_table].table);
+    if (left_field == nullptr || right_field == nullptr) {
+      LDB_COL_REJECT("inner join key unresolvable");
+    }
+    join_edges.push_back(
+        {left_table, right_table, left_field, right_field});
+  }
+  if (join_edges.empty()) LDB_COL_REJECT("inner cross join");
+
+  auto &request = ctx->query_block_request;
+  request.Clear();
+  std::vector<int> scan_nodes(tables.size(), -1);
+  for (size_t table_idx = 0; table_idx < tables.size(); table_idx++) {
+    TABLE *table = tables[table_idx].table;
+    request.add_tables()->set_table_name(table->s->normalized_path.str);
+    auto *scan = request.add_nodes()->mutable_scan();
+    scan->set_table_idx(static_cast<uint32_t>(table_idx));
+    scan_nodes[table_idx] = request.nodes_size() - 1;
+    if (!table_filters[table_idx].empty() &&
+        !SerializeTableFilters(table_filters[table_idx], table,
+                               scan->mutable_filter())) {
+      LDB_COL_REJECT("inner filter not pushable");
+    }
+  }
+
+  int current_node = scan_nodes[0];
+  std::vector<bool> joined(tables.size(), false);
+  joined[0] = true;
+  std::vector<int> pending_tables;
+  for (size_t table_idx = 1; table_idx < tables.size(); table_idx++) {
+    pending_tables.push_back(static_cast<int>(table_idx));
+  }
+  while (!pending_tables.empty()) {
+    int table_idx = -1;
+    size_t pending_idx = 0;
+    for (size_t idx = 0; idx < pending_tables.size(); idx++) {
+      for (const JoinEdge &edge : join_edges) {
+        if ((edge.left_table == pending_tables[idx] &&
+             joined[edge.right_table]) ||
+            (edge.right_table == pending_tables[idx] &&
+             joined[edge.left_table])) {
+          table_idx = pending_tables[idx];
+          pending_idx = idx;
+          break;
+        }
+      }
+      if (table_idx >= 0) break;
+    }
+    if (table_idx < 0) LDB_COL_REJECT("inner disconnected");
+    pending_tables.erase(pending_tables.begin() + pending_idx);
+
+    auto *join_node = request.add_nodes()->mutable_join();
+    join_node->set_type(LineairDB::Protocol::QueryBlockJoin::INNER);
+    join_node->set_build(scan_nodes[table_idx]);
+    join_node->set_probe(current_node);
+    bool connected = false;
+    for (const JoinEdge &edge : join_edges) {
+      const Field *build_field = nullptr;
+      const Field *probe_field = nullptr;
+      int probe_table = -1;
+      if (edge.left_table == table_idx && joined[edge.right_table]) {
+        build_field = edge.left_field;
+        probe_field = edge.right_field;
+        probe_table = edge.right_table;
+      } else if (edge.right_table == table_idx &&
+                 joined[edge.left_table]) {
+        build_field = edge.right_field;
+        probe_field = edge.left_field;
+        probe_table = edge.left_table;
+      } else {
+        continue;
+      }
+
+      auto *build_key = join_node->add_build_keys();
+      build_key->set_table_idx(static_cast<uint32_t>(table_idx));
+      build_key->set_column(build_field->field_index());
+      auto *probe_key = join_node->add_probe_keys();
+      probe_key->set_table_idx(static_cast<uint32_t>(probe_table));
+      probe_key->set_column(probe_field->field_index());
+      connected = true;
+    }
+    if (!connected) LDB_COL_REJECT("inner disconnected");
+    joined[table_idx] = true;
+    current_node = request.nodes_size() - 1;
+  }
+
+  auto *aggregate = request.add_nodes()->mutable_aggregate();
+  aggregate->set_input(current_node);
+  std::vector<Item *> group_outer_items;
+  for (ORDER *group = qb->group_list.first; group != nullptr;
+       group = group->next) {
+    Item *outer = (*group->item)->real_item();
+    Item *inner = dereference_derived_item(outer);
+    if (inner == nullptr) LDB_COL_REJECT("group dereference");
+
+    auto *group_column = aggregate->add_group_columns();
+    if (const Field *year_field = ExtractYearField(inner)) {
+      const int table_idx = TableIndexOfField(year_field, tables);
+      const Field *field =
+          table_idx >= 0
+              ? ResolveBaseField(year_field, tables[table_idx].table)
+              : nullptr;
+      if (field == nullptr || field->is_nullable()) {
+        LDB_COL_REJECT("group year column");
+      }
+      group_column->set_table_idx(static_cast<uint32_t>(table_idx));
+      group_column->set_column(field->field_index());
+      group_column->set_prefix_len(4);
+      group_column->set_cmp_kind(0);
+    } else if (inner->type() == Item::FIELD_ITEM) {
+      const Field *raw_field = down_cast<Item_field *>(inner)->field;
+      const int table_idx = TableIndexOfField(raw_field, tables);
+      const Field *field =
+          table_idx >= 0
+              ? ResolveBaseField(raw_field, tables[table_idx].table)
+              : nullptr;
+      if (field == nullptr || field->is_nullable() ||
+          !GroupColumnIsBinarySafe(field)) {
+        LDB_COL_REJECT("group column not binary-safe");
+      }
+      group_column->set_table_idx(static_cast<uint32_t>(table_idx));
+      group_column->set_column(field->field_index());
+      group_column->set_cmp_kind(field->result_type() == STRING_RESULT ? 1
+                                                                       : 0);
+    } else {
+      LDB_COL_REJECT("group expression");
+    }
+    group_outer_items.push_back(outer);
+  }
+
+  std::vector<Item *> output_items;
+  for (Item *item : VisibleFields(qb->fields)) output_items.push_back(item);
+  for (Item *item : output_items) {
+    Item *real = item->real_item();
+    auto *output = request.add_output();
+    if (real->type() == Item::FIELD_ITEM) {
+      int group_position = -1;
+      for (size_t group_idx = 0; group_idx < group_outer_items.size();
+           group_idx++) {
+        Item *group_item = group_outer_items[group_idx];
+        if (group_item == real ||
+            (group_item->type() == Item::FIELD_ITEM &&
+             down_cast<Item_field *>(group_item)->field ==
+                 down_cast<Item_field *>(real)->field)) {
+          group_position = static_cast<int>(group_idx);
+          break;
+        }
+      }
+      if (group_position < 0) LDB_COL_REJECT("output not grouped");
+      output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::GROUP);
+      output->set_ordinal(group_position);
+      continue;
+    }
+
+    if (real->type() != Item::SUM_FUNC_ITEM)
+      LDB_COL_REJECT("output shape");
+    Item_sum *sum = down_cast<Item_sum *>(real);
+    if (sum->sum_func() != Item_sum::SUM_FUNC ||
+        sum->argument_count() != 1) {
+      LDB_COL_REJECT("aggregate kind");
+    }
+    Item *arg = dereference_derived_item(sum->get_arg(0));
+    if (arg == nullptr) LDB_COL_REJECT("aggregate dereference");
+    if (arg->result_type() != DECIMAL_RESULT &&
+        arg->result_type() != INT_RESULT) {
+      LDB_COL_REJECT("aggregate arg type");
+    }
+
+    auto *function = aggregate->add_aggs();
+    function->set_kind(LineairDB::Protocol::QueryBlockAggFunc::SUM);
+    function->set_arg_table(0);
+    function->set_arg_scale(arg->decimals);
+    if (!SerializeAggregateExpressionForTables(arg, tables, 0,
+                                               function->mutable_arg())) {
+      LDB_COL_REJECT("aggregate expr not pushable");
+    }
+    output->set_source(LineairDB::Protocol::QueryBlockOutputExpr::AGG);
+    output->set_ordinal(aggregate->aggs_size() - 1);
+  }
+  if (aggregate->aggs_size() == 0) LDB_COL_REJECT("no aggregates");
+
+  for (ORDER *order = qb->order_list.first; order != nullptr;
+       order = order->next) {
+    const int output_ordinal = OrderOutputOrdinal(*order->item, output_items);
+    if (output_ordinal < 0) LDB_COL_REJECT("outer ORDER BY");
+    auto *sort_key = request.add_order_by();
+    sort_key->set_output_ordinal(output_ordinal);
+    sort_key->set_descending(order->direction == ORDER_DESC);
+    Item *output_item = output_items[output_ordinal]->real_item();
+    sort_key->set_cmp_kind(output_item->result_type() == STRING_RESULT ? 1 : 0);
+  }
+
+  Query_expression *outer_unit = qb->master_query_expression();
+  if (qb->has_limit()) {
+    if (outer_unit->select_limit_cnt != HA_POS_ERROR)
+      request.set_limit(outer_unit->select_limit_cnt);
+    if (outer_unit->offset_limit_cnt > 0) {
+      request.set_offset(outer_unit->offset_limit_cnt);
+      if (request.limit() > 0)
+        request.set_limit(request.limit() - outer_unit->offset_limit_cnt);
+    }
+  }
+
+  ctx->query_block_ready = true;
+  *why = nullptr;
+  return true;
+
+#undef LDB_COL_REJECT
+}
+
+/**
  * @brief Recognize aggregate query blocks supported by LINEAIRDB_COLUMNAR.
  *
  * Unsupported shapes return false and set `why`; callers convert that into a
@@ -801,7 +1134,8 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
 
   if (qb->leaf_tables != nullptr && qb->leaf_tables->next_leaf == nullptr &&
       qb->leaf_tables->is_view_or_derived()) {
-    return RecognizeDerivedRegroup(join, ctx, why);
+    if (RecognizeDerivedRegroup(join, ctx, why)) return true;
+    return RecognizeFlattenedAggregate(join, ctx, why);
   }
 
   if (qb->having_cond() != nullptr) LDB_COL_REJECT("has HAVING");

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -1821,6 +1821,13 @@ bool BuildQueryBlockRequest(
     std::map<int, double> node_rows;
     size_t next_virtual_table = real_table_count;
 
+    // Missing optimizer row estimates are treated as huge so they cannot pass
+    // small-side guards or win semi-filter source selection.
+    constexpr double kUnknownRowEstimate = 1e30;
+    // Keyless INNER joins are cross products. Allow them only when one side is
+    // clearly small; larger shapes stay rejected.
+    constexpr double kTinyKeylessInnerJoinRows = 100.0;
+
     struct MappedJoinKey {
       LineairDB::Protocol::QueryBlockJoin::Type join_type;
       int build_node = -1;
@@ -2001,7 +2008,16 @@ bool BuildQueryBlockRequest(
             break;
           }
         }
-        if (!build_is_one_row) {
+        const double probe_rows =
+            node_rows.count(probe) != 0 ? node_rows[probe]
+                                        : kUnknownRowEstimate;
+        const double build_rows =
+            node_rows.count(build) != 0 ? node_rows[build]
+                                        : kUnknownRowEstimate;
+        const bool tiny_inner_join =
+            join_type == LineairDB::Protocol::QueryBlockJoin::INNER &&
+            std::min(probe_rows, build_rows) <= kTinyKeylessInnerJoinRows;
+        if (!build_is_one_row && !tiny_inner_join) {
           *why = "plan keyless join";
           return -1;
         }
@@ -2357,7 +2373,8 @@ bool BuildQueryBlockRequest(
               }
               const auto rows_it = node_rows.find(partner_node);
               consider(partner_node,
-                       rows_it == node_rows.end() ? 1e30 : rows_it->second,
+                       rows_it == node_rows.end() ? kUnknownRowEstimate
+                                                  : rows_it->second,
                        key_source_table, key_source_column,
                        key_target_column);
             };

--- a/proxy/ha_lineairdb_columnar.hh
+++ b/proxy/ha_lineairdb_columnar.hh
@@ -16,11 +16,17 @@ class Table;
 namespace lineairdb_columnar {
 
 /**
- * @brief Secondary engine handler for the LINEAIRDB_COLUMNAR plugin.
+ * @brief MySQL secondary engine handler for LINEAIRDB_COLUMNAR.
  *
- * The handler owns the MySQL secondary-engine lifecycle. SECONDARY_LOAD records
- * that a table may be opened through this engine; table data still lives in
- * LineairDB and is not copied into a separate store.
+ * This is the table-facing handler MySQL opens after a table is assigned to
+ * LINEAIRDB_COLUMNAR and marked with SECONDARY_LOAD. Loading only records that
+ * the table may be opened through this plugin; rows stay in LineairDB/PAX
+ * storage and are shared with the primary LineairDB handler.
+ *
+ * Row-access methods are intentionally inert. Supported SELECT blocks run
+ * through JOIN::override_executor_func after optimize_secondary_engine accepts
+ * their shape; unsupported blocks reject from the secondary path and can retry
+ * on the primary engine when use_secondary_engine=ON.
  */
 class ha_lineairdb_columnar : public handler {
  public:

--- a/proxy/ha_lineairdb_columnar.hh
+++ b/proxy/ha_lineairdb_columnar.hh
@@ -1,0 +1,60 @@
+#ifndef HA_LINEAIRDB_COLUMNAR_HH
+#define HA_LINEAIRDB_COLUMNAR_HH
+
+#include "my_base.h"
+#include "sql/handler.h"
+#include "thr_lock.h"
+
+class THD;
+struct TABLE;
+struct TABLE_SHARE;
+
+namespace dd {
+class Table;
+}
+
+namespace lineairdb_columnar {
+
+/**
+ * @brief Secondary engine handler for the LINEAIRDB_COLUMNAR plugin.
+ *
+ * The handler owns the MySQL secondary-engine lifecycle. SECONDARY_LOAD records
+ * that a table may be opened through this engine; table data still lives in
+ * LineairDB and is not copied into a separate store.
+ */
+class ha_lineairdb_columnar : public handler {
+ public:
+  ha_lineairdb_columnar(handlerton *hton, TABLE_SHARE *table_share_arg);
+
+  int create(const char *, TABLE *, HA_CREATE_INFO *, dd::Table *) override {
+    return HA_ERR_WRONG_COMMAND;
+  }
+  int open(const char *name, int mode, unsigned int test_if_locked,
+           const dd::Table *table_def) override;
+  int close() override { return 0; }
+  int rnd_init(bool) override { return 0; }
+  int rnd_next(unsigned char *) override { return HA_ERR_END_OF_FILE; }
+  int rnd_pos(unsigned char *, unsigned char *) override {
+    return HA_ERR_WRONG_COMMAND;
+  }
+  int info(unsigned int flags) override;
+  ha_rows records_in_range(unsigned int index, key_range *min_key,
+                           key_range *max_key) override;
+  void position(const unsigned char *) override {}
+  unsigned long index_flags(unsigned int index, unsigned int part,
+                            bool all_parts) const override;
+  THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
+                             thr_lock_type lock_type) override;
+  Table_flags table_flags() const override { return HA_NO_INDEX_ACCESS; }
+  const char *table_type() const override { return "LINEAIRDB_COLUMNAR"; }
+  int load_table(const TABLE &table) override;
+  int unload_table(const char *db_name, const char *table_name,
+                   bool error_if_not_loaded) override;
+
+ private:
+  THR_LOCK_DATA lock_data_;
+};
+
+}  // namespace lineairdb_columnar
+
+#endif  // HA_LINEAIRDB_COLUMNAR_HH

--- a/proxy/index_scan.cc
+++ b/proxy/index_scan.cc
@@ -144,6 +144,14 @@ int ha_lineairdb::index_read_map(uchar *buf, const uchar *key,
   // The optimizer has run, so the SELECT/generic-DML QEP is available.
   if (int err = maybe_prefetch_for_statement(ha_thd(), tx, table)) return err;
 
+  if (tx->grouped_summary_skipped(table) && key == nullptr) {
+    reset_index_search_buffers();
+    last_fetched_primary_key_.clear();
+    if (int err = fill_grouped_summary_buffers(tx)) return err;
+    if (secondary_index_results_.empty()) return HA_ERR_END_OF_FILE;
+    return fetch_and_set_current_result(buf, tx);
+  }
+
   build_search_plan(key, keypart_map, find_flag, key_info);
 
   return execute_plan(buf, tx);

--- a/proxy/lineairdb_autogen.cc
+++ b/proxy/lineairdb_autogen.cc
@@ -138,20 +138,14 @@ bool is_int32_key_field(const Field *f) {
          f->pack_length() == 4 && !f->is_unsigned();
 }
 
-// Physical-table key from a TABLE's own share: "./<db>/<table>", matching the
-// path ha_lineairdb::open() stores in db_table_name.
+// Handler table key from the TABLE share path. MySQL passes the same normalized
+// path to ha_lineairdb::open(), and the handler stores it as db_table_name.
 std::string physical_table_key(const TABLE *t) {
   if (t == nullptr || t->s == nullptr) return std::string();
   const TABLE_SHARE *s = t->s;
-  std::string key = "./";
-  if (s->db.str != nullptr && s->db.length > 0) {
-    key.append(s->db.str, s->db.length);
-  }
-  key.push_back('/');
-  if (s->table_name.str != nullptr && s->table_name.length > 0) {
-    key.append(s->table_name.str, s->table_name.length);
-  }
-  return key;
+  if (s->normalized_path.str == nullptr || s->normalized_path.length == 0)
+    return std::string();
+  return std::string(s->normalized_path.str, s->normalized_path.length);
 }
 
 int qep_table_field_index(TABLE *t, Field *f) {

--- a/proxy/lineairdb_autogen.cc
+++ b/proxy/lineairdb_autogen.cc
@@ -1589,6 +1589,56 @@ bool autogen_read_plan_from_qep(
     }
   }
 
+  // Grouped semijoin: prepend the inner GROUP BY/HAVING aggregate step and use
+  // its group keys as a membership set for the plain outer scan.
+  if (allow_filter_pushdown) {
+    LineairDBTransaction *query_tx = find_tx();
+    if (query_tx != nullptr && !query_tx->grouped_semijoins().empty()) {
+      for (const auto &grouped_semijoin : query_tx->grouped_semijoins()) {
+        int outer_idx = -1;
+        for (size_t i = 0; i < steps.size(); ++i) {
+          const auto &step = steps[i];
+          if (step.is_scan && !step.for_each &&
+              step.table_name == grouped_semijoin.outer_table_key &&
+              step.aggregate_serialized.empty() && step.index_name.empty() &&
+              step.key_prefix.empty() &&
+              step.end_key_prefix == lineairdb_keyenc::scan_end_sentinel() &&
+              step.scan_limit == 0 && step.semijoins.empty()) {
+            outer_idx = static_cast<int>(i);
+            break;
+          }
+        }
+        if (outer_idx < 0) continue;
+
+        LineairDBProxy::ReadPlanStep aggregate_step;
+        aggregate_step.table_name = grouped_semijoin.inner_table_key;
+        aggregate_step.is_scan = true;
+        aggregate_step.for_each = false;
+        aggregate_step.end_key_prefix = lineairdb_keyenc::scan_end_sentinel();
+        aggregate_step.aggregate_serialized = grouped_semijoin.agg_spec;
+        aggregate_step.serialized_filter = grouped_semijoin.having_filter;
+
+        steps.insert(steps.begin(), std::move(aggregate_step));
+        step_aliases.insert(step_aliases.begin(), {});
+        for (auto &step : steps) {
+          for (auto &binding : step.bindings) ++binding.source_step;
+          for (auto &binding : step.end_bindings) ++binding.source_step;
+          for (auto &semijoin : step.semijoins) ++semijoin.source_step;
+        }
+        for (auto &kv : table_steps) {
+          if (kv.second >= 0) ++kv.second;
+        }
+
+        LineairDBProxy::ReadPlanStep::Semijoin semijoin;
+        semijoin.source_step = 0;
+        semijoin.source_column = 0;
+        semijoin.probe_column = grouped_semijoin.outer_probe_column;
+        steps[static_cast<size_t>(outer_idx + 1)].semijoins.push_back(
+            std::move(semijoin));
+      }
+    }
+  }
+
   *out = std::move(steps);
   return true;
 }
@@ -1598,6 +1648,11 @@ void plan_projection_pushdown(
     std::unordered_map<std::string, std::vector<uint32_t>> *kept_out) {
   kept_out->clear();
   if (thd == nullptr || thd->lex == nullptr || steps == nullptr) return;
+
+  const auto source_is_aggregate = [&](uint32_t source_step) -> bool {
+    return source_step < steps->size() &&
+           !(*steps)[source_step].aggregate_serialized.empty();
+  };
 
   std::unordered_map<std::string, std::vector<bool>> union_rs;
   std::unordered_map<std::string, uint32_t> fields_of;
@@ -1655,6 +1710,7 @@ void plan_projection_pushdown(
   for (const auto &s : *steps) {
     for (const auto &sj : s.semijoins) {
       if (sj.source_step >= steps->size()) continue;
+      if (source_is_aggregate(sj.source_step)) continue;
       const std::string &src = (*steps)[sj.source_step].table_name;
       auto fo = fields_of.find(src);
       if (fo == fields_of.end()) continue;
@@ -1708,6 +1764,7 @@ void plan_projection_pushdown(
   for (auto &s : *steps) {
     for (auto &sj : s.semijoins) {
       if (sj.source_step >= steps->size()) continue;
+      if (source_is_aggregate(sj.source_step)) continue;
       auto it = full_to_proj.find((*steps)[sj.source_step].table_name);
       if (it == full_to_proj.end()) continue;
       const uint32_t fi = sj.source_column;
@@ -1717,6 +1774,7 @@ void plan_projection_pushdown(
   }
 
   for (auto &s : *steps) {
+    if (!s.aggregate_serialized.empty()) continue;
     auto it = kept_out->find(s.table_name);
     if (it == kept_out->end()) continue;
     s.projection = it->second;

--- a/proxy/lineairdb_autogen.cc
+++ b/proxy/lineairdb_autogen.cc
@@ -26,6 +26,8 @@
 #include "sql/table.h"
 #include "storage/lineairdb/ha_lineairdb.hh"
 
+extern handlerton *lineairdb_hton;
+
 namespace {
 
 struct UnsupportedQep {
@@ -1304,6 +1306,114 @@ bool autogen_read_plan_from_qep(
       for (auto &kv : table_steps) {
         if (kv.second >= 0 && kv.second < static_cast<int>(new_index.size()))
           kv.second = static_cast<int>(new_index[kv.second]);
+      }
+    }
+  }
+
+  LineairDBTransaction *tx = nullptr;
+  const auto find_tx = [&]() -> LineairDBTransaction * {
+    if (tx != nullptr) return tx;
+    for (const auto &aliases : step_aliases) {
+      for (TABLE *t : aliases) {
+        if (t == nullptr || t->file == nullptr || t->file->ht != lineairdb_hton)
+          continue;
+        tx = down_cast<ha_lineairdb *>(t->file)->tx_for_autogen();
+        return tx;
+      }
+    }
+    return nullptr;
+  };
+
+  // If aggregate pushdown registered a grouped summary leaf, drop the base
+  // full-scan step from prefetch staging. The handler will serve that TABLE*
+  // from synthetic GROUP rows instead of base rows.
+  if (allow_filter_pushdown) {
+    LineairDBTransaction *query_tx = find_tx();
+    if (query_tx != nullptr &&
+        query_tx->has_grouped_summary_registrations()) {
+      std::vector<bool> referenced(steps.size(), false);
+      for (const auto &step : steps) {
+        for (const auto &binding : step.bindings) {
+          if (binding.source_step < referenced.size())
+            referenced[binding.source_step] = true;
+        }
+        for (const auto &binding : step.end_bindings) {
+          if (binding.source_step < referenced.size())
+            referenced[binding.source_step] = true;
+        }
+        for (const auto &semijoin : step.semijoins) {
+          if (semijoin.source_step < referenced.size())
+            referenced[semijoin.source_step] = true;
+        }
+      }
+
+      std::vector<uint32_t> new_index(steps.size(), 0);
+      std::vector<bool> dropped(steps.size(), false);
+      std::vector<LineairDBProxy::ReadPlanStep> kept;
+      std::vector<std::vector<TABLE *>> kept_aliases;
+      kept.reserve(steps.size());
+      kept_aliases.reserve(step_aliases.size());
+
+      bool any_drop = false;
+      for (size_t i = 0; i < steps.size(); ++i) {
+        bool drop = steps[i].is_scan && !steps[i].for_each &&
+                    steps[i].key_prefix.empty() &&
+                    steps[i].end_key_prefix ==
+                        lineairdb_keyenc::scan_end_sentinel() &&
+                    steps[i].serialized_filter.empty() &&
+                    steps[i].scan_limit == 0 && !referenced[i] &&
+                    i < step_aliases.size() && !step_aliases[i].empty() &&
+                    steps[i].semijoins.empty();
+        if (drop) {
+          for (TABLE *alias : step_aliases[i]) {
+            if (alias == nullptr ||
+                query_tx->grouped_summary_registration(alias) == nullptr) {
+              drop = false;
+              break;
+            }
+          }
+        }
+        if (drop) {
+          for (TABLE *alias : step_aliases[i]) {
+            query_tx->mark_grouped_summary_skipped(alias);
+          }
+          dropped[i] = true;
+          any_drop = true;
+          continue;
+        }
+        new_index[i] = static_cast<uint32_t>(kept.size());
+        kept.push_back(std::move(steps[i]));
+        kept_aliases.push_back(std::move(step_aliases[i]));
+      }
+
+      steps = std::move(kept);
+      step_aliases = std::move(kept_aliases);
+      if (any_drop) {
+        for (auto &step : steps) {
+          for (auto &binding : step.bindings) {
+            if (binding.source_step < new_index.size())
+              binding.source_step = new_index[binding.source_step];
+          }
+          for (auto &binding : step.end_bindings) {
+            if (binding.source_step < new_index.size())
+              binding.source_step = new_index[binding.source_step];
+          }
+          for (auto &semijoin : step.semijoins) {
+            if (semijoin.source_step < new_index.size())
+              semijoin.source_step = new_index[semijoin.source_step];
+          }
+        }
+        for (auto it = table_steps.begin(); it != table_steps.end();) {
+          const int idx = it->second;
+          if (idx >= 0 && idx < static_cast<int>(dropped.size()) &&
+              dropped[idx]) {
+            it = table_steps.erase(it);
+          } else {
+            if (idx >= 0 && idx < static_cast<int>(new_index.size()))
+              it->second = static_cast<int>(new_index[idx]);
+            ++it;
+          }
+        }
       }
     }
   }

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -1277,7 +1277,9 @@ std::optional<SecondaryIndexEntry> LineairDBProxy::tx_fetch_last_secondary_entry
     return std::nullopt;
 }
 
-bool LineairDBProxy::db_create_table(const std::string& table_name) {
+bool LineairDBProxy::db_create_table(
+    const std::string& table_name,
+    const std::vector<uint32_t>& pax_field_max_bytes) {
     LOG_DEBUG("CLIENT: db_create_table called with table=%s", table_name.c_str());
     if (!connected_) {
         LOG_ERROR("RPC failed: Not connected to server");
@@ -1288,6 +1290,9 @@ bool LineairDBProxy::db_create_table(const std::string& table_name) {
     LineairDB::Protocol::DbCreateTable::Response response;
 
     request.set_table_name(table_name);
+    for (const uint32_t width : pax_field_max_bytes) {
+        request.add_pax_field_max_bytes(width);
+    }
 
     if (!send_protobuf_message(request, response, MessageType::DB_CREATE_TABLE)) {
         LOG_ERROR("RPC failed: Failed to send message to server");

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -430,6 +430,25 @@ LineairDBProxy::tx_stateless_batch_read(
     return results;
 }
 
+bool LineairDBProxy::tx_execute_query_block(
+    const LineairDB::Protocol::TxExecuteQueryBlock::Request& request,
+    LineairDB::Protocol::TxExecuteQueryBlock::Response* response) {
+    if (!connected_) {
+        LOG_ERROR("RPC failed: Not connected to server");
+        return false;
+    }
+    if (response == nullptr) {
+        LOG_ERROR("RPC failed: query block response is null");
+        return false;
+    }
+    if (!send_protobuf_message(request, *response,
+                               MessageType::TX_EXECUTE_QUERY_BLOCK)) {
+        LOG_ERROR("RPC failed: query block message");
+        return false;
+    }
+    return true;
+}
+
 LineairDBProxy::ReadPlanResult LineairDBProxy::tx_execute_read_plan(
     const std::vector<ReadPlanStep>& steps) {
     ReadPlanResult result;

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -255,6 +255,10 @@ public:
         const std::vector<StatelessReadKey>& keys);
     ReadPlanResult tx_execute_read_plan(
         const std::vector<ReadPlanStep>& steps);
+    // Send a prepared query-block request to the LineairDB server.
+    bool tx_execute_query_block(
+        const LineairDB::Protocol::TxExecuteQueryBlock::Request& request,
+        LineairDB::Protocol::TxExecuteQueryBlock::Response* response);
     bool tx_validate_and_commit(
         const std::vector<StatelessReadKey>& reads,
         const std::vector<uint64_t>& read_tids,

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -80,7 +80,10 @@ enum class MessageType : uint32_t {
     TX_STATELESS_BATCH_READ = 28,
     TX_VALIDATE_AND_COMMIT = 29,
     TX_EXECUTE_READ_PLAN = 30,
-    TX_GET_TABLE_STATS = 31
+    TX_GET_TABLE_STATS = 31,
+
+    // Secondary-engine computation pushdown.
+    TX_EXECUTE_QUERY_BLOCK = 36
 };
 
 /**

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -326,7 +326,11 @@ public:
                                                                                const std::string& end_key);
 
     // table/index management (non-transactional)
-    bool db_create_table(const std::string& table_name);
+    // Optional PAX storage cell widths. Entry 0 is the null-flags field; later
+    // entries follow TABLE::field order. Empty keeps the ordinary row layout.
+    bool db_create_table(
+        const std::string& table_name,
+        const std::vector<uint32_t>& pax_field_max_bytes = {});
     bool db_set_table(int64_t tx_id, const std::string& table_name);
     bool db_create_secondary_index(const std::string& table_name,
                                    const std::string& index_name,

--- a/proxy/lineairdb_pushdown.cc
+++ b/proxy/lineairdb_pushdown.cc
@@ -36,6 +36,12 @@
 // Predicate Pushdown: serialize MySQL Item tree → FilterExpr protobuf
 // ---------------------------------------------------------------------------
 
+static thread_local const SerializeColumnEncoder *g_column_encoder = nullptr;
+
+void set_serialize_column_encoder(const SerializeColumnEncoder *encoder) {
+  g_column_encoder = encoder;
+}
+
 const Item *ha_lineairdb::cond_push(const Item *cond) {
   DBUG_TRACE;
   pushed_filter_serialized_.clear();
@@ -61,6 +67,13 @@ const Item *ha_lineairdb::cond_push(const Item *cond) {
 bool serialize_item(const Item *item,
                     LineairDB::Protocol::FilterExpr *expr) {
   if (!item) return false;
+
+  // View and derived-table references point at the item that should be
+  // serialized.
+  if (item->type() == Item::REF_ITEM) {
+    const Item *real = const_cast<Item *>(item)->real_item();
+    if (real != nullptr && real != item) return serialize_item(real, expr);
+  }
 
   // Unwrap constant-propagation caches before reading their value.
   if (item->type() == Item::CACHE_ITEM) {
@@ -193,7 +206,13 @@ bool serialize_item(const Item *item,
       Field *field = field_item->field;
       if (!field) return false;
       expr->set_op(LineairDB::Protocol::FilterExpr::COLUMN_REF);
-      expr->set_column_index(field->field_index());
+      if (g_column_encoder != nullptr) {
+        const int encoded = (*g_column_encoder)(field);
+        if (encoded < 0) return false;
+        expr->set_column_index(static_cast<uint32_t>(encoded));
+      } else {
+        expr->set_column_index(field->field_index());
+      }
 
       // Set compare_type based on MySQL field type
       switch (field->result_type()) {

--- a/proxy/lineairdb_pushdown.hh
+++ b/proxy/lineairdb_pushdown.hh
@@ -1,17 +1,31 @@
 #ifndef LINEAIRDB_PUSHDOWN_HH
 #define LINEAIRDB_PUSHDOWN_HH
 
+#include <functional>
 #include <string>
 
 #include "lineairdb.pb.h"
 
 class Item;
+class Field;
 class THD;
 struct TABLE;
 class LineairDBTransaction;
 
 bool serialize_item(const Item *item,
                     LineairDB::Protocol::FilterExpr *expr);
+
+using SerializeColumnEncoder = std::function<int(const Field *)>;
+
+/**
+ * @brief Install a statement-local column encoder for predicate serialization.
+ *
+ * @details When unset, `serialize_item()` encodes `Item_field` references as
+ * the field index within one table. Joined tuple predicates can set this hook
+ * while serializing so each field becomes an ordinal in a tuple-wide column
+ * registry.
+ */
+void set_serialize_column_encoder(const SerializeColumnEncoder *encoder);
 
 bool prepare_select_filter_for_tx(THD *thd, TABLE *table,
                                   LineairDBTransaction *tx,

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -428,6 +428,17 @@ void LineairDBTransaction::execute_read_plan(
 
     if (step.index_name.empty()) {
       // Primary scan: cache row values and stage one primary range entry.
+      const bool aggregate_step = !step.aggregate_serialized.empty();
+      bool grouped_semijoin_aggregate_step = false;
+      if (aggregate_step) {
+        for (const auto& grouped_semijoin : grouped_semijoins_) {
+          if (grouped_semijoin.inner_table_key == step.table_name) {
+            grouped_semijoin_aggregate_step = true;
+            break;
+          }
+        }
+      }
+      std::vector<std::string> grouped_semijoin_group_rows;
       std::vector<std::pair<std::string, std::string>> rows;
       std::vector<uint64_t> row_tids;
       rows.reserve(step_result.scan_keys.size());
@@ -440,16 +451,27 @@ void LineairDBTransaction::execute_read_plan(
         const uint64_t tid =
             j < step_result.scan_tids.size() ? step_result.scan_tids[j] : 0;
         const bool found = !value.empty();
-        record_row_cache(step.table_name, key, found, value, tid, true);
+        if (!aggregate_step) {
+          record_row_cache(step.table_name, key, found, value, tid, true);
+        }
         if (found) {
+          if (grouped_semijoin_aggregate_step) {
+            grouped_semijoin_group_rows.push_back(value);
+          }
           rows.emplace_back(std::move(key), std::move(value));
           row_tids.push_back(tid);
         }
       }
-      push_range_scan_cache(
-          {step.table_name, step_result.actual_start_key,
-           step_result.actual_end_key, step.reverse_scan, step.scan_limit,
-           std::move(rows), std::move(row_tids)});
+      if (grouped_semijoin_aggregate_step) {
+        cache_grouped_semijoin_group_rows(
+            step.table_name, std::move(grouped_semijoin_group_rows));
+      }
+      LocalRangeScanEntry entry{
+          step.table_name, step_result.actual_start_key,
+          step_result.actual_end_key, step.reverse_scan, step.scan_limit,
+          std::move(rows), std::move(row_tids)};
+      entry.aggregate_rows = aggregate_step;
+      push_range_scan_cache(std::move(entry));
       // Rejected primary keys become local not-found answers for later point
       // probes into this filtered scan.
       for (auto& fk : step_result.filtered_keys) {
@@ -1284,6 +1306,23 @@ void LineairDBTransaction::abort_prefetch_cache_miss(
   thd_mark_transaction_to_rollback(thread, 1);
 }
 
+bool LineairDBTransaction::execute_read_plan_raw(
+    const std::vector<LineairDBProxy::ReadPlanStep>& steps,
+    std::vector<std::string>* values) {
+  if (values == nullptr || steps.empty()) return false;
+  if (!ro_novalidate_) return false;
+
+  LineairDBProxy::ReadPlanResult result =
+      lineairdb_proxy->tx_execute_read_plan(steps);
+  if (!result.ok || result.steps.size() != steps.size()) {
+    rpc_trace_.record_local_view("abort_read_plan_raw_rpc");
+    is_aborted_ = true;
+    return false;
+  }
+  *values = std::move(result.steps[0].scan_values);
+  return true;
+}
+
 void LineairDBTransaction::push_range_scan_cache(LocalRangeScanEntry entry) {
   range_scan_start_index_[scan_cache_index_key(entry.table_name, "",
                                                entry.start_key)]
@@ -1307,6 +1346,8 @@ LineairDBTransaction::lookup_range_scan_cache(
     bool allow_truncated) const {
   const bool pending_in_range =
       has_pending_row_ops_in_range(table_name, start_key, end_key);
+  const bool aggregate_consumer =
+      !pushed_aggregate_.empty() && pushed_aggregate_table_ == table_name;
 
   // Grouped for_each range probes are staged by exact start key. Try that
   // index before falling back to the wider range-cache scan below.
@@ -1316,6 +1357,7 @@ LineairDBTransaction::lookup_range_scan_cache(
     for (auto rit = idx_it->second.rbegin(); rit != idx_it->second.rend();
          ++rit) {
       const auto& e = range_scan_cache_[*rit];
+      if (e.aggregate_rows != aggregate_consumer) continue;
       if (e.row_limit != 0 && pending_in_range) continue;
       if (e.reverse_scan == reverse_scan && e.row_limit == row_limit &&
           end_key <= e.end_key) {
@@ -1345,6 +1387,7 @@ LineairDBTransaction::lookup_range_scan_cache(
 
   for (auto it = range_scan_cache_.rbegin();
        it != range_scan_cache_.rend(); ++it) {
+    if (it->aggregate_rows != aggregate_consumer) continue;
     if (it->row_limit != 0 && pending_in_range) continue;
     const bool same_table = it->table_name == table_name;
     const bool same_direction = it->reverse_scan == reverse_scan;
@@ -1384,6 +1427,7 @@ LineairDBTransaction::lookup_range_scan_cache(
       for (auto rit = idx_it->second.rbegin(); rit != idx_it->second.rend();
            ++rit) {
         const auto& e = range_scan_cache_[*rit];
+        if (e.aggregate_rows != aggregate_consumer) continue;
         if (e.row_limit > 0 && !e.reverse_scan && e.start_key == start_key &&
             e.end_key == end_key) {
           LocalRangeScanEntry cached = e;

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -5,6 +5,8 @@
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "sql/handler.h" /* handler */
 #include "mysql/plugin.h"
@@ -118,6 +120,10 @@ public:
     autogen_stmt_resolved_ = false;
     autogen_stmt_handler_deferred_ = false;
     autogen_staged_roots_.clear();
+    grouped_summary_registrations_.clear();
+    grouped_summary_skipped_.clear();
+    grouped_semijoins_.clear();
+    grouped_semijoin_group_rows_.clear();
   }
   bool autogen_stmt_resolved() const { return autogen_stmt_resolved_; }
   void mark_autogen_stmt_resolved() { autogen_stmt_resolved_ = true; }
@@ -168,9 +174,74 @@ public:
   void clear_pushed_filter() { pushed_filter_.clear(); }
 
   // Aggregation pushdown: serialized AggregateSpec for the primary scan.
-  void set_pushed_aggregate(const std::string& s) { pushed_aggregate_ = s; }
-  void clear_pushed_aggregate() { pushed_aggregate_.clear(); }
+  void set_pushed_aggregate(const std::string& s) {
+    pushed_aggregate_ = s;
+    pushed_aggregate_table_ = db_table_key;
+  }
+  void clear_pushed_aggregate() {
+    pushed_aggregate_.clear();
+    pushed_aggregate_table_.clear();
+  }
   bool has_pushed_aggregate() const { return !pushed_aggregate_.empty(); }
+
+  // Grouped summary registration lets a grouped aggregate leaf be served as
+  // synthetic full-width rows instead of base table rows.
+  struct GroupedSummaryRegistration {
+    std::string spec;
+    std::string filter;
+    std::vector<std::string> template_cols;
+    uint32_t group_col = 0;
+    uint32_t col_a = 0;
+    uint32_t col_b = 0;
+    bool single_sum = false;
+  };
+  void register_grouped_summary(const void* leaf,
+                                GroupedSummaryRegistration registration) {
+    grouped_summary_registrations_[leaf] = std::move(registration);
+  }
+  const GroupedSummaryRegistration* grouped_summary_registration(
+      const void* leaf) const {
+    auto it = grouped_summary_registrations_.find(leaf);
+    return it == grouped_summary_registrations_.end() ? nullptr
+                                                      : &it->second;
+  }
+  bool has_grouped_summary_registrations() const {
+    return !grouped_summary_registrations_.empty();
+  }
+  void mark_grouped_summary_skipped(const void* leaf) {
+    grouped_summary_skipped_.insert(leaf);
+  }
+  bool grouped_summary_skipped(const void* leaf) const {
+    return grouped_summary_skipped_.count(leaf) != 0;
+  }
+
+  // Grouped semijoin reduces an outer scan by membership in the inner
+  // GROUP BY/HAVING result.
+  struct GroupedSemijoin {
+    std::string inner_table_key;
+    std::string agg_spec;
+    std::string having_filter;
+    std::string outer_table_key;
+    uint32_t outer_probe_column = 0;
+  };
+  void register_grouped_semijoin(GroupedSemijoin grouped_semijoin) {
+    grouped_semijoins_.push_back(std::move(grouped_semijoin));
+  }
+  const std::vector<GroupedSemijoin>& grouped_semijoins() const {
+    return grouped_semijoins_;
+  }
+  void cache_grouped_semijoin_group_rows(const std::string& table,
+                                         std::vector<std::string> rows) {
+    grouped_semijoin_group_rows_[table] = std::move(rows);
+  }
+  const std::vector<std::string>* grouped_semijoin_group_rows(
+      const std::string& table) const {
+    auto it = grouped_semijoin_group_rows_.find(table);
+    return it == grouped_semijoin_group_rows_.end() ? nullptr : &it->second;
+  }
+  bool execute_read_plan_raw(
+      const std::vector<LineairDBProxy::ReadPlanStep>& steps,
+      std::vector<std::string>* values);
 
   // Projection pushdown stores kept field ordinals per physical table.
   static uint64_t load_projection_global_epoch() {
@@ -295,6 +366,10 @@ private:
     // Set only on lookup return copies: this entry came from a LIMIT-staged
     // window, so the handler must abort if MySQL asks past these rows.
     bool truncated = false;
+    // Aggregate steps emit synthetic GROUP rows keyed by the same physical
+    // table. They are visible only to the aggregate consumer, never to base-row
+    // scans.
+    bool aggregate_rows = false;
   };
   struct LocalSecondaryScanEntry {
     std::string table_name;
@@ -319,6 +394,14 @@ private:
   std::string pushed_filter_;
   // Aggregation pushdown: serialized AggregateSpec for the primary scan
   std::string pushed_aggregate_;
+  std::string pushed_aggregate_table_;
+
+  std::unordered_map<const void*, GroupedSummaryRegistration>
+      grouped_summary_registrations_;
+  std::unordered_set<const void*> grouped_summary_skipped_;
+  std::vector<GroupedSemijoin> grouped_semijoins_;
+  std::unordered_map<std::string, std::vector<std::string>>
+      grouped_semijoin_group_rows_;
 
   // Physical table name -> kept field ordinals for projected staged rows.
   std::unordered_map<std::string, std::vector<uint32_t>> table_projection_;

--- a/proxy/rpc_trace.cc
+++ b/proxy/rpc_trace.cc
@@ -93,6 +93,8 @@ const char* message_type_name(MessageType t) {
       return "TX_EXECUTE_READ_PLAN";
     case MessageType::TX_GET_TABLE_STATS:
       return "TX_GET_TABLE_STATS";
+    case MessageType::TX_EXECUTE_QUERY_BLOCK:
+      return "TX_EXECUTE_QUERY_BLOCK";
   }
   return "UNDEFINED";
 }

--- a/proxy/table_scan.cc
+++ b/proxy/table_scan.cc
@@ -56,6 +56,10 @@ int ha_lineairdb::rnd_init(bool) {
     DBUG_RETURN(err);
   }
 
+  if (tx->grouped_summary_skipped(table)) {
+    DBUG_RETURN(fill_grouped_summary_buffers(tx));
+  }
+
   DBUG_RETURN(0);
 }
 

--- a/scripts/start_mysql.sh
+++ b/scripts/start_mysql.sh
@@ -76,6 +76,8 @@ done
 echo "Step 4/5: Installing LineairDB plugin..."
 ./runtime_output_directory/mysql -u root --socket="$SOCKET" --port="$MYSQLD_PORT" \
   -e "INSTALL PLUGIN lineairdb SONAME 'ha_lineairdb_storage_engine.so';" 2>/dev/null || true
+./runtime_output_directory/mysql -u root --socket="$SOCKET" --port="$MYSQLD_PORT" \
+  -e "INSTALL PLUGIN lineairdb_columnar SONAME 'ha_lineairdb_storage_engine.so';" 2>/dev/null || true
 
 echo "Step 5/5: Stopping MySQL and restarting with LineairDB as default..."
 kill "$BOOT_PID" 2>/dev/null || true

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -19,6 +19,8 @@ else
   echo "WARNING: jemalloc not found, using system malloc (apt install libjemalloc2)" >&2
 fi
 
+export HELIOS_PAX_STORAGE=1
+
 if [ ! -x "$BIN" ]; then
   echo "ERROR: binary not found: $BIN" >&2
   echo "Hint: build it via: bash scripts/build.sh (or build_partial.sh)" >&2
@@ -39,4 +41,3 @@ echo $PID > "$PID_FILE"
 echo "Started lineairdb-server with PID $PID"
 echo "Logs: $LOG_FILE"
 echo "PID file: $PID_FILE"
-

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SOURCES
     rpc/transaction_control.cc
     rpc/predicate_evaluator.cc
     rpc/predicate_evaluator.hh
+    rpc/query_block_dispatch.cc
     rpc/query_block_executor.cc
     rpc/query_block_executor.hh
     

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -71,6 +71,8 @@ set(SOURCES
     rpc/transaction_control.cc
     rpc/predicate_evaluator.cc
     rpc/predicate_evaluator.hh
+    rpc/query_block_executor.cc
+    rpc/query_block_executor.hh
     
     # Storage layer
     storage/database_manager.cc

--- a/server/protocol/message.hh
+++ b/server/protocol/message.hh
@@ -58,5 +58,8 @@ enum class MessageType : uint32_t {
     TX_STATELESS_BATCH_READ = 28,
     TX_VALIDATE_AND_COMMIT = 29,
     TX_EXECUTE_READ_PLAN = 30,
-    TX_GET_TABLE_STATS = 31
+    TX_GET_TABLE_STATS = 31,
+
+    // Secondary-engine computation pushdown.
+    TX_EXECUTE_QUERY_BLOCK = 36
 };

--- a/server/rpc/aggregate_executor.cc
+++ b/server/rpc/aggregate_executor.cc
@@ -23,6 +23,82 @@ static void agg_emit_field(std::string& out, std::string_view v, bool is_null) {
     out.append(v.data(), v.size());
 }
 
+bool is_aggregate_having_filter(
+    const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step) {
+    return step.has_aggregate() && step.has_filter() &&
+           step.filter().has_expr() &&
+           step.filter().num_columns() == kAggregateHavingFilterColumns;
+}
+
+namespace {
+
+bool decimal_from_filter_constant(
+    const LineairDB::Protocol::FilterExpr& expr,
+    DecimalValue& value) {
+    using FE = LineairDB::Protocol::FilterExpr;
+    switch (expr.op()) {
+        case FE::CONST_INT:
+            value.mantissa = expr.int_val();
+            value.scale = 0;
+            value.is_null = false;
+            return true;
+        case FE::CONST_UINT:
+            value.mantissa = static_cast<__int128>(expr.uint_val());
+            value.scale = 0;
+            value.is_null = false;
+            return true;
+        case FE::CONST_STRING:
+            value = parse_decimal_value(expr.string_val());
+            return !value.is_null;
+        default:
+            return false;
+    }
+}
+
+bool aggregate_having_row_passes(
+    const LineairDB::Protocol::PushedPredicate* predicate,
+    const std::string& group_row) {
+    if (predicate == nullptr) return true;
+
+    using FE = LineairDB::Protocol::FilterExpr;
+    const auto& expr = predicate->expr();
+    switch (expr.op()) {
+        case FE::OP_GT:
+        case FE::OP_GE:
+        case FE::OP_LT:
+        case FE::OP_LE:
+        case FE::OP_EQ:
+        case FE::OP_NE:
+            break;
+        default:
+            return false;
+    }
+    if (expr.children_size() != 2 ||
+        expr.children(0).op() != FE::COLUMN_REF) {
+        return false;
+    }
+
+    const DecimalValue lhs = parse_decimal_value(
+        extract_value_column(group_row, expr.children(0).column_index()));
+    DecimalValue rhs;
+    if (lhs.is_null || !decimal_from_filter_constant(expr.children(1), rhs)) {
+        return false;
+    }
+
+    const int cmp = compare_decimal_values(lhs, rhs);
+    switch (expr.op()) {
+        case FE::OP_GT: return cmp > 0;
+        case FE::OP_GE: return cmp >= 0;
+        case FE::OP_LT: return cmp < 0;
+        case FE::OP_LE: return cmp <= 0;
+        case FE::OP_EQ: return cmp == 0;
+        case FE::OP_NE: return cmp != 0;
+        default: return false;
+    }
+}
+
+}  // namespace
+
 void aggregate_rows_range(
     const LineairDB::Protocol::AggregateSpec& spec,
     const std::vector<LineairDB::StatelessScanRow>& rows,
@@ -99,7 +175,8 @@ void merge_agg_groups(
 void emit_agg_groups(
     const LineairDB::Protocol::AggregateSpec& spec,
     std::unordered_map<std::string, AggGroupState>& groups,
-    LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result) {
+    LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result,
+    const LineairDB::Protocol::PushedPredicate* group_having) {
     using AF = LineairDB::Protocol::AggFunc;
     const int n_agg = spec.aggs_size();
     const int n_grp = spec.group_columns_size();
@@ -131,6 +208,7 @@ void emit_agg_groups(
                 agg_emit_field(row, cnt, false);
             }
         }
+        if (!aggregate_having_row_passes(group_having, row)) continue;
         step_result->add_scan_keys(std::string());
         step_result->add_scan_values(std::move(row));
         step_result->add_scan_tids(0);
@@ -140,7 +218,8 @@ void emit_agg_groups(
 bool server_aggregate_scan(
     const LineairDB::Protocol::AggregateSpec& spec,
     std::vector<LineairDB::StatelessScanRow>& rows,
-    LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result) {
+    LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result,
+    const LineairDB::Protocol::PushedPredicate* group_having) {
     const int n_agg = spec.aggs_size();
     std::unordered_map<std::string, AggGroupState> groups;
 
@@ -178,6 +257,6 @@ bool server_aggregate_scan(
         for (auto& local : locals) merge_agg_groups(groups, local, n_agg);
     }
 
-    emit_agg_groups(spec, groups, step_result);
+    emit_agg_groups(spec, groups, step_result, group_having);
     return true;
 }

--- a/server/rpc/aggregate_executor.hh
+++ b/server/rpc/aggregate_executor.hh
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -14,6 +15,15 @@
 // Server-side aggregate execution helpers. These functions build per-group
 // partials from scan rows and serialize the partials back into synthetic rows
 // consumed by the proxy.
+
+constexpr uint32_t kAggregateHavingFilterColumns =
+    std::numeric_limits<uint32_t>::max();
+
+/**
+ * @brief Return true when a plan-step filter is an aggregate HAVING carrier.
+ */
+bool is_aggregate_having_filter(
+    const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step);
 
 /**
  * @brief Accumulators for one GROUP BY key.
@@ -46,7 +56,8 @@ void merge_agg_groups(std::unordered_map<std::string, AggGroupState>& dst,
 void emit_agg_groups(
     const LineairDB::Protocol::AggregateSpec& spec,
     std::unordered_map<std::string, AggGroupState>& groups,
-    LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result);
+    LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result,
+    const LineairDB::Protocol::PushedPredicate* group_having = nullptr);
 
 /**
  * @brief Aggregate scan rows and emit one synthetic group row per group.
@@ -56,4 +67,5 @@ void emit_agg_groups(
 bool server_aggregate_scan(
     const LineairDB::Protocol::AggregateSpec& spec,
     std::vector<LineairDB::StatelessScanRow>& rows,
-    LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result);
+    LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result,
+    const LineairDB::Protocol::PushedPredicate* group_having = nullptr);

--- a/server/rpc/database_operations.cc
+++ b/server/rpc/database_operations.cc
@@ -1,5 +1,8 @@
 #include "lineairdb_rpc.hh"
 
+#include <cstdint>
+#include <vector>
+
 #include "../../common/log.h"
 #include "lineairdb.pb.h"
 
@@ -34,6 +37,21 @@ void LineairDBRpc::handleDbCreateTable(const std::string& message,
     response.set_success(success);
     LOG_DEBUG("CreateTable '%s': %s", request.table_name().c_str(),
               success ? "success" : "already exists");
+
+    // Non-empty widths mean the proxy wants this table to try PAX storage.
+    if (request.pax_field_max_bytes_size() > 0) {
+        std::vector<uint32_t> widths;
+        widths.reserve(request.pax_field_max_bytes_size());
+        for (const uint32_t width : request.pax_field_max_bytes()) {
+            widths.push_back(width);
+        }
+
+        const bool installed = db_manager_->get_database()->InstallPaxSchema(
+            request.table_name(), widths);
+        LOG_INFO("PAX schema for '%s': %zu fields, %s",
+                 request.table_name().c_str(), widths.size(),
+                 installed ? "installed" : "skipped");
+    }
 
     result = response.SerializeAsString();
 }

--- a/server/rpc/decimal_arithmetic.cc
+++ b/server/rpc/decimal_arithmetic.cc
@@ -15,10 +15,12 @@ __int128 decimal_power_of_ten(int n) {
     return r;
 }
 
+}  // namespace
+
 /**
  * @brief Parse an ASCII decimal string into DecimalValue.
  */
-DecimalValue parse_decimal(std::string_view v) {
+DecimalValue parse_decimal_value(std::string_view v) {
     DecimalValue d;
     if (v.empty()) {
         d.is_null = true;
@@ -53,6 +55,24 @@ DecimalValue parse_decimal(std::string_view v) {
     return d;
 }
 
+int compare_decimal_values(const DecimalValue& lhs,
+                           const DecimalValue& rhs) {
+    if (lhs.is_null && rhs.is_null) return 0;
+    if (lhs.is_null) return -1;
+    if (rhs.is_null) return 1;
+
+    const int scale = lhs.scale > rhs.scale ? lhs.scale : rhs.scale;
+    const __int128 lhs_mantissa =
+        lhs.mantissa * decimal_power_of_ten(scale - lhs.scale);
+    const __int128 rhs_mantissa =
+        rhs.mantissa * decimal_power_of_ten(scale - rhs.scale);
+    if (lhs_mantissa < rhs_mantissa) return -1;
+    if (lhs_mantissa > rhs_mantissa) return 1;
+    return 0;
+}
+
+namespace {
+
 enum class DecimalOperation {
     kAdd,
     kSubtract,
@@ -80,7 +100,7 @@ DecimalValue evaluate_decimal_expression_impl(
     using FE = LineairDB::Protocol::FilterExpr;
     switch (expression.op()) {
         case FE::COLUMN_REF:
-            return parse_decimal(
+            return parse_decimal_value(
                 extract_value_column(row, expression.column_index()));
         case FE::CONST_INT: {
             DecimalValue d;

--- a/server/rpc/decimal_arithmetic.cc
+++ b/server/rpc/decimal_arithmetic.cc
@@ -72,15 +72,11 @@ void combine_decimal_values(DecimalValue& a, const DecimalValue& b,
     a.is_null = a.is_null || b.is_null;
 }
 
-}  // namespace
-
-void add_decimal_value(DecimalValue& total, const DecimalValue& value) {
-    combine_decimal_values(total, value, DecimalOperation::kAdd);
-}
-
-DecimalValue evaluate_decimal_expression(
-    const LineairDB::Protocol::FilterExpr& expression,
-    const std::string& row) {
+template <typename Row>
+DecimalValue evaluate_decimal_expression_impl(
+    const LineairDB::Protocol::FilterExpr& expression, const Row& row) {
+    // FilterExpr is reused here as a scalar-expression tree, not as a boolean
+    // row filter.
     using FE = LineairDB::Protocol::FilterExpr;
     switch (expression.op()) {
         case FE::COLUMN_REF:
@@ -104,10 +100,11 @@ DecimalValue evaluate_decimal_expression(
                 d.is_null = true;
                 return d;
             }
-            DecimalValue a = evaluate_decimal_expression(
+            DecimalValue a = evaluate_decimal_expression_impl(
                 expression.children(0), row);
             combine_decimal_values(
-                a, evaluate_decimal_expression(expression.children(1), row),
+                a,
+                evaluate_decimal_expression_impl(expression.children(1), row),
                 DecimalOperation::kAdd);
             return a;
         }
@@ -117,10 +114,11 @@ DecimalValue evaluate_decimal_expression(
                 d.is_null = true;
                 return d;
             }
-            DecimalValue a = evaluate_decimal_expression(
+            DecimalValue a = evaluate_decimal_expression_impl(
                 expression.children(0), row);
             combine_decimal_values(
-                a, evaluate_decimal_expression(expression.children(1), row),
+                a,
+                evaluate_decimal_expression_impl(expression.children(1), row),
                 DecimalOperation::kSubtract);
             return a;
         }
@@ -130,9 +128,9 @@ DecimalValue evaluate_decimal_expression(
                 d.is_null = true;
                 return d;
             }
-            DecimalValue a = evaluate_decimal_expression(
+            DecimalValue a = evaluate_decimal_expression_impl(
                 expression.children(0), row);
-            DecimalValue b = evaluate_decimal_expression(
+            DecimalValue b = evaluate_decimal_expression_impl(
                 expression.children(1), row);
             DecimalValue r;
             r.mantissa = a.mantissa * b.mantissa;
@@ -146,7 +144,7 @@ DecimalValue evaluate_decimal_expression(
                 d.is_null = true;
                 return d;
             }
-            DecimalValue a = evaluate_decimal_expression(
+            DecimalValue a = evaluate_decimal_expression_impl(
                 expression.children(0), row);
             a.mantissa = -a.mantissa;
             return a;
@@ -157,6 +155,24 @@ DecimalValue evaluate_decimal_expression(
             return d;
         }
     }
+}
+
+}  // namespace
+
+void add_decimal_value(DecimalValue& total, const DecimalValue& value) {
+    combine_decimal_values(total, value, DecimalOperation::kAdd);
+}
+
+DecimalValue evaluate_decimal_expression(
+    const LineairDB::Protocol::FilterExpr& expression,
+    const std::string& row) {
+    return evaluate_decimal_expression_impl(expression, row);
+}
+
+DecimalValue evaluate_decimal_expression(
+    const LineairDB::Protocol::FilterExpr& expression,
+    const PaxRowRef& row) {
+    return evaluate_decimal_expression_impl(expression, row);
 }
 
 std::string format_decimal_value(const DecimalValue& value) {

--- a/server/rpc/decimal_arithmetic.hh
+++ b/server/rpc/decimal_arithmetic.hh
@@ -26,6 +26,18 @@ struct DecimalValue {
 void add_decimal_value(DecimalValue& total, const DecimalValue& value);
 
 /**
+ * @brief Parse an ASCII decimal string into a DecimalValue.
+ */
+DecimalValue parse_decimal_value(std::string_view value);
+
+/**
+ * @brief Compare two decimal values after aligning their scales.
+ *
+ * Returns -1, 0, or 1 for less-than, equal, or greater-than.
+ */
+int compare_decimal_values(const DecimalValue& lhs, const DecimalValue& rhs);
+
+/**
  * @brief Evaluate a decimal-valued aggregate argument tree against one
  * materialized row.
  *

--- a/server/rpc/decimal_arithmetic.hh
+++ b/server/rpc/decimal_arithmetic.hh
@@ -5,6 +5,8 @@
 
 #include "lineairdb.pb.h"
 
+struct PaxRowRef;
+
 // Arithmetic helpers for decimal fixed-point values used by server-side
 // aggregate partials. DecimalValue stores a value as mantissa * 10^-scale,
 // plus a null marker.
@@ -24,11 +26,26 @@ struct DecimalValue {
 void add_decimal_value(DecimalValue& total, const DecimalValue& value);
 
 /**
- * @brief Evaluate an aggregate argument expression against one base row.
+ * @brief Evaluate a decimal-valued aggregate argument tree against one
+ * materialized row.
+ *
+ * Aggregate arguments reuse FilterExpr as a scalar-expression tree, for example
+ * the argument of `SUM(l_extendedprice * (1 - l_discount))`.
  */
 DecimalValue evaluate_decimal_expression(
     const LineairDB::Protocol::FilterExpr& expression,
     const std::string& row);
+
+/**
+ * @brief Evaluate a decimal-valued aggregate argument tree against one PAX row
+ * slot.
+ *
+ * Column references read directly from PAX strip cells instead of a
+ * materialized row.
+ */
+DecimalValue evaluate_decimal_expression(
+    const LineairDB::Protocol::FilterExpr& expression,
+    const PaxRowRef& row);
 
 /**
  * @brief Format a decimal value back to its string representation.

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -69,6 +69,10 @@ void LineairDBRpc::handle_rpc(uint64_t sender_id, MessageType message_type,
             handleTxExecuteReadPlan(message, result);
             release_masstree_thread_epoch();
             return;
+        case MessageType::TX_EXECUTE_QUERY_BLOCK:
+            handleTxExecuteQueryBlock(message, result);
+            release_masstree_thread_epoch();
+            return;
 
         // Table statistics
         case MessageType::TX_GET_TABLE_STATS:

--- a/server/rpc/lineairdb_rpc.hh
+++ b/server/rpc/lineairdb_rpc.hh
@@ -82,6 +82,9 @@ private:
     // Read-plan execution
     void handleTxExecuteReadPlan(const std::string& message, std::string& result);
 
+    // Query-block execution
+    void handleTxExecuteQueryBlock(const std::string& message, std::string& result);
+
     // Secondary index operations
     void handleTxReadSecondaryIndex(const std::string& message, std::string& result);
     void handleTxWriteSecondaryIndex(const std::string& message, std::string& result);

--- a/server/rpc/parallel_scan.cc
+++ b/server/rpc/parallel_scan.cc
@@ -47,7 +47,8 @@ const std::vector<uint32_t>* selected_columns_for_projected_read(
     }
     selected_columns.assign(step.projection().field_indexes().begin(),
                             step.projection().field_indexes().end());
-    if (step.has_filter() && step.filter().has_expr()) {
+    if (step.has_filter() && step.filter().has_expr() &&
+        !is_aggregate_having_filter(step)) {
         collect_filter_columns(step.filter().expr(), selected_columns);
     }
     sort_unique_columns(selected_columns);
@@ -65,7 +66,8 @@ const std::vector<uint32_t>* selected_columns_for_aggregate_read(
     if (!step.has_aggregate() || step.aggregate().aggs_size() == 0) {
         return nullptr;
     }
-    if (step.has_filter() && step.filter().has_expr()) {
+    if (step.has_filter() && step.filter().has_expr() &&
+        !is_aggregate_having_filter(step)) {
         collect_filter_columns(step.filter().expr(), selected_columns);
     }
     const auto& spec = step.aggregate();
@@ -92,7 +94,8 @@ bool aggregate_pax_group(
     using AF = LineairDB::Protocol::AggFunc;
 
     const auto& spec = step.aggregate();
-    const bool has_filter = step.has_filter() && step.filter().has_expr();
+    const bool has_filter = step.has_filter() && step.filter().has_expr() &&
+                            !is_aggregate_having_filter(step);
     const int n_agg = spec.aggs_size();
     const int n_grp = spec.group_columns_size();
 
@@ -261,7 +264,9 @@ bool parallel_primary_pax_aggregate_scan(
         return false;
     }
 
-    emit_agg_groups(step.aggregate(), groups, step_result);
+    emit_agg_groups(step.aggregate(), groups, step_result,
+                    is_aggregate_having_filter(step) ? &step.filter()
+                                                     : nullptr);
     return true;
 }
 
@@ -557,7 +562,9 @@ bool parallel_primary_aggregate_scan(
                                           : encode_int_key_part(end_value);
     }
 
-    const bool has_filter = step.has_filter() && step.filter().has_expr();
+    const bool group_having = is_aggregate_having_filter(step);
+    const bool has_filter =
+        step.has_filter() && step.filter().has_expr() && !group_having;
     const auto& spec = step.aggregate();
     const int n_agg = spec.aggs_size();
     std::vector<uint32_t> selected_columns;
@@ -615,7 +622,8 @@ bool parallel_primary_aggregate_scan(
 
     std::unordered_map<std::string, AggGroupState> groups;
     for (auto& local : locals) merge_agg_groups(groups, local, n_agg);
-    emit_agg_groups(spec, groups, step_result);
+    emit_agg_groups(spec, groups, step_result,
+                    group_having ? &step.filter() : nullptr);
     return true;
 }
 

--- a/server/rpc/parallel_scan.cc
+++ b/server/rpc/parallel_scan.cc
@@ -201,6 +201,237 @@ bool parallel_primary_pax_aggregate_scan(
     return true;
 }
 
+bool parallel_primary_pax_row_ref_scan(
+    LineairDB::Database* db,
+    const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,
+    const std::string& start_key, const std::string& end_key,
+    LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result,
+    bool& projection_failed) {
+    if (db == nullptr) return false;
+
+    const bool has_filter = step.has_filter() && step.filter().has_expr();
+    const bool has_projection = step.has_projection();
+    // With a pushed filter, LIMIT applies after filter evaluation.
+    const uint64_t ref_scan_limit = has_filter ? 0 : step.scan_limit();
+
+    std::vector<uint32_t> kept_columns;
+    if (has_projection) {
+        kept_columns.assign(step.projection().field_indexes().begin(),
+                            step.projection().field_indexes().end());
+    }
+
+    struct RefChunkOut {
+        struct Event {
+            bool filtered_key = false;
+            size_t index = 0;
+        };
+
+        // Preserve the scan observation order between accepted rows and
+        // filtered keys. LIMIT is applied while replaying this event stream,
+        // matching the materialized-row path's key-set coverage.
+        std::vector<std::string> scan_keys;
+        std::vector<std::string> scan_values;
+        std::vector<std::string> filtered_keys;
+        std::vector<uint64_t> tids;
+        std::vector<Event> events;
+        bool materialized_path_required = false;
+        bool projection_failed = false;
+    };
+
+    auto run_range = [&](const std::string& chunk_start,
+                         const std::string& chunk_end, RefChunkOut& out,
+                         bool release_epoch) {
+        auto refs = db->StatelessPaxRowRefScan(
+            step.table_name(), chunk_start, chunk_end, ref_scan_limit,
+            step.reverse_scan());
+        if (!refs.ok) {
+            out.materialized_path_required = true;
+            if (release_epoch) db->ReleaseMasstreeThreadEpoch();
+            return;
+        }
+
+        PredicateEvaluator evaluator;
+        for (auto& row_ref : refs.rows) {
+            const auto* group =
+                static_cast<const LineairDB::Pax::PaxGroup*>(row_ref.group);
+            bool pass = true;
+            if (has_filter) {
+                if (!evaluator.set_row_from_pax(
+                        *group, row_ref.slot, step.filter().num_columns())) {
+                    out.materialized_path_required = true;
+                    break;
+                }
+                pass = evaluator.evaluate(step.filter().expr());
+            }
+
+            std::string value;
+            if (pass) {
+                if (has_projection) {
+                    if (!group->GatherRowProjected(row_ref.slot,
+                                                   kept_columns.data(),
+                                                   kept_columns.size(),
+                                                   value)) {
+                        out.materialized_path_required = true;
+                        break;
+                    }
+                } else {
+                    value.resize(row_ref.row_size);
+                    const size_t gathered = group->GatherRow(
+                        row_ref.slot,
+                        reinterpret_cast<std::byte*>(value.data()),
+                        row_ref.row_size);
+                    if (gathered != row_ref.row_size) value.resize(gathered);
+                }
+            }
+
+            // The cells just read are valid only if the row TID still matches
+            // the ref-scan observation. Otherwise re-read a stable row copy.
+            if (LineairDB::PaxRowRefCurrentTid(row_ref) != row_ref.tid) {
+                auto reread =
+                    db->StatelessRead(step.table_name(), row_ref.key);
+                if (!reread.found) continue;
+
+                bool reread_pass = true;
+                if (has_filter) {
+                    PredicateEvaluator reread_eval;
+                    if (reread_eval.parse_row(reread.value.data(),
+                                              reread.value.size(),
+                                              step.filter().num_columns())) {
+                        reread_pass =
+                            reread_eval.evaluate(step.filter().expr());
+                    }
+                }
+                if (!reread_pass) {
+                    out.events.push_back({true, out.filtered_keys.size()});
+                    out.filtered_keys.push_back(std::move(row_ref.key));
+                    continue;
+                }
+
+                std::string reread_value;
+                if (has_projection) {
+                    if (!trim_row_value(reread.value,
+                                        step.projection().field_indexes(),
+                                        step.projection().num_columns(),
+                                        reread_value)) {
+                        out.projection_failed = true;
+                        reread_value = std::move(reread.value);
+                    }
+                } else {
+                    reread_value = std::move(reread.value);
+                }
+                out.events.push_back({false, out.scan_keys.size()});
+                out.scan_keys.push_back(std::move(row_ref.key));
+                out.scan_values.push_back(std::move(reread_value));
+                out.tids.push_back(reread.tid);
+                continue;
+            }
+
+            if (!pass) {
+                out.events.push_back({true, out.filtered_keys.size()});
+                out.filtered_keys.push_back(std::move(row_ref.key));
+                continue;
+            }
+            out.events.push_back({false, out.scan_keys.size()});
+            out.scan_keys.push_back(std::move(row_ref.key));
+            out.scan_values.push_back(std::move(value));
+            out.tids.push_back(row_ref.tid);
+        }
+
+        if (release_epoch) db->ReleaseMasstreeThreadEpoch();
+    };
+
+    std::vector<RefChunkOut> chunks;
+    bool ran_parallel = false;
+    if (step.scan_limit() == 0 && !step.reverse_scan()) {
+        const unsigned nproc = std::thread::hardware_concurrency();
+        const unsigned max_threads = std::min<unsigned>(nproc ? nproc : 4, 8);
+        auto first = db->StatelessRangeScan(step.table_name(), start_key,
+                                            end_key, 1, false);
+        auto last = db->StatelessRangeScan(step.table_name(), start_key,
+                                           end_key, 1, true);
+        int64_t lo = 0;
+        int64_t hi = 0;
+        if (max_threads > 1 && first.ok && !first.rows.empty() && last.ok &&
+            !last.rows.empty() &&
+            decode_leading_int_key(first.rows.front().key, lo) &&
+            decode_leading_int_key(last.rows.front().key, hi) && hi > lo) {
+            const uint64_t span = static_cast<uint64_t>(hi - lo) + 1;
+            constexpr uint64_t kMinParallelRows = 500000;
+            constexpr uint64_t kMorselRows = 128000;
+            if (span >= kMinParallelRows) {
+                const unsigned worker_count = static_cast<unsigned>(
+                    std::min<uint64_t>(
+                        (span + kMorselRows - 1) / kMorselRows,
+                        max_threads));
+                if (worker_count > 1) {
+                    std::vector<std::string> starts(worker_count);
+                    std::vector<std::string> ends(worker_count);
+                    for (unsigned i = 0; i < worker_count; ++i) {
+                        const int64_t begin_value =
+                            lo + static_cast<int64_t>((span * i) /
+                                                      worker_count);
+                        const int64_t end_value =
+                            (i + 1 == worker_count)
+                                ? hi + 1
+                                : lo + static_cast<int64_t>(
+                                           (span * (i + 1)) / worker_count);
+                        starts[i] = i == 0 ? start_key
+                                           : encode_int_key_part(begin_value);
+                        ends[i] = i + 1 == worker_count
+                                      ? end_key
+                                      : encode_int_key_part(end_value);
+                    }
+
+                    chunks = std::vector<RefChunkOut>(worker_count);
+                    std::vector<std::thread> workers;
+                    workers.reserve(worker_count);
+                    for (unsigned worker_index = 0;
+                         worker_index < worker_count; ++worker_index) {
+                        workers.emplace_back([&, worker_index] {
+                            run_range(starts[worker_index],
+                                      ends[worker_index],
+                                      chunks[worker_index], true);
+                        });
+                    }
+                    for (auto& worker : workers) worker.join();
+                    ran_parallel = true;
+                }
+            }
+        }
+    }
+    if (!ran_parallel) {
+        chunks = std::vector<RefChunkOut>(1);
+        run_range(start_key, end_key, chunks[0], false);
+    }
+
+    for (const auto& chunk : chunks) {
+        if (chunk.materialized_path_required) return false;
+        if (chunk.projection_failed) projection_failed = true;
+    }
+
+    uint64_t emitted = 0;
+    for (auto& chunk : chunks) {
+        // Replay the mixed stream in scan order so filtered keys observed
+        // before LIMIT cutoff remain visible to range validation.
+        for (const auto& event : chunk.events) {
+            if (event.filtered_key) {
+                step_result->add_filtered_keys(
+                    std::move(chunk.filtered_keys[event.index]));
+                continue;
+            }
+            step_result->add_scan_keys(
+                std::move(chunk.scan_keys[event.index]));
+            step_result->add_scan_values(
+                std::move(chunk.scan_values[event.index]));
+            step_result->add_scan_tids(chunk.tids[event.index]);
+            if (step.scan_limit() > 0 && ++emitted >= step.scan_limit()) {
+                return true;
+            }
+        }
+    }
+    return true;
+}
+
 bool parallel_primary_aggregate_scan(
     LineairDB::Database* db,
     const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,

--- a/server/rpc/parallel_scan.cc
+++ b/server/rpc/parallel_scan.cc
@@ -236,10 +236,12 @@ bool parallel_primary_pax_aggregate_scan(
         std::vector<uint64_t> write_counters(n_groups, 0);
         for (size_t group_index = 0; group_index < n_groups; ++group_index) {
             auto* group = store->group(group_index);
-            write_counters[group_index] =
+            const uint64_t counter =
                 group != nullptr
                     ? group->write_counter.load(std::memory_order_acquire)
                     : 0;
+            if ((counter & 1u) != 0) return false;
+            write_counters[group_index] = counter;
         }
 
         const unsigned nproc = std::thread::hardware_concurrency();
@@ -278,15 +280,20 @@ bool parallel_primary_pax_aggregate_scan(
             if (worker_failed) return false;
         }
 
-        // A changed counter means a writer scattered or retired a slot while
-        // this scan was reading cells; retry through the TID-checked row path.
+        // PAX strip-direct scans require the same even counter before and after
+        // the fold. A changed or odd counter means a writer scattered or retired
+        // a slot while this scan was reading cells; retry through the
+        // TID-checked row path.
         for (size_t group_index = 0; group_index < n_groups; ++group_index) {
             auto* group = store->group(group_index);
             const uint64_t current_counter =
                 group != nullptr
                     ? group->write_counter.load(std::memory_order_acquire)
                     : 0;
-            if (current_counter != write_counters[group_index]) return false;
+            if ((current_counter & 1u) != 0 ||
+                current_counter != write_counters[group_index]) {
+                return false;
+            }
         }
 
         for (auto& local : locals) merge_agg_groups(groups, local, n_agg);

--- a/server/rpc/parallel_scan.cc
+++ b/server/rpc/parallel_scan.cc
@@ -1,8 +1,10 @@
 #include "parallel_scan.hh"
 
 #include <algorithm>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -11,6 +13,193 @@
 #include "aggregate_executor.hh"
 #include "predicate_evaluator.hh"
 #include "row_codec.hh"
+
+namespace {
+
+bool is_scan_end_sentinel(const std::string& key) {
+    return key.size() == 16 &&
+           key.find_first_not_of(static_cast<char>(0xFF)) == std::string::npos;
+}
+
+bool aggregate_pax_group(
+    const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,
+    const LineairDB::Pax::PaxGroup& group,
+    std::unordered_map<std::string, AggGroupState>& groups) {
+    using AF = LineairDB::Protocol::AggFunc;
+
+    const auto& spec = step.aggregate();
+    const bool has_filter = step.has_filter() && step.filter().has_expr();
+    const int n_agg = spec.aggs_size();
+    const int n_grp = spec.group_columns_size();
+
+    PredicateEvaluator evaluator;
+    std::string keybuf;
+    std::vector<std::string_view> group_values(n_grp);
+
+    for (uint32_t base = 0; base < LineairDB::Pax::PaxGroup::kRows;
+         base += 64) {
+        // Gather one visibility word at a time; empty tail regions become one
+        // cheap zero-word check.
+        uint64_t visible_slots = 0;
+        for (uint32_t offset = 0; offset < 64; ++offset) {
+            if (group.IsVisible(base + offset)) {
+                visible_slots |= uint64_t{1} << offset;
+            }
+        }
+
+        while (visible_slots != 0) {
+            const uint32_t bit =
+                static_cast<uint32_t>(__builtin_ctzll(visible_slots));
+            visible_slots &= visible_slots - 1;
+            const uint32_t slot = base + bit;
+
+            if (has_filter) {
+                if (!evaluator.set_row_from_pax(
+                        group, slot, step.filter().num_columns())) {
+                    return false;
+                }
+                if (!evaluator.evaluate(step.filter().expr())) continue;
+            }
+
+            const PaxRowRef row{&group, slot};
+            keybuf.clear();
+            for (int g = 0; g < n_grp; ++g) {
+                group_values[g] = extract_value_column(row,
+                                                       spec.group_columns(g));
+                const uint32_t length =
+                    static_cast<uint32_t>(group_values[g].size());
+                keybuf.append(reinterpret_cast<const char*>(&length),
+                              sizeof(length));
+                keybuf.append(group_values[g].data(), group_values[g].size());
+            }
+
+            auto it = groups.find(keybuf);
+            AggGroupState* group_state;
+            if (it == groups.end()) {
+                AggGroupState state;
+                state.key_cols.resize(n_grp);
+                for (int g = 0; g < n_grp; ++g) {
+                    state.key_cols[g] = std::string(group_values[g]);
+                }
+                state.count.assign(n_agg, 0);
+                state.sum.assign(n_agg, DecimalValue{});
+                group_state =
+                    &groups.emplace(std::move(keybuf), std::move(state))
+                         .first->second;
+                keybuf.clear();
+            } else {
+                group_state = &it->second;
+            }
+
+            for (int a = 0; a < n_agg; ++a) {
+                const auto& aggregate_func = spec.aggs(a);
+                if (aggregate_func.kind() == AF::AGG_COUNT) {
+                    group_state->count[a] += 1;
+                    continue;
+                }
+
+                DecimalValue value =
+                    evaluate_decimal_expression(aggregate_func.arg(), row);
+                if (!value.is_null) {
+                    add_decimal_value(group_state->sum[a], value);
+                    group_state->count[a] += 1;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+bool parallel_primary_pax_aggregate_scan(
+    LineairDB::Database* db,
+    const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,
+    const std::string& start_key, const std::string& end_key,
+    LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result) {
+    if (db == nullptr) return false;
+
+    // PAX strips do not store primary-key bytes, so this path is only valid
+    // for the whole-table primary scan shape produced by the proxy.
+    if (!start_key.empty() || !is_scan_end_sentinel(end_key)) return false;
+
+    auto* store = db->GetPaxStore(step.table_name());
+    if (store == nullptr) return false;
+
+    const uint64_t overflow_before = store->overflow_count();
+    if (overflow_before > 0) return false;
+    const uint64_t slots_before = store->slots_allocated();
+    const size_t n_groups = store->group_count();
+
+    std::unordered_map<std::string, AggGroupState> groups;
+    if (n_groups > 0) {
+        std::vector<uint64_t> write_counters(n_groups, 0);
+        for (size_t group_index = 0; group_index < n_groups; ++group_index) {
+            auto* group = store->group(group_index);
+            write_counters[group_index] =
+                group != nullptr
+                    ? group->write_counter.load(std::memory_order_acquire)
+                    : 0;
+        }
+
+        const unsigned nproc = std::thread::hardware_concurrency();
+        const unsigned max_threads = std::min<unsigned>(nproc ? nproc : 4, 8);
+        const unsigned worker_count = static_cast<unsigned>(
+            std::min<size_t>(std::max<size_t>(n_groups / 8, 1), max_threads));
+        const int n_agg = step.aggregate().aggs_size();
+
+        std::vector<std::unordered_map<std::string, AggGroupState>> locals(
+            worker_count);
+        std::vector<char> failed(worker_count, 0);
+        std::vector<std::thread> workers;
+        workers.reserve(worker_count);
+
+        for (unsigned worker_index = 0; worker_index < worker_count;
+             ++worker_index) {
+            workers.emplace_back([&, worker_index] {
+                const size_t begin = n_groups * worker_index / worker_count;
+                const size_t end =
+                    n_groups * (worker_index + 1) / worker_count;
+                for (size_t group_index = begin; group_index < end;
+                     ++group_index) {
+                    auto* group = store->group(group_index);
+                    if (group == nullptr) continue;
+                    if (!aggregate_pax_group(step, *group,
+                                             locals[worker_index])) {
+                        failed[worker_index] = 1;
+                        return;
+                    }
+                }
+            });
+        }
+        for (auto& worker : workers) worker.join();
+
+        for (char worker_failed : failed) {
+            if (worker_failed) return false;
+        }
+
+        // A changed counter means a writer scattered or retired a slot while
+        // this scan was reading cells; retry through the TID-checked row path.
+        for (size_t group_index = 0; group_index < n_groups; ++group_index) {
+            auto* group = store->group(group_index);
+            const uint64_t current_counter =
+                group != nullptr
+                    ? group->write_counter.load(std::memory_order_acquire)
+                    : 0;
+            if (current_counter != write_counters[group_index]) return false;
+        }
+
+        for (auto& local : locals) merge_agg_groups(groups, local, n_agg);
+    }
+
+    if (store->slots_allocated() != slots_before ||
+        store->overflow_count() != overflow_before) {
+        return false;
+    }
+
+    emit_agg_groups(step.aggregate(), groups, step_result);
+    return true;
+}
 
 bool parallel_primary_aggregate_scan(
     LineairDB::Database* db,

--- a/server/rpc/parallel_scan.cc
+++ b/server/rpc/parallel_scan.cc
@@ -413,10 +413,13 @@ bool parallel_primary_pax_row_ref_scan(
     if (step.scan_limit() == 0 && !step.reverse_scan()) {
         const unsigned nproc = std::thread::hardware_concurrency();
         const unsigned max_threads = std::min<unsigned>(nproc ? nproc : 4, 8);
+        const std::vector<uint32_t> key_only_columns;
         auto first = db->StatelessRangeScan(step.table_name(), start_key,
-                                            end_key, 1, false);
+                                            end_key, 1, false,
+                                            &key_only_columns);
         auto last = db->StatelessRangeScan(step.table_name(), start_key,
-                                           end_key, 1, true);
+                                           end_key, 1, true,
+                                           &key_only_columns);
         int64_t lo = 0;
         int64_t hi = 0;
         if (max_threads > 1 && first.ok && !first.rows.empty() && last.ok &&
@@ -515,11 +518,12 @@ bool parallel_primary_aggregate_scan(
     if (max_threads <= 1) return false;
 
     // Probe the actual key span before creating split boundaries.
+    const std::vector<uint32_t> key_only_columns;
     auto first = db->StatelessRangeScan(step.table_name(), start_key, end_key,
-                                        1, false);
+                                        1, false, &key_only_columns);
     if (!first.ok || first.rows.empty()) return false;
     auto last = db->StatelessRangeScan(step.table_name(), start_key, end_key,
-                                       1, true);
+                                       1, true, &key_only_columns);
     if (!last.ok || last.rows.empty()) return false;
 
     int64_t lo = 0;
@@ -630,11 +634,12 @@ bool parallel_primary_filter_scan(
     if (max_threads <= 1) return false;
 
     // Probe the actual key span before creating split boundaries.
+    const std::vector<uint32_t> key_only_columns;
     auto first = db->StatelessRangeScan(step.table_name(), start_key, end_key,
-                                        1, false);
+                                        1, false, &key_only_columns);
     if (!first.ok || first.rows.empty()) return false;
     auto last = db->StatelessRangeScan(step.table_name(), start_key, end_key,
-                                       1, true);
+                                       1, true, &key_only_columns);
     if (!last.ok || last.rows.empty()) return false;
 
     int64_t lo = 0;

--- a/server/rpc/parallel_scan.cc
+++ b/server/rpc/parallel_scan.cc
@@ -21,6 +21,70 @@ bool is_scan_end_sentinel(const std::string& key) {
            key.find_first_not_of(static_cast<char>(0xFF)) == std::string::npos;
 }
 
+void collect_filter_columns(
+    const LineairDB::Protocol::FilterExpr& expr,
+    std::vector<uint32_t>& columns) {
+    if (expr.op() == LineairDB::Protocol::FilterExpr::COLUMN_REF) {
+        columns.push_back(expr.column_index());
+    }
+    for (const auto& child : expr.children()) {
+        collect_filter_columns(child, columns);
+    }
+}
+
+void sort_unique_columns(std::vector<uint32_t>& columns) {
+    std::sort(columns.begin(), columns.end());
+    columns.erase(std::unique(columns.begin(), columns.end()), columns.end());
+}
+
+const std::vector<uint32_t>* selected_columns_for_projected_read(
+    const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,
+    std::vector<uint32_t>& selected_columns) {
+    selected_columns.clear();
+    if (!step.has_projection() ||
+        step.projection().field_indexes_size() == 0) {
+        return nullptr;
+    }
+    selected_columns.assign(step.projection().field_indexes().begin(),
+                            step.projection().field_indexes().end());
+    if (step.has_filter() && step.filter().has_expr()) {
+        collect_filter_columns(step.filter().expr(), selected_columns);
+    }
+    sort_unique_columns(selected_columns);
+    if (step.projection().num_columns() > 0 &&
+        selected_columns.size() >= step.projection().num_columns()) {
+        return nullptr;
+    }
+    return &selected_columns;
+}
+
+const std::vector<uint32_t>* selected_columns_for_aggregate_read(
+    const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,
+    std::vector<uint32_t>& selected_columns) {
+    selected_columns.clear();
+    if (!step.has_aggregate() || step.aggregate().aggs_size() == 0) {
+        return nullptr;
+    }
+    if (step.has_filter() && step.filter().has_expr()) {
+        collect_filter_columns(step.filter().expr(), selected_columns);
+    }
+    const auto& spec = step.aggregate();
+    for (uint32_t column : spec.group_columns()) {
+        selected_columns.push_back(column);
+    }
+    for (const auto& aggregate_func : spec.aggs()) {
+        if (aggregate_func.kind() != LineairDB::Protocol::AggFunc::AGG_COUNT) {
+            collect_filter_columns(aggregate_func.arg(), selected_columns);
+        }
+    }
+    sort_unique_columns(selected_columns);
+    if (spec.num_columns() > 0 &&
+        selected_columns.size() >= spec.num_columns()) {
+        return nullptr;
+    }
+    return &selected_columns;
+}
+
 bool aggregate_pax_group(
     const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,
     const LineairDB::Pax::PaxGroup& group,
@@ -219,6 +283,9 @@ bool parallel_primary_pax_row_ref_scan(
         kept_columns.assign(step.projection().field_indexes().begin(),
                             step.projection().field_indexes().end());
     }
+    std::vector<uint32_t> selected_columns;
+    const std::vector<uint32_t>* selected_columns_for_reread =
+        selected_columns_for_projected_read(step, selected_columns);
 
     struct RefChunkOut {
         struct Event {
@@ -287,8 +354,9 @@ bool parallel_primary_pax_row_ref_scan(
             // The cells just read are valid only if the row TID still matches
             // the ref-scan observation. Otherwise re-read a stable row copy.
             if (LineairDB::PaxRowRefCurrentTid(row_ref) != row_ref.tid) {
-                auto reread =
-                    db->StatelessRead(step.table_name(), row_ref.key);
+                auto reread = db->StatelessRead(
+                    step.table_name(), row_ref.key,
+                    selected_columns_for_reread);
                 if (!reread.found) continue;
 
                 bool reread_pass = true;
@@ -488,6 +556,9 @@ bool parallel_primary_aggregate_scan(
     const bool has_filter = step.has_filter() && step.filter().has_expr();
     const auto& spec = step.aggregate();
     const int n_agg = spec.aggs_size();
+    std::vector<uint32_t> selected_columns;
+    const std::vector<uint32_t>* selected_columns_for_reads =
+        selected_columns_for_aggregate_read(step, selected_columns);
     std::vector<std::unordered_map<std::string, AggGroupState>> locals(
         worker_count);
     std::vector<char> failed(worker_count, 0);
@@ -499,7 +570,8 @@ bool parallel_primary_aggregate_scan(
         workers.emplace_back([&, worker_index] {
             auto scan_result =
                 db->StatelessRangeScan(step.table_name(), starts[worker_index],
-                                       ends[worker_index], 0, false);
+                                       ends[worker_index], 0, false,
+                                       selected_columns_for_reads);
             if (!scan_result.ok) {
                 failed[worker_index] = 1;
                 db->ReleaseMasstreeThreadEpoch();
@@ -605,6 +677,9 @@ bool parallel_primary_filter_scan(
     std::vector<WorkerOut> outputs(worker_count);
     std::vector<char> failed(worker_count, 0);
     const bool has_projection = step.has_projection();
+    std::vector<uint32_t> selected_columns;
+    const std::vector<uint32_t>* selected_columns_for_reads =
+        selected_columns_for_projected_read(step, selected_columns);
     std::vector<std::thread> workers;
     workers.reserve(worker_count);
 
@@ -614,7 +689,8 @@ bool parallel_primary_filter_scan(
             auto scan_result =
                 db->StatelessRangeScan(step.table_name(),
                                        starts[worker_index],
-                                       ends[worker_index], 0, false);
+                                       ends[worker_index], 0, false,
+                                       selected_columns_for_reads);
             if (!scan_result.ok) {
                 failed[worker_index] = 1;
                 db->ReleaseMasstreeThreadEpoch();

--- a/server/rpc/parallel_scan.cc
+++ b/server/rpc/parallel_scan.cc
@@ -37,6 +37,36 @@ void sort_unique_columns(std::vector<uint32_t>& columns) {
     columns.erase(std::unique(columns.begin(), columns.end()), columns.end());
 }
 
+bool semijoin_rejects_value(
+    const std::vector<SemijoinReduction>& semijoin_reductions,
+    const std::string& value) {
+    for (const auto& reduction : semijoin_reductions) {
+        auto column = extract_value_column(value, reduction.probe_column);
+        if (reduction.keys.find(std::string(column)) == reduction.keys.end()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool semijoin_rejects_pax_slot(
+    const std::vector<SemijoinReduction>& semijoin_reductions,
+    const LineairDB::Pax::PaxGroup& group, uint32_t slot,
+    bool& schema_mismatch) {
+    for (const auto& reduction : semijoin_reductions) {
+        const size_t field = static_cast<size_t>(reduction.probe_column) + 1;
+        if (field >= group.schema().field_count()) {
+            schema_mismatch = true;
+            return false;
+        }
+        const std::string_view column = group.cell(field, slot);
+        if (reduction.keys.find(std::string(column)) == reduction.keys.end()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 const std::vector<uint32_t>* selected_columns_for_projected_read(
     const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,
     std::vector<uint32_t>& selected_columns) {
@@ -50,6 +80,9 @@ const std::vector<uint32_t>* selected_columns_for_projected_read(
     if (step.has_filter() && step.filter().has_expr() &&
         !is_aggregate_having_filter(step)) {
         collect_filter_columns(step.filter().expr(), selected_columns);
+    }
+    for (const auto& semijoin : step.semijoins()) {
+        selected_columns.push_back(semijoin.probe_column());
     }
     sort_unique_columns(selected_columns);
     if (step.projection().num_columns() > 0 &&
@@ -275,7 +308,8 @@ bool parallel_primary_pax_row_ref_scan(
     const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,
     const std::string& start_key, const std::string& end_key,
     LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result,
-    bool& projection_failed) {
+    bool& projection_failed,
+    const std::vector<SemijoinReduction>& semijoin_reductions) {
     if (db == nullptr) return false;
 
     const bool has_filter = step.has_filter() && step.filter().has_expr();
@@ -336,8 +370,20 @@ bool parallel_primary_pax_row_ref_scan(
                 pass = evaluator.evaluate(step.filter().expr());
             }
 
+            bool semijoin_rejected = false;
+            if (pass && !semijoin_reductions.empty()) {
+                bool schema_mismatch = false;
+                semijoin_rejected = semijoin_rejects_pax_slot(
+                    semijoin_reductions, *group, row_ref.slot,
+                    schema_mismatch);
+                if (schema_mismatch) {
+                    out.materialized_path_required = true;
+                    break;
+                }
+            }
+
             std::string value;
-            if (pass) {
+            if (pass && !semijoin_rejected) {
                 if (has_projection) {
                     if (!group->GatherRowProjected(row_ref.slot,
                                                    kept_columns.data(),
@@ -380,6 +426,12 @@ bool parallel_primary_pax_row_ref_scan(
                     continue;
                 }
 
+                if (!semijoin_reductions.empty() &&
+                    semijoin_rejects_value(semijoin_reductions,
+                                           reread.value)) {
+                    continue;
+                }
+
                 std::string reread_value;
                 if (has_projection) {
                     if (!trim_row_value(reread.value,
@@ -404,6 +456,7 @@ bool parallel_primary_pax_row_ref_scan(
                 out.filtered_keys.push_back(std::move(row_ref.key));
                 continue;
             }
+            if (semijoin_rejected) continue;
             out.events.push_back({false, out.scan_keys.size()});
             out.scan_keys.push_back(std::move(row_ref.key));
             out.scan_values.push_back(std::move(value));

--- a/server/rpc/parallel_scan.hh
+++ b/server/rpc/parallel_scan.hh
@@ -5,7 +5,7 @@
 #include "lineairdb.pb.h"
 #include "lineairdb/lineairdb.h"
 
-// Parallel scan helpers for primary ranges and PAX full-scan aggregates. These
+// Parallel scan helpers for primary ranges and PAX strip-direct scans. These
 // functions fall back to the serial path when the table, key shape, or row
 // count is not suitable for the specialized path.
 
@@ -20,6 +20,19 @@ bool parallel_primary_pax_aggregate_scan(
     const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,
     const std::string& start_key, const std::string& end_key,
     LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result);
+
+/**
+ * @brief Scan primary rows through PAX row references and gather survivors.
+ *
+ * @return true when rows were emitted; false lets the caller use the
+ * materialized-row path.
+ */
+bool parallel_primary_pax_row_ref_scan(
+    LineairDB::Database* db,
+    const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,
+    const std::string& start_key, const std::string& end_key,
+    LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result,
+    bool& projection_failed);
 
 /**
  * @brief Scan integer primary-key slices in parallel and aggregate locally.

--- a/server/rpc/parallel_scan.hh
+++ b/server/rpc/parallel_scan.hh
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
+#include <unordered_set>
 
 #include "lineairdb.pb.h"
 #include "lineairdb/lineairdb.h"
@@ -8,6 +10,14 @@
 // Parallel scan helpers for primary ranges and PAX strip-direct scans. These
 // functions fall back to the serial path when the table, key shape, or row
 // count is not suitable for the specialized path.
+
+/**
+ * @brief Membership set for one hoisted semijoin reduction.
+ */
+struct SemijoinReduction {
+    std::unordered_set<std::string> keys;  // accepted join-key values
+    uint32_t probe_column = 0;             // probed column in the current row
+};
 
 /**
  * @brief Aggregate a full primary scan directly from PAX row-group strips.

--- a/server/rpc/parallel_scan.hh
+++ b/server/rpc/parallel_scan.hh
@@ -5,9 +5,21 @@
 #include "lineairdb.pb.h"
 #include "lineairdb/lineairdb.h"
 
-// Parallel scan helpers for integer primary-key ranges. These functions split
-// a range into ordered key slices and fall back to the serial path when the
-// table, key shape, or row count is not suitable for parallel execution.
+// Parallel scan helpers for primary ranges and PAX full-scan aggregates. These
+// functions fall back to the serial path when the table, key shape, or row
+// count is not suitable for the specialized path.
+
+/**
+ * @brief Aggregate a full primary scan directly from PAX row-group strips.
+ *
+ * @return true when group rows were emitted; false lets the caller use the
+ * materialized-row path.
+ */
+bool parallel_primary_pax_aggregate_scan(
+    LineairDB::Database* db,
+    const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,
+    const std::string& start_key, const std::string& end_key,
+    LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result);
 
 /**
  * @brief Scan integer primary-key slices in parallel and aggregate locally.

--- a/server/rpc/parallel_scan.hh
+++ b/server/rpc/parallel_scan.hh
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 #include "lineairdb.pb.h"
 #include "lineairdb/lineairdb.h"
@@ -42,7 +43,8 @@ bool parallel_primary_pax_row_ref_scan(
     const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,
     const std::string& start_key, const std::string& end_key,
     LineairDB::Protocol::TxExecuteReadPlan::StepResult* step_result,
-    bool& projection_failed);
+    bool& projection_failed,
+    const std::vector<SemijoinReduction>& semijoin_reductions);
 
 /**
  * @brief Scan integer primary-key slices in parallel and aggregate locally.

--- a/server/rpc/predicate_evaluator.cc
+++ b/server/rpc/predicate_evaluator.cc
@@ -92,6 +92,20 @@ bool PredicateEvaluator::set_row_from_pax(
   return true;
 }
 
+void PredicateEvaluator::set_row_from_views(
+    const std::vector<std::string_view>& cells,
+    const std::vector<bool>& nulls) {
+  columns_.assign(cells.begin(), cells.end());
+  null_flags_.assign((columns_.size() + 7) / 8, 0);
+  for (size_t idx = 0; idx < nulls.size() && idx < columns_.size(); ++idx) {
+    if (nulls[idx]) {
+      null_flags_[idx / 8] =
+          static_cast<char>(static_cast<unsigned char>(null_flags_[idx / 8]) |
+                            (1u << (idx % 8)));
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Value extraction
 // ---------------------------------------------------------------------------

--- a/server/rpc/predicate_evaluator.cc
+++ b/server/rpc/predicate_evaluator.cc
@@ -5,8 +5,46 @@
 #include <climits>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 
 using FilterExpr = LineairDB::Protocol::FilterExpr;
+
+namespace {
+
+bool parse_int_value(std::string_view value, int64_t* out) {
+  if (out == nullptr || value.empty()) return false;
+  const std::string text(value);
+  errno = 0;
+  char* end = nullptr;
+  const long long parsed = std::strtoll(text.c_str(), &end, 10);
+  if (errno != 0 || end != text.c_str() + text.size()) return false;
+  *out = static_cast<int64_t>(parsed);
+  return true;
+}
+
+bool parse_uint_value(std::string_view value, uint64_t* out) {
+  if (out == nullptr || value.empty() || value.front() == '-') return false;
+  const std::string text(value);
+  errno = 0;
+  char* end = nullptr;
+  const unsigned long long parsed = std::strtoull(text.c_str(), &end, 10);
+  if (errno != 0 || end != text.c_str() + text.size()) return false;
+  *out = static_cast<uint64_t>(parsed);
+  return true;
+}
+
+bool parse_double_value(std::string_view value, double* out) {
+  if (out == nullptr || value.empty()) return false;
+  const std::string text(value);
+  errno = 0;
+  char* end = nullptr;
+  const double parsed = std::strtod(text.c_str(), &end);
+  if (errno != 0 || end != text.c_str() + text.size()) return false;
+  *out = parsed;
+  return true;
+}
+
+}  // namespace
 
 // ---------------------------------------------------------------------------
 // Row parsing
@@ -161,10 +199,7 @@ PredicateEvaluator::Val PredicateEvaluator::extract_value(
       switch (expr.compare_type()) {
         case 0: {  // SIGNED_INT
           v.type = ValType::INT;
-          errno = 0;
-          char* end = nullptr;
-          v.i = std::strtoll(col.data(), &end, 10);
-          if (errno != 0 || end == col.data()) {
+          if (!parse_int_value(col, &v.i)) {
             // Conversion failed → fall back to string comparison
             v.type = ValType::STRING;
             v.s = col;
@@ -173,10 +208,7 @@ PredicateEvaluator::Val PredicateEvaluator::extract_value(
         }
         case 1: {  // UNSIGNED_INT
           v.type = ValType::UINT;
-          errno = 0;
-          char* end = nullptr;
-          v.u = std::strtoull(col.data(), &end, 10);
-          if (errno != 0 || end == col.data()) {
+          if (!parse_uint_value(col, &v.u)) {
             v.type = ValType::STRING;
             v.s = col;
           }
@@ -184,10 +216,7 @@ PredicateEvaluator::Val PredicateEvaluator::extract_value(
         }
         case 2: {  // DOUBLE
           v.type = ValType::DOUBLE;
-          errno = 0;
-          char* end = nullptr;
-          v.d = std::strtod(col.data(), &end);
-          if (errno != 0 || end == col.data()) {
+          if (!parse_double_value(col, &v.d)) {
             v.type = ValType::STRING;
             v.s = col;
           }

--- a/server/rpc/predicate_evaluator.cc
+++ b/server/rpc/predicate_evaluator.cc
@@ -72,6 +72,26 @@ bool PredicateEvaluator::parse_row(const char* data, size_t length,
   return field_index == total_fields;
 }
 
+bool PredicateEvaluator::set_row_from_pax(
+    const LineairDB::Pax::PaxGroup& group, uint32_t slot,
+    uint32_t num_columns) {
+  columns_.clear();
+  null_flags_.clear();
+
+  if (group.schema().field_count() < static_cast<size_t>(num_columns) + 1) {
+    return false;
+  }
+
+  const std::string_view null_flags = group.cell(0, slot);
+  null_flags_.assign(null_flags.data(), null_flags.size());
+
+  columns_.reserve(num_columns);
+  for (uint32_t i = 0; i < num_columns; ++i) {
+    columns_.push_back(group.cell(i + 1, slot));
+  }
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // Value extraction
 // ---------------------------------------------------------------------------

--- a/server/rpc/predicate_evaluator.hh
+++ b/server/rpc/predicate_evaluator.hh
@@ -39,6 +39,15 @@ class PredicateEvaluator {
   bool set_row_from_pax(const LineairDB::Pax::PaxGroup& group, uint32_t slot,
                         uint32_t num_columns);
 
+  /**
+   * @brief Read predicate inputs from already decoded column views.
+   *
+   * Joined tuple filters build a compact row consisting only of the columns
+   * referenced by the predicate. `nulls[i]` marks SQL NULL for `cells[i]`.
+   */
+  void set_row_from_views(const std::vector<std::string_view>& cells,
+                          const std::vector<bool>& nulls);
+
   // Recursively evaluate a FilterExpr tree against the parsed row.
   // Returns true if the row satisfies the predicate.
   bool evaluate(const LineairDB::Protocol::FilterExpr& expr) const;

--- a/server/rpc/predicate_evaluator.hh
+++ b/server/rpc/predicate_evaluator.hh
@@ -3,6 +3,8 @@
 
 #include "lineairdb.pb.h"
 
+#include <lineairdb/pax_store.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -25,6 +27,17 @@ class PredicateEvaluator {
   // byteSize == 0xFF means null/empty.
   // Returns false if the row is malformed.
   bool parse_row(const char* data, size_t length, uint32_t num_columns);
+
+  /**
+   * @brief Reads predicate inputs directly from a PAX row-group slot.
+   *
+   * The null-flags field is stored at PAX field 0, and MySQL column N is
+   * stored at PAX field N + 1.
+   *
+   * @return false when the PAX schema cannot contain the requested columns.
+   */
+  bool set_row_from_pax(const LineairDB::Pax::PaxGroup& group, uint32_t slot,
+                        uint32_t num_columns);
 
   // Recursively evaluate a FilterExpr tree against the parsed row.
   // Returns true if the row satisfies the predicate.

--- a/server/rpc/query_block_dispatch.cc
+++ b/server/rpc/query_block_dispatch.cc
@@ -1,0 +1,35 @@
+#include "lineairdb_rpc.hh"
+
+#include <memory>
+#include <string>
+
+#include "lineairdb.pb.h"
+#include "query_block_executor.hh"
+
+// Query-block dispatch: parse TX_EXECUTE_QUERY_BLOCK requests and hand them to
+// the server-side executor. Operator execution stays in query_block_executor.cc.
+
+void LineairDBRpc::handleTxExecuteQueryBlock(const std::string& message,
+                                             std::string& result) {
+    LineairDB::Protocol::TxExecuteQueryBlock::Request request;
+    LineairDB::Protocol::TxExecuteQueryBlock::Response response;
+
+    if (!request.ParseFromString(message)) {
+        response.set_ok(false);
+        response.set_error("failed to parse query-block request");
+        result = response.SerializeAsString();
+        return;
+    }
+
+    std::shared_ptr<LineairDB::Database> db =
+        db_manager_ ? db_manager_->get_database() : nullptr;
+    if (!db) {
+        response.set_ok(false);
+        response.set_error("database is unavailable");
+        result = response.SerializeAsString();
+        return;
+    }
+
+    query_block::ExecuteQueryBlock(db.get(), request, &response);
+    result = response.SerializeAsString();
+}

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -717,6 +717,113 @@ class Executor {
         }
     }
 
+    bool AggregateRowValue(const pb::QueryBlockAggregate& aggregate,
+                           int group_count, const GroupState& state,
+                           uint32_t ordinal, std::string* value,
+                           bool* is_null) {
+        value->clear();
+        *is_null = false;
+        if (ordinal < static_cast<uint32_t>(group_count)) {
+            value->assign(state.keys[ordinal]);
+            return true;
+        }
+
+        const int aggregate_idx = static_cast<int>(ordinal) - group_count;
+        if (aggregate_idx < 0 || aggregate_idx >= aggregate.aggs_size()) {
+            return fail("regroup value ordinal out of range");
+        }
+        value->assign(AggregateValue(aggregate.aggs(aggregate_idx), state,
+                                     aggregate_idx, is_null));
+        return true;
+    }
+
+    static void AppendRegroupKeyPart(std::string* key, std::string_view value,
+                                     bool is_null) {
+        key->push_back(is_null ? '\1' : '\0');
+        if (is_null) return;
+        AppendJoinKeyPart(key, value);
+    }
+
+    struct RegroupState {
+        std::vector<std::string> keys;
+        std::vector<bool> nulls;
+        uint64_t count = 0;
+    };
+
+    bool BuildRegroupedRows(const pb::QueryBlockAggregate& aggregate,
+                            int group_count, const GroupMap& groups,
+                            std::vector<OutputRow>* output_rows) {
+        const auto& regroup = aggregate.regroup();
+        if (!regroup.count_star()) return fail("regroup must count");
+
+        std::unordered_map<std::string, RegroupState> regrouped;
+        std::string key;
+        std::vector<std::string> values;
+        std::vector<bool> nulls;
+        for (const auto& entry : groups) {
+            const GroupState& state = entry.second;
+            key.clear();
+            values.clear();
+            nulls.clear();
+            values.reserve(regroup.group_value_ordinals_size());
+            nulls.reserve(regroup.group_value_ordinals_size());
+
+            for (const uint32_t ordinal : regroup.group_value_ordinals()) {
+                std::string value;
+                bool is_null = false;
+                if (!AggregateRowValue(aggregate, group_count, state, ordinal,
+                                       &value, &is_null)) {
+                    return false;
+                }
+                AppendRegroupKeyPart(&key, value, is_null);
+                values.push_back(std::move(value));
+                nulls.push_back(is_null);
+            }
+
+            auto [it, inserted] = regrouped.emplace(key, RegroupState{});
+            RegroupState& regroup_state = it->second;
+            if (inserted) {
+                regroup_state.keys = values;
+                regroup_state.nulls = nulls;
+            }
+            regroup_state.count += 1;
+        }
+
+        output_rows->clear();
+        output_rows->reserve(regrouped.size());
+        for (const auto& entry : regrouped) {
+            const RegroupState& state = entry.second;
+            OutputRow row;
+            row.values.reserve(request_.output_size());
+            row.nulls.reserve(request_.output_size());
+            for (const pb::QueryBlockOutputExpr& expression :
+                 request_.output()) {
+                switch (expression.source()) {
+                    case pb::QueryBlockOutputExpr::GROUP:
+                        if (expression.ordinal() >= state.keys.size()) {
+                            return fail("regroup output ordinal out of range");
+                        }
+                        row.values.push_back(
+                            state.keys[expression.ordinal()]);
+                        row.nulls.push_back(
+                            state.nulls[expression.ordinal()]);
+                        break;
+                    case pb::QueryBlockOutputExpr::AGG:
+                        if (expression.ordinal() != 0) {
+                            return fail("regroup aggregate ordinal out of range");
+                        }
+                        row.values.push_back(std::to_string(state.count));
+                        row.nulls.push_back(false);
+                        break;
+                    default:
+                        return fail("unsupported regroup output source");
+                }
+            }
+            output_rows->push_back(std::move(row));
+        }
+        return true;
+    }
+
     bool SortOutputRows(std::vector<OutputRow>* output_rows) {
         for (const pb::QueryBlockSortKey& key : request_.order_by()) {
             if (key.output_ordinal() >=
@@ -833,41 +940,53 @@ class Executor {
         }
 
         std::vector<OutputRow> output_rows;
-        output_rows.reserve(groups.size());
-        for (auto& entry : groups) {
-            GroupState& state = entry.second;
-            OutputRow row;
-            row.values.reserve(request_.output_size());
-            row.nulls.reserve(request_.output_size());
-            for (const pb::QueryBlockOutputExpr& expression :
-                 request_.output()) {
-                switch (expression.source()) {
-                    case pb::QueryBlockOutputExpr::GROUP:
-                        if (expression.ordinal() >=
-                            static_cast<uint32_t>(group_count)) {
-                            return fail("group output ordinal out of range");
-                        }
-                        row.values.push_back(
-                            state.keys[expression.ordinal()]);
-                        row.nulls.push_back(false);
-                        break;
-                    case pb::QueryBlockOutputExpr::AGG: {
-                        if (expression.ordinal() >=
-                            static_cast<uint32_t>(aggregate.aggs_size())) {
-                            return fail("aggregate output ordinal out of range");
-                        }
-                        bool is_null = false;
-                        row.values.push_back(AggregateValue(
-                            aggregate.aggs(expression.ordinal()), state,
-                            static_cast<int>(expression.ordinal()), &is_null));
-                        row.nulls.push_back(is_null);
-                        break;
-                    }
-                    default:
-                        return fail("unsupported query-block output source");
-                }
+        if (aggregate.has_regroup()) {
+            if (!BuildRegroupedRows(aggregate, group_count, groups,
+                                    &output_rows)) {
+                return false;
             }
-            output_rows.push_back(std::move(row));
+        } else {
+            output_rows.reserve(groups.size());
+            for (auto& entry : groups) {
+                GroupState& state = entry.second;
+                OutputRow row;
+                row.values.reserve(request_.output_size());
+                row.nulls.reserve(request_.output_size());
+                for (const pb::QueryBlockOutputExpr& expression :
+                     request_.output()) {
+                    switch (expression.source()) {
+                        case pb::QueryBlockOutputExpr::GROUP:
+                            if (expression.ordinal() >=
+                                static_cast<uint32_t>(group_count)) {
+                                return fail(
+                                    "group output ordinal out of range");
+                            }
+                            row.values.push_back(
+                                state.keys[expression.ordinal()]);
+                            row.nulls.push_back(false);
+                            break;
+                        case pb::QueryBlockOutputExpr::AGG: {
+                            if (expression.ordinal() >=
+                                static_cast<uint32_t>(
+                                    aggregate.aggs_size())) {
+                                return fail(
+                                    "aggregate output ordinal out of range");
+                            }
+                            bool is_null = false;
+                            row.values.push_back(AggregateValue(
+                                aggregate.aggs(expression.ordinal()), state,
+                                static_cast<int>(expression.ordinal()),
+                                &is_null));
+                            row.nulls.push_back(is_null);
+                            break;
+                        }
+                        default:
+                            return fail(
+                                "unsupported query-block output source");
+                    }
+                }
+                output_rows.push_back(std::move(row));
+            }
         }
 
         if (!SortOutputRows(&output_rows)) return false;

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -197,6 +197,13 @@ class Executor {
                 }
                 continue;
             }
+            if (node.has_filter()) {
+                if (node.filter().input() >=
+                    static_cast<uint32_t>(node_idx)) {
+                    return fail("tuple filter child order");
+                }
+                continue;
+            }
             if (node.has_aggregate()) {
                 if (node.aggregate().input() >=
                     static_cast<uint32_t>(node_idx)) {
@@ -223,6 +230,16 @@ class Executor {
         const int position = input.table_pos(table_idx);
         if (position < 0) return PaxRowRef{};
         return ToRowRef(table_idx, input.refs[position][row_idx]);
+    }
+
+    static bool IsNullColumn(const PaxRowRef& row, uint32_t column_idx) {
+        if (row.group == nullptr) return true;
+        const std::string_view null_flags = row.group->cell(0, row.slot);
+        const size_t byte_idx = column_idx / 8;
+        const uint32_t bit_idx = column_idx % 8;
+        return byte_idx < null_flags.size() &&
+               (static_cast<unsigned char>(null_flags[byte_idx]) &
+                (1u << bit_idx)) != 0;
     }
 
     static DecodedColumnRef DecodeAggregateColumnRef(
@@ -437,6 +454,140 @@ class Executor {
         for (const std::vector<uint64_t>& refs : local_refs) {
             output->refs[0].insert(output->refs[0].end(), refs.begin(),
                                    refs.end());
+        }
+        return true;
+    }
+
+    struct TupleFilterColumn {
+        int ref_position = -1;
+        uint32_t table_idx = 0;
+        uint32_t column = 0;
+    };
+
+    bool ResolveTupleFilterColumns(
+        const pb::QueryBlockTupleFilter& filter, const NodeResult& input,
+        std::vector<TupleFilterColumn>* columns) {
+        if (!filter.has_predicate() || !filter.predicate().has_expr()) {
+            return fail("tuple filter predicate missing");
+        }
+        if (filter.predicate().num_columns() !=
+            static_cast<uint32_t>(filter.columns_size())) {
+            return fail("tuple filter column count");
+        }
+
+        columns->clear();
+        columns->reserve(filter.columns_size());
+        for (const pb::QueryBlockColumnRef& column : filter.columns()) {
+            const int position = input.table_pos(column.table_idx());
+            if (position < 0) return fail("tuple filter table");
+            columns->push_back(
+                TupleFilterColumn{position, column.table_idx(),
+                                  column.column()});
+        }
+        return true;
+    }
+
+    bool BuildTupleFilterRow(
+        const NodeResult& input,
+        const std::vector<TupleFilterColumn>& columns, size_t row_idx,
+        std::vector<std::string_view>* cells,
+        std::vector<bool>* nulls) const {
+        cells->resize(columns.size());
+        nulls->resize(columns.size());
+        for (size_t column_idx = 0; column_idx < columns.size();
+             ++column_idx) {
+            const TupleFilterColumn& column = columns[column_idx];
+            const uint64_t ref = input.refs[column.ref_position][row_idx];
+            if (ref == kNullRowRef) {
+                (*cells)[column_idx] = {};
+                (*nulls)[column_idx] = true;
+                continue;
+            }
+
+            const PaxRowRef row = ToRowRef(column.table_idx, ref);
+            if (row.group == nullptr) return false;
+            (*cells)[column_idx] =
+                extract_value_column(row, static_cast<int>(column.column));
+            (*nulls)[column_idx] = IsNullColumn(row, column.column);
+        }
+        return true;
+    }
+
+    bool RunTupleFilter(const pb::QueryBlockTupleFilterNode& filter,
+                        NodeResult* output) {
+        if (filter.input() >= results_.size()) {
+            return fail("tuple filter child out of range");
+        }
+        const NodeResult& input = results_[filter.input()];
+
+        std::vector<TupleFilterColumn> columns;
+        if (!ResolveTupleFilterColumns(filter.filter(), input, &columns)) {
+            return false;
+        }
+
+        output->tables = input.tables;
+        output->refs.assign(input.refs.size(), {});
+        const size_t input_rows = input.rows();
+        const unsigned worker_count = static_cast<unsigned>(std::min<size_t>(
+            WorkerCount(), std::max<size_t>(input_rows / 16384, 1)));
+
+        struct WorkerOutput {
+            std::vector<std::vector<uint64_t>> refs;
+        };
+        std::vector<WorkerOutput> local_outputs(worker_count);
+        std::vector<char> worker_failed(worker_count, 0);
+        std::vector<std::thread> workers;
+        workers.reserve(worker_count);
+
+        for (unsigned worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+            workers.emplace_back([&, worker_idx] {
+                PredicateEvaluator evaluator;
+                std::vector<std::string_view> cells;
+                std::vector<bool> nulls;
+                WorkerOutput& local = local_outputs[worker_idx];
+                local.refs.assign(input.refs.size(), {});
+                const size_t begin = input_rows * worker_idx / worker_count;
+                const size_t end =
+                    input_rows * (worker_idx + 1) / worker_count;
+                for (size_t row_idx = begin; row_idx < end; ++row_idx) {
+                    if (!BuildTupleFilterRow(input, columns, row_idx, &cells,
+                                             &nulls)) {
+                        worker_failed[worker_idx] = 1;
+                        return;
+                    }
+                    evaluator.set_row_from_views(cells, nulls);
+                    if (!evaluator.evaluate(filter.filter().predicate()
+                                                .expr())) {
+                        continue;
+                    }
+                    for (size_t column_idx = 0; column_idx < input.refs.size();
+                         ++column_idx) {
+                        local.refs[column_idx].push_back(
+                            input.refs[column_idx][row_idx]);
+                    }
+                }
+            });
+        }
+
+        for (std::thread& worker : workers) worker.join();
+        for (char failed : worker_failed) {
+            if (failed) return fail("tuple filter cannot read PAX columns");
+        }
+
+        size_t total_rows = 0;
+        for (const WorkerOutput& local : local_outputs) {
+            total_rows += local.refs.empty() ? 0 : local.refs[0].size();
+        }
+        for (size_t column_idx = 0; column_idx < output->refs.size();
+             ++column_idx) {
+            output->refs[column_idx].reserve(total_rows);
+            for (const WorkerOutput& local : local_outputs) {
+                if (local.refs.empty()) continue;
+                output->refs[column_idx].insert(
+                    output->refs[column_idx].end(),
+                    local.refs[column_idx].begin(),
+                    local.refs[column_idx].end());
+            }
         }
         return true;
     }
@@ -1201,6 +1352,12 @@ class Executor {
             }
             if (node.has_join()) {
                 if (!RunJoin(node.join(), &results_[node_idx])) return false;
+                continue;
+            }
+            if (node.has_filter()) {
+                if (!RunTupleFilter(node.filter(), &results_[node_idx])) {
+                    return false;
+                }
                 continue;
             }
             if (node.has_aggregate()) {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -6,13 +6,16 @@
 #include <exception>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include <lineairdb/database.h>
 #include <lineairdb/pax_store.h>
 
+#include "decimal_arithmetic.hh"
 #include "predicate_evaluator.hh"
+#include "row_codec.hh"
 
 namespace query_block {
 namespace {
@@ -134,6 +137,14 @@ class Executor {
         return true;
     }
 
+    PaxRowRef ToRowRef(uint32_t table_idx, uint64_t ref) const {
+        PaxStore* store = stores_[table_idx];
+        return PaxRowRef{
+            store->group(ref / PaxGroup::kRows),
+            static_cast<uint32_t>(ref % PaxGroup::kRows),
+        };
+    }
+
     bool RunScan(const pb::QueryBlockScan& scan, NodeResult* output) {
         if (scan.table_idx() >= static_cast<uint32_t>(request_.tables_size())) {
             return fail("scan table out of range");
@@ -213,6 +224,245 @@ class Executor {
         return true;
     }
 
+    struct GroupState {
+        std::vector<std::string> keys;
+        std::vector<uint64_t> counts;
+        std::vector<DecimalValue> decimals;
+        std::vector<std::string> strings;
+        std::vector<bool> has_value;
+    };
+
+    using GroupMap = std::unordered_map<std::string, GroupState>;
+
+    bool AccumulateRange(const pb::QueryBlockAggregate& aggregate,
+                         const NodeResult& input, size_t begin, size_t end,
+                         GroupMap* groups) {
+        const int group_count = aggregate.group_columns_size();
+        const int aggregate_count = aggregate.aggs_size();
+
+        std::vector<int> group_positions(group_count, -1);
+        for (int group_idx = 0; group_idx < group_count; ++group_idx) {
+            group_positions[group_idx] =
+                input.table_pos(aggregate.group_columns(group_idx).table_idx());
+            if (group_positions[group_idx] < 0) {
+                return fail("group table is not in aggregate input");
+            }
+        }
+
+        std::vector<int> aggregate_positions(aggregate_count, -1);
+        for (int aggregate_idx = 0; aggregate_idx < aggregate_count;
+             ++aggregate_idx) {
+            const pb::QueryBlockAggFunc& function =
+                aggregate.aggs(aggregate_idx);
+            if (function.has_arg() || function.has_filter()) {
+                aggregate_positions[aggregate_idx] =
+                    input.table_pos(function.arg_table());
+                if (aggregate_positions[aggregate_idx] < 0) {
+                    return fail("aggregate table is not in aggregate input");
+                }
+            }
+        }
+
+        PredicateEvaluator evaluator;
+        std::string key_buffer;
+        std::vector<std::string_view> group_values(group_count);
+        for (size_t row_idx = begin; row_idx < end; ++row_idx) {
+            key_buffer.clear();
+            for (int group_idx = 0; group_idx < group_count; ++group_idx) {
+                const pb::QueryBlockColumnRef& column =
+                    aggregate.group_columns(group_idx);
+                const uint64_t ref =
+                    input.refs[group_positions[group_idx]][row_idx];
+                group_values[group_idx] =
+                    extract_value_column(ToRowRef(column.table_idx(), ref),
+                                         column.column());
+                const uint32_t length =
+                    static_cast<uint32_t>(group_values[group_idx].size());
+                key_buffer.append(reinterpret_cast<const char*>(&length),
+                                  sizeof(length));
+                key_buffer.append(group_values[group_idx].data(),
+                                  group_values[group_idx].size());
+            }
+
+            auto group_it = groups->find(key_buffer);
+            GroupState* state = nullptr;
+            if (group_it == groups->end()) {
+                GroupState new_state;
+                new_state.keys.resize(group_count);
+                for (int group_idx = 0; group_idx < group_count; ++group_idx) {
+                    new_state.keys[group_idx] =
+                        std::string(group_values[group_idx]);
+                }
+                new_state.counts.assign(aggregate_count, 0);
+                new_state.decimals.assign(aggregate_count, DecimalValue{});
+                new_state.strings.assign(aggregate_count, {});
+                new_state.has_value.assign(aggregate_count, false);
+                state = &groups->emplace(std::move(key_buffer),
+                                         std::move(new_state))
+                             .first->second;
+                key_buffer.clear();
+            } else {
+                state = &group_it->second;
+            }
+
+            for (int aggregate_idx = 0; aggregate_idx < aggregate_count;
+                 ++aggregate_idx) {
+                const pb::QueryBlockAggFunc& function =
+                    aggregate.aggs(aggregate_idx);
+                const int input_pos = aggregate_positions[aggregate_idx];
+                const uint64_t ref =
+                    input_pos >= 0 ? input.refs[input_pos][row_idx] : 0;
+
+                if (function.has_filter() && function.filter().has_expr()) {
+                    PaxRowRef row = ToRowRef(function.arg_table(), ref);
+                    if (row.group == nullptr ||
+                        !evaluator.set_row_from_pax(
+                            *row.group, row.slot,
+                            function.filter().num_columns())) {
+                        return fail("aggregate filter cannot read PAX columns");
+                    }
+                    if (!evaluator.evaluate(function.filter().expr())) {
+                        continue;
+                    }
+                }
+
+                switch (function.kind()) {
+                    case pb::QueryBlockAggFunc::COUNT:
+                        state->counts[aggregate_idx] += 1;
+                        break;
+                    case pb::QueryBlockAggFunc::SUM:
+                    case pb::QueryBlockAggFunc::AVG: {
+                        DecimalValue value = evaluate_decimal_expression(
+                            function.arg(),
+                            ToRowRef(function.arg_table(), ref));
+                        if (value.is_null) break;
+                        add_decimal_value(state->decimals[aggregate_idx],
+                                          value);
+                        state->counts[aggregate_idx] += 1;
+                        break;
+                    }
+                    case pb::QueryBlockAggFunc::MIN:
+                    case pb::QueryBlockAggFunc::MAX: {
+                        const bool wants_max =
+                            function.kind() == pb::QueryBlockAggFunc::MAX;
+                        if (function.cmp_kind() == 1) {
+                            std::string_view value = extract_value_column(
+                                ToRowRef(function.arg_table(), ref),
+                                function.arg().column_index());
+                            if (!state->has_value[aggregate_idx] ||
+                                (wants_max
+                                     ? value >
+                                           std::string_view(
+                                               state->strings[aggregate_idx])
+                                     : value <
+                                           std::string_view(
+                                               state->strings[aggregate_idx]))) {
+                                state->strings[aggregate_idx] =
+                                    std::string(value);
+                            }
+                        } else {
+                            DecimalValue value = evaluate_decimal_expression(
+                                function.arg(),
+                                ToRowRef(function.arg_table(), ref));
+                            if (value.is_null) break;
+                            if (!state->has_value[aggregate_idx] ||
+                                (wants_max
+                                     ? compare_decimal_values(
+                                           value,
+                                           state->decimals[aggregate_idx]) > 0
+                                     : compare_decimal_values(
+                                           value,
+                                           state->decimals[aggregate_idx]) < 0)) {
+                                state->decimals[aggregate_idx] = value;
+                            }
+                        }
+                        state->has_value[aggregate_idx] = true;
+                        break;
+                    }
+                    default:
+                        return fail("unsupported aggregate function");
+                }
+            }
+        }
+        return true;
+    }
+
+    static void MergeGroups(GroupMap* destination, GroupMap* source,
+                            const pb::QueryBlockAggregate& aggregate) {
+        if (destination->empty()) {
+            *destination = std::move(*source);
+            return;
+        }
+
+        for (auto& entry : *source) {
+            auto destination_it = destination->find(entry.first);
+            if (destination_it == destination->end()) {
+                destination->emplace(entry.first, std::move(entry.second));
+                continue;
+            }
+
+            GroupState& destination_state = destination_it->second;
+            GroupState& source_state = entry.second;
+            for (int aggregate_idx = 0;
+                 aggregate_idx < aggregate.aggs_size(); ++aggregate_idx) {
+                const pb::QueryBlockAggFunc& function =
+                    aggregate.aggs(aggregate_idx);
+                switch (function.kind()) {
+                    case pb::QueryBlockAggFunc::COUNT:
+                        destination_state.counts[aggregate_idx] +=
+                            source_state.counts[aggregate_idx];
+                        break;
+                    case pb::QueryBlockAggFunc::SUM:
+                    case pb::QueryBlockAggFunc::AVG:
+                        if (source_state.counts[aggregate_idx] > 0) {
+                            add_decimal_value(
+                                destination_state.decimals[aggregate_idx],
+                                source_state.decimals[aggregate_idx]);
+                            destination_state.counts[aggregate_idx] +=
+                                source_state.counts[aggregate_idx];
+                        }
+                        break;
+                    case pb::QueryBlockAggFunc::MIN:
+                    case pb::QueryBlockAggFunc::MAX: {
+                        if (!source_state.has_value[aggregate_idx]) break;
+                        const bool wants_max =
+                            function.kind() == pb::QueryBlockAggFunc::MAX;
+                        if (function.cmp_kind() == 1) {
+                            if (!destination_state.has_value[aggregate_idx] ||
+                                (wants_max
+                                     ? source_state.strings[aggregate_idx] >
+                                           destination_state
+                                               .strings[aggregate_idx]
+                                     : source_state.strings[aggregate_idx] <
+                                           destination_state
+                                               .strings[aggregate_idx])) {
+                                destination_state.strings[aggregate_idx] =
+                                    std::move(
+                                        source_state.strings[aggregate_idx]);
+                            }
+                        } else if (
+                            !destination_state.has_value[aggregate_idx] ||
+                            (wants_max
+                                 ? compare_decimal_values(
+                                       source_state.decimals[aggregate_idx],
+                                       destination_state
+                                           .decimals[aggregate_idx]) > 0
+                                 : compare_decimal_values(
+                                       source_state.decimals[aggregate_idx],
+                                       destination_state
+                                           .decimals[aggregate_idx]) < 0)) {
+                            destination_state.decimals[aggregate_idx] =
+                                source_state.decimals[aggregate_idx];
+                        }
+                        destination_state.has_value[aggregate_idx] = true;
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            }
+        }
+    }
     bool RunNodes() {
         results_.resize(request_.nodes_size());
         for (int node_idx = 0; node_idx < request_.nodes_size(); ++node_idx) {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -686,7 +686,9 @@ class Executor {
     bool RunJoin(const pb::QueryBlockJoin& join, NodeResult* output) {
         const bool is_inner = join.type() == pb::QueryBlockJoin::INNER;
         const bool is_left = join.type() == pb::QueryBlockJoin::LEFT;
-        if (!is_inner && !is_left) {
+        const bool is_semi = join.type() == pb::QueryBlockJoin::SEMI;
+        const bool is_anti = join.type() == pb::QueryBlockJoin::ANTI;
+        if (!is_inner && !is_left && !is_semi && !is_anti) {
             return fail("unsupported query-block join type");
         }
         if (join.build_keys_size() != join.probe_keys_size() ||
@@ -697,9 +699,9 @@ class Executor {
             return fail("join child out of range");
         }
 
-        // INNER joins are symmetric; hash the smaller child at runtime. LEFT
-        // joins keep the request's build/probe sides because probe rows must be
-        // preserved when the build side has no match.
+        // INNER joins are symmetric; hash the smaller child at runtime. LEFT,
+        // SEMI, and ANTI keep the request's build/probe sides because their
+        // output semantics are defined by the probe side.
         const bool swap =
             is_inner &&
             results_[join.build()].rows() > results_[join.probe()].rows();
@@ -729,7 +731,7 @@ class Executor {
             join.has_residual() && join.residual().has_predicate() &&
             join.residual().predicate().has_expr();
         if (has_residual) {
-            if (!is_inner) return fail("residual on non-inner join");
+            if (is_left) return fail("residual on LEFT join");
             if (join.residual().predicate().num_columns() !=
                 static_cast<uint32_t>(join.residual().columns_size())) {
                 return fail("join residual column count");
@@ -765,9 +767,12 @@ class Executor {
 
         // Keep only row references in the joined tuple; later operators read
         // column values directly from each table's PAX strips.
+        const bool keep_build = is_inner || is_left;
         output->tables = probe.tables;
-        output->tables.insert(output->tables.end(), build.tables.begin(),
-                              build.tables.end());
+        if (keep_build) {
+            output->tables.insert(output->tables.end(),
+                                  build.tables.begin(), build.tables.end());
+        }
         output->refs.assign(output->tables.size(), {});
 
         struct WorkerOutput {
@@ -833,7 +838,47 @@ class Executor {
                     const auto match = has_probe_key
                                            ? hash_table.find(probe_key)
                                            : hash_table.end();
+                    bool matched =
+                        match != hash_table.end() && !match->second.empty();
+                    if (matched && has_residual) {
+                        matched = false;
+                        for (const size_t build_idx : match->second) {
+                            if (residual_ok(probe_idx, build_idx)) {
+                                matched = true;
+                                break;
+                            }
+                        }
+                    }
+
                     if (match == hash_table.end()) {
+                        if (!is_left && !is_anti) continue;
+                        for (size_t column_idx = 0;
+                             column_idx < probe.tables.size(); ++column_idx) {
+                            local.refs[column_idx].push_back(
+                                probe.refs[column_idx][probe_idx]);
+                        }
+                        if (is_anti) continue;
+                        for (size_t column_idx = 0;
+                             column_idx < build.tables.size(); ++column_idx) {
+                            local.refs[probe.tables.size() + column_idx]
+                                .push_back(kNullRowRef);
+                        }
+                        continue;
+                    }
+
+                    if (is_semi || is_anti) {
+                        if (matched == is_semi) {
+                            for (size_t column_idx = 0;
+                                 column_idx < probe.tables.size();
+                                 ++column_idx) {
+                                local.refs[column_idx].push_back(
+                                    probe.refs[column_idx][probe_idx]);
+                            }
+                        }
+                        continue;
+                    }
+
+                    if (!matched) {
                         if (!is_left) continue;
                         for (size_t column_idx = 0;
                              column_idx < probe.tables.size(); ++column_idx) {
@@ -849,7 +894,10 @@ class Executor {
                     }
 
                     for (const size_t build_idx : match->second) {
-                        if (!residual_ok(probe_idx, build_idx)) continue;
+                        if (has_residual &&
+                            !residual_ok(probe_idx, build_idx)) {
+                            continue;
+                        }
                         for (size_t column_idx = 0;
                              column_idx < probe.tables.size(); ++column_idx) {
                             local.refs[column_idx].push_back(

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -142,19 +142,24 @@ class Executor {
 
         stores_.assign(request_.tables_size(), nullptr);
         write_counter_snapshots_.assign(request_.tables_size(), {});
+        slot_snapshots_.assign(request_.tables_size(), 0);
+        overflow_snapshots_.assign(request_.tables_size(), 0);
         for (int table_idx = 0; table_idx < request_.tables_size();
              ++table_idx) {
             PaxStore* store =
                 db_->GetPaxStore(request_.tables(table_idx).table_name());
             if (store == nullptr) return fail("table has no PAX store");
-            if (store->overflow_count() > 0) {
+            const uint64_t overflow_snapshot = store->overflow_count();
+            if (overflow_snapshot > 0) {
                 return fail("table has heap fallback rows");
             }
 
             stores_[table_idx] = store;
+            slot_snapshots_[table_idx] = store->slots_allocated();
+            overflow_snapshots_[table_idx] = overflow_snapshot;
 
             // Capture each allocated group's writer counter before operators
-            // read strip cells. A changed counter rejects the whole request.
+            // read strip cells. A changed or odd counter rejects the request.
             std::vector<uint64_t>& snapshot =
                 write_counter_snapshots_[table_idx];
             snapshot.resize(store->group_count());
@@ -165,6 +170,9 @@ class Executor {
                     group == nullptr
                         ? 0
                         : group->write_counter.load(std::memory_order_acquire);
+                if ((snapshot[group_idx] & 1u) != 0) {
+                    return fail("table has in-progress PAX writes");
+                }
             }
         }
         return true;
@@ -359,7 +367,8 @@ class Executor {
         }
 
         PaxStore* store = stores_[scan.table_idx()];
-        const size_t group_count = store->group_count();
+        const size_t group_count =
+            write_counter_snapshots_[scan.table_idx()].size();
         output->tables = {scan.table_idx()};
         output->refs.assign(1, {});
         if (group_count == 0) return true;
@@ -1208,6 +1217,10 @@ class Executor {
     bool TablesAreStillQuiet() const {
         for (size_t table_idx = 0; table_idx < stores_.size(); ++table_idx) {
             PaxStore* store = stores_[table_idx];
+            if (store->slots_allocated() != slot_snapshots_[table_idx] ||
+                store->overflow_count() != overflow_snapshots_[table_idx]) {
+                return false;
+            }
             const std::vector<uint64_t>& snapshot =
                 write_counter_snapshots_[table_idx];
             for (size_t group_idx = 0; group_idx < snapshot.size();
@@ -1217,7 +1230,9 @@ class Executor {
                     group == nullptr
                         ? 0
                         : group->write_counter.load(std::memory_order_acquire);
-                if (current != snapshot[group_idx]) return false;
+                if ((current & 1u) != 0 || current != snapshot[group_idx]) {
+                    return false;
+                }
             }
         }
         return true;
@@ -1234,6 +1249,8 @@ class Executor {
     std::string error_;
     std::vector<PaxStore*> stores_;
     std::vector<std::vector<uint64_t>> write_counter_snapshots_;
+    std::vector<uint64_t> slot_snapshots_;
+    std::vector<uint64_t> overflow_snapshots_;
     std::vector<NodeResult> results_;
 };
 

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -1750,6 +1750,60 @@ class Executor {
         }
     }
 
+    bool RunEmitRows(
+        const NodeResult& input,
+        pb::TxExecuteQueryBlock::Response* response) {
+        std::vector<int> output_positions(request_.output_size(), -1);
+        for (int output_idx = 0; output_idx < request_.output_size();
+             ++output_idx) {
+            const pb::QueryBlockOutputExpr& expression =
+                request_.output(output_idx);
+            if (expression.source() != pb::QueryBlockOutputExpr::COLUMN) {
+                return fail("row output source");
+            }
+            output_positions[output_idx] =
+                input.table_pos(expression.column().table_idx());
+            if (output_positions[output_idx] < 0) {
+                return fail("row output table is not in input");
+            }
+        }
+
+        std::vector<OutputRow> output_rows;
+        output_rows.reserve(input.rows());
+        for (size_t row_idx = 0; row_idx < input.rows(); ++row_idx) {
+            OutputRow row;
+            row.values.reserve(request_.output_size());
+            row.nulls.reserve(request_.output_size());
+
+            for (int output_idx = 0; output_idx < request_.output_size();
+                 ++output_idx) {
+                const pb::QueryBlockColumnRef& column =
+                    request_.output(output_idx).column();
+                const uint64_t ref =
+                    input.refs[output_positions[output_idx]][row_idx];
+                if (NullOf(column.table_idx(), ref, column.column())) {
+                    row.values.emplace_back();
+                    row.nulls.push_back(true);
+                    continue;
+                }
+
+                std::string_view value =
+                    ValueOf(column.table_idx(), ref, column.column());
+                if (column.prefix_len() > 0 &&
+                    value.size() > column.prefix_len()) {
+                    value = value.substr(0, column.prefix_len());
+                }
+                row.values.emplace_back(value);
+                row.nulls.push_back(false);
+            }
+            output_rows.push_back(std::move(row));
+        }
+
+        if (!SortOutputRows(&output_rows)) return false;
+        EmitOutputRows(output_rows, response);
+        return true;
+    }
+
     bool RunAggregateAndEmit(
         const pb::QueryBlockAggregate& aggregate,
         pb::TxExecuteQueryBlock::Response* response) {
@@ -1947,7 +2001,8 @@ class Executor {
             }
             return fail("unknown query-block node");
         }
-        return fail("root must be an aggregate node");
+        if (request_.nodes_size() == 0) return fail("root node missing");
+        return RunEmitRows(results_.back(), response);
     }
 
     bool TablesAreStillQuiet() const {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <exception>
 #include <limits>
+#include <set>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -1080,6 +1081,7 @@ class Executor {
         std::vector<DecimalValue> decimals;
         std::vector<std::string> strings;
         std::vector<bool> has_value;
+        std::vector<std::set<std::string>> distinct_values;
     };
 
     struct OutputRow {
@@ -1206,6 +1208,7 @@ class Executor {
                 new_state.decimals.assign(aggregate_count, DecimalValue{});
                 new_state.strings.assign(aggregate_count, {});
                 new_state.has_value.assign(aggregate_count, false);
+                new_state.distinct_values.resize(aggregate_count);
                 state = &groups->emplace(std::move(key_buffer),
                                          std::move(new_state))
                              .first->second;
@@ -1246,6 +1249,17 @@ class Executor {
 
                 switch (function.kind()) {
                     case pb::QueryBlockAggFunc::COUNT:
+                        if (function.distinct()) {
+                            if (!function.has_arg() || !has_arg_row) break;
+                            std::string_view value;
+                            if (ReadAggregateColumn(
+                                    function.arg(), input, row_idx,
+                                    function.arg_table(), &value)) {
+                                state->distinct_values[aggregate_idx].emplace(
+                                    value);
+                            }
+                            break;
+                        }
                         if (function.has_arg() && !has_arg_row) break;
                         state->counts[aggregate_idx] += 1;
                         break;
@@ -1332,6 +1346,12 @@ class Executor {
                     aggregate.aggs(aggregate_idx);
                 switch (function.kind()) {
                     case pb::QueryBlockAggFunc::COUNT:
+                        if (function.distinct()) {
+                            destination_state.distinct_values[aggregate_idx]
+                                .merge(source_state
+                                           .distinct_values[aggregate_idx]);
+                            break;
+                        }
                         destination_state.counts[aggregate_idx] +=
                             source_state.counts[aggregate_idx];
                         break;
@@ -1393,7 +1413,10 @@ class Executor {
         *is_null = false;
         switch (function.kind()) {
             case pb::QueryBlockAggFunc::COUNT:
-                return std::to_string(state.counts[aggregate_idx]);
+                return std::to_string(
+                    function.distinct()
+                        ? state.distinct_values[aggregate_idx].size()
+                        : state.counts[aggregate_idx]);
             case pb::QueryBlockAggFunc::SUM:
                 if (state.counts[aggregate_idx] == 0) {
                     if (function.zero_if_empty()) {
@@ -1774,7 +1797,51 @@ class Executor {
             state.decimals.assign(aggregate.aggs_size(), DecimalValue{});
             state.strings.assign(aggregate.aggs_size(), {});
             state.has_value.assign(aggregate.aggs_size(), false);
+            state.distinct_values.resize(aggregate.aggs_size());
             groups.emplace(std::string(), std::move(state));
+        }
+
+        // HAVING predicates read the first-stage aggregate row layout:
+        // group values first, then aggregate values.
+        if (aggregate.has_having() && aggregate.having().has_expr()) {
+            PredicateEvaluator evaluator;
+            std::vector<std::string> values;
+            std::vector<std::string_view> cells;
+            std::vector<bool> nulls;
+            for (auto group_it = groups.begin(); group_it != groups.end();) {
+                const GroupState& state = group_it->second;
+                values.clear();
+                cells.clear();
+                nulls.clear();
+                values.reserve(group_count + aggregate.aggs_size());
+                cells.reserve(group_count + aggregate.aggs_size());
+                nulls.reserve(group_count + aggregate.aggs_size());
+
+                for (int group_idx = 0; group_idx < group_count;
+                     ++group_idx) {
+                    values.push_back(state.keys[group_idx]);
+                    nulls.push_back(false);
+                }
+                for (int aggregate_idx = 0;
+                     aggregate_idx < aggregate.aggs_size();
+                     ++aggregate_idx) {
+                    bool is_null = false;
+                    values.push_back(AggregateValue(
+                        aggregate.aggs(aggregate_idx), state,
+                        aggregate_idx, &is_null));
+                    nulls.push_back(is_null);
+                }
+                for (const std::string& value : values) {
+                    cells.push_back(value);
+                }
+
+                evaluator.set_row_from_views(cells, nulls);
+                if (evaluator.evaluate(aggregate.having().expr())) {
+                    ++group_it;
+                } else {
+                    group_it = groups.erase(group_it);
+                }
+            }
         }
 
         std::vector<OutputRow> output_rows;

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -1,15 +1,146 @@
 #include "query_block_executor.hh"
 
+#include <atomic>
+#include <cstdint>
 #include <exception>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <lineairdb/database.h>
+#include <lineairdb/pax_store.h>
 
 namespace query_block {
 namespace {
 
-void fail(LineairDB::Protocol::TxExecuteQueryBlock::Response* response,
-          const char* message) {
+namespace pb = LineairDB::Protocol;
+using LineairDB::Pax::PaxGroup;
+using LineairDB::Pax::PaxStore;
+
+void set_failure(pb::TxExecuteQueryBlock::Response* response,
+                 const std::string& message) {
     if (response == nullptr) return;
     response->set_ok(false);
     response->set_error(message);
+    response->clear_rows();
+}
+
+class Executor {
+ public:
+    Executor(LineairDB::Database* db,
+             const pb::TxExecuteQueryBlock::Request& request)
+        : db_(db), request_(request) {}
+
+    bool Run() {
+        if (!PrepareTables()) return false;
+        if (!ValidateNodeOrder()) return false;
+        if (!TablesAreStillQuiet()) return fail("concurrent modification");
+        return fail("query-block operators are not implemented");
+    }
+
+    const std::string& error() const { return error_; }
+
+ private:
+    bool fail(std::string message) {
+        if (error_.empty()) error_ = std::move(message);
+        return false;
+    }
+
+    bool PrepareTables() {
+        if (db_ == nullptr) return fail("database is unavailable");
+        if (request_.tables_size() == 0) {
+            return fail("query block has no tables");
+        }
+
+        stores_.assign(request_.tables_size(), nullptr);
+        write_counter_snapshots_.assign(request_.tables_size(), {});
+        for (int table_idx = 0; table_idx < request_.tables_size();
+             ++table_idx) {
+            PaxStore* store =
+                db_->GetPaxStore(request_.tables(table_idx).table_name());
+            if (store == nullptr) return fail("table has no PAX store");
+            if (store->overflow_count() > 0) {
+                return fail("table has heap fallback rows");
+            }
+
+            stores_[table_idx] = store;
+
+            // Capture each allocated group's writer counter before operators
+            // read strip cells. A changed counter rejects the whole request.
+            std::vector<uint64_t>& snapshot =
+                write_counter_snapshots_[table_idx];
+            snapshot.resize(store->group_count());
+            for (size_t group_idx = 0; group_idx < snapshot.size();
+                 ++group_idx) {
+                PaxGroup* group = store->group(group_idx);
+                snapshot[group_idx] =
+                    group == nullptr
+                        ? 0
+                        : group->write_counter.load(std::memory_order_acquire);
+            }
+        }
+        return true;
+    }
+
+    bool ValidateNodeOrder() {
+        if (request_.nodes_size() == 0) return fail("empty query block");
+
+        for (int node_idx = 0; node_idx < request_.nodes_size(); ++node_idx) {
+            const pb::QueryBlockNode& node = request_.nodes(node_idx);
+            if (node.has_scan()) {
+                if (node.scan().table_idx() >=
+                    static_cast<uint32_t>(request_.tables_size())) {
+                    return fail("scan table out of range");
+                }
+                continue;
+            }
+            if (node.has_join()) {
+                if (node.join().build() >= static_cast<uint32_t>(node_idx) ||
+                    node.join().probe() >= static_cast<uint32_t>(node_idx)) {
+                    return fail("join child order");
+                }
+                continue;
+            }
+            if (node.has_aggregate()) {
+                if (node.aggregate().input() >=
+                    static_cast<uint32_t>(node_idx)) {
+                    return fail("aggregate child order");
+                }
+                continue;
+            }
+            return fail("unknown query-block node");
+        }
+        return true;
+    }
+
+    bool TablesAreStillQuiet() const {
+        for (size_t table_idx = 0; table_idx < stores_.size(); ++table_idx) {
+            PaxStore* store = stores_[table_idx];
+            const std::vector<uint64_t>& snapshot =
+                write_counter_snapshots_[table_idx];
+            for (size_t group_idx = 0; group_idx < snapshot.size();
+                 ++group_idx) {
+                PaxGroup* group = store->group(group_idx);
+                const uint64_t current =
+                    group == nullptr
+                        ? 0
+                        : group->write_counter.load(std::memory_order_acquire);
+                if (current != snapshot[group_idx]) return false;
+            }
+        }
+        return true;
+    }
+
+    LineairDB::Database* db_;
+    const pb::TxExecuteQueryBlock::Request& request_;
+    std::string error_;
+    std::vector<PaxStore*> stores_;
+    std::vector<std::vector<uint64_t>> write_counter_snapshots_;
+};
+
+const std::string& default_error(const Executor& executor) {
+    static const std::string kDefaultError = "query-block execution failed";
+    return executor.error().empty() ? kDefaultError : executor.error();
 }
 
 }  // namespace
@@ -18,15 +149,20 @@ void ExecuteQueryBlock(
     LineairDB::Database* db,
     const LineairDB::Protocol::TxExecuteQueryBlock::Request& request,
     LineairDB::Protocol::TxExecuteQueryBlock::Response* response) {
-    (void)db;
-    (void)request;
+    if (response == nullptr) return;
+    response->Clear();
 
     try {
-        fail(response, "query-block execution is not implemented");
+        Executor executor(db, request);
+        if (!executor.Run()) {
+            set_failure(response, default_error(executor));
+            return;
+        }
+        response->set_ok(true);
     } catch (const std::exception& e) {
-        fail(response, e.what());
+        set_failure(response, e.what());
     } catch (...) {
-        fail(response, "query-block execution failed");
+        set_failure(response, "query-block execution failed");
     }
 }
 

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -667,6 +667,41 @@ class Executor {
             return fail("probe key table is not in join input");
         }
 
+        struct ResidualColumn {
+            bool from_build = false;
+            int ref_position = -1;
+            uint32_t table_idx = 0;
+            uint32_t column = 0;
+        };
+
+        std::vector<ResidualColumn> residual_columns;
+        const bool has_residual =
+            join.has_residual() && join.residual().has_predicate() &&
+            join.residual().predicate().has_expr();
+        if (has_residual) {
+            if (!is_inner) return fail("residual on non-inner join");
+            if (join.residual().predicate().num_columns() !=
+                static_cast<uint32_t>(join.residual().columns_size())) {
+                return fail("join residual column count");
+            }
+            residual_columns.reserve(join.residual().columns_size());
+            for (const pb::QueryBlockColumnRef& column :
+                 join.residual().columns()) {
+                int position = probe.table_pos(column.table_idx());
+                if (position >= 0) {
+                    residual_columns.push_back(
+                        ResidualColumn{false, position, column.table_idx(),
+                                       column.column()});
+                    continue;
+                }
+                position = build.table_pos(column.table_idx());
+                if (position < 0) return fail("join residual table");
+                residual_columns.push_back(
+                    ResidualColumn{true, position, column.table_idx(),
+                                   column.column()});
+            }
+        }
+
         // Build a composite byte-key hash table from the chosen build child.
         std::unordered_map<std::string, std::vector<size_t>> hash_table;
         hash_table.reserve(build.rows());
@@ -703,6 +738,42 @@ class Executor {
                 WorkerOutput& local = local_outputs[worker_idx];
                 local.refs.assign(output->tables.size(), {});
                 std::string probe_key;
+                PredicateEvaluator residual_evaluator;
+                std::vector<std::string_view> residual_cells(
+                    residual_columns.size());
+                std::vector<bool> residual_nulls(residual_columns.size());
+                auto residual_ok = [&](size_t probe_idx,
+                                       size_t build_idx) -> bool {
+                    if (!has_residual) return true;
+                    for (size_t column_idx = 0;
+                         column_idx < residual_columns.size();
+                         ++column_idx) {
+                        const ResidualColumn& column =
+                            residual_columns[column_idx];
+                        const NodeResult& source =
+                            column.from_build ? build : probe;
+                        const size_t source_row =
+                            column.from_build ? build_idx : probe_idx;
+                        const uint64_t ref =
+                            source.refs[column.ref_position][source_row];
+                        if (ref == kNullRowRef) {
+                            residual_cells[column_idx] = {};
+                            residual_nulls[column_idx] = true;
+                            continue;
+                        }
+
+                        const PaxRowRef row = ToRowRef(column.table_idx, ref);
+                        if (row.group == nullptr) return false;
+                        residual_cells[column_idx] = extract_value_column(
+                            row, static_cast<int>(column.column));
+                        residual_nulls[column_idx] =
+                            IsNullColumn(row, column.column);
+                    }
+                    residual_evaluator.set_row_from_views(residual_cells,
+                                                          residual_nulls);
+                    return residual_evaluator.evaluate(
+                        join.residual().predicate().expr());
+                };
                 const size_t begin = probe_rows * worker_idx / worker_count;
                 const size_t end =
                     probe_rows * (worker_idx + 1) / worker_count;
@@ -728,6 +799,7 @@ class Executor {
                     }
 
                     for (const size_t build_idx : match->second) {
+                        if (!residual_ok(probe_idx, build_idx)) continue;
                         for (size_t column_idx = 0;
                              column_idx < probe.tables.size(); ++column_idx) {
                             local.refs[column_idx].push_back(

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -338,7 +338,7 @@ class Executor {
     bool NullOf(uint32_t table_idx, uint64_t ref, uint32_t column) const {
         if (ref == kNullRowRef) return true;
         if (!IsVirtualTable(table_idx)) {
-            return IsNullColumn(ToRowRef(table_idx, ref), column);
+            return ValueOf(table_idx, ref, column).empty();
         }
 
         const VirtualTable* table = FindVirtualTable(table_idx);
@@ -364,16 +364,6 @@ class Executor {
         const int position = input.table_pos(table_idx);
         if (position < 0) return PaxRowRef{};
         return ToRowRef(table_idx, input.refs[position][row_idx]);
-    }
-
-    static bool IsNullColumn(const PaxRowRef& row, uint32_t column_idx) {
-        if (row.group == nullptr) return true;
-        const std::string_view null_flags = row.group->cell(0, row.slot);
-        const size_t byte_idx = column_idx / 8;
-        const uint32_t bit_idx = column_idx % 8;
-        return byte_idx < null_flags.size() &&
-               (static_cast<unsigned char>(null_flags[byte_idx]) &
-                (1u << bit_idx)) != 0;
     }
 
     static DecodedColumnRef DecodeAggregateColumnRef(
@@ -542,10 +532,9 @@ class Executor {
         const PaxGroup* group, uint32_t slot, uint32_t column,
         const std::unordered_set<std::string>* keys) {
         if (keys == nullptr) return true;
-        if (group == nullptr || IsNullColumn(PaxRowRef{group, slot}, column)) {
-            return false;
-        }
+        if (group == nullptr) return false;
         const std::string_view value = group->cell(column + 1, slot);
+        if (value.empty()) return false;
         return keys->find(std::string(value)) != keys->end();
     }
 
@@ -922,9 +911,9 @@ class Executor {
         key->clear();
         for (const JoinKeyColumn& column : key_columns) {
             const uint64_t ref = input.refs[column.ref_position][row_idx];
-            // SQL equijoins are null-rejecting, while an empty non-NULL string
-            // is still a valid key part. Use the null bitmap instead of the
-            // value bytes so hash joins match the scan semi-filter semantics.
+            // SQL equijoins are null-rejecting. Real PAX cells encode NULL as
+            // an empty cell, so empty key parts never match, mirroring the
+            // scan semi-filter semantics.
             if (NullOf(column.table_idx, ref, column.column)) return false;
             AppendJoinKeyPart(key,
                               ValueOf(column.table_idx, ref, column.column));

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -922,6 +922,9 @@ class Executor {
         key->clear();
         for (const JoinKeyColumn& column : key_columns) {
             const uint64_t ref = input.refs[column.ref_position][row_idx];
+            // SQL equijoins are null-rejecting, while an empty non-NULL string
+            // is still a valid key part. Use the null bitmap instead of the
+            // value bytes so hash joins match the scan semi-filter semantics.
             if (NullOf(column.table_idx, ref, column.column)) return false;
             AppendJoinKeyPart(key,
                               ValueOf(column.table_idx, ref, column.column));

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -873,7 +873,6 @@ class Executor {
             join.has_residual() && join.residual().has_predicate() &&
             join.residual().predicate().has_expr();
         if (has_residual) {
-            if (is_left) return fail("residual on LEFT join");
             if (join.residual().predicate().num_columns() !=
                 static_cast<uint32_t>(join.residual().columns_size())) {
                 return fail("join residual column count");

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -1,0 +1,33 @@
+#include "query_block_executor.hh"
+
+#include <exception>
+
+namespace query_block {
+namespace {
+
+void fail(LineairDB::Protocol::TxExecuteQueryBlock::Response* response,
+          const char* message) {
+    if (response == nullptr) return;
+    response->set_ok(false);
+    response->set_error(message);
+}
+
+}  // namespace
+
+void ExecuteQueryBlock(
+    LineairDB::Database* db,
+    const LineairDB::Protocol::TxExecuteQueryBlock::Request& request,
+    LineairDB::Protocol::TxExecuteQueryBlock::Response* response) {
+    (void)db;
+    (void)request;
+
+    try {
+        fail(response, "query-block execution is not implemented");
+    } catch (const std::exception& e) {
+        fail(response, e.what());
+    } catch (...) {
+        fail(response, "query-block execution failed");
+    }
+}
+
+}  // namespace query_block

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -1,14 +1,18 @@
 #include "query_block_executor.hh"
 
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <exception>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
 #include <lineairdb/database.h>
 #include <lineairdb/pax_store.h>
+
+#include "predicate_evaluator.hh"
 
 namespace query_block {
 namespace {
@@ -25,6 +29,22 @@ void set_failure(pb::TxExecuteQueryBlock::Response* response,
     response->clear_rows();
 }
 
+// Materialized operator output. Each logical tuple is represented as one PAX row
+// reference per participating table.
+struct NodeResult {
+    std::vector<uint32_t> tables;
+    std::vector<std::vector<uint64_t>> refs;
+
+    size_t rows() const { return refs.empty() ? 0 : refs[0].size(); }
+
+    int table_pos(uint32_t table_idx) const {
+        for (size_t idx = 0; idx < tables.size(); ++idx) {
+            if (tables[idx] == table_idx) return static_cast<int>(idx);
+        }
+        return -1;
+    }
+};
+
 class Executor {
  public:
     Executor(LineairDB::Database* db,
@@ -34,8 +54,9 @@ class Executor {
     bool Run() {
         if (!PrepareTables()) return false;
         if (!ValidateNodeOrder()) return false;
+        if (!RunNodes()) return false;
         if (!TablesAreStillQuiet()) return fail("concurrent modification");
-        return fail("query-block operators are not implemented");
+        return fail("query-block output is not implemented");
     }
 
     const std::string& error() const { return error_; }
@@ -113,6 +134,104 @@ class Executor {
         return true;
     }
 
+    bool RunScan(const pb::QueryBlockScan& scan, NodeResult* output) {
+        if (scan.table_idx() >= static_cast<uint32_t>(request_.tables_size())) {
+            return fail("scan table out of range");
+        }
+
+        PaxStore* store = stores_[scan.table_idx()];
+        const size_t group_count = store->group_count();
+        output->tables = {scan.table_idx()};
+        output->refs.assign(1, {});
+        if (group_count == 0) return true;
+
+        const bool has_filter = scan.has_filter() && scan.filter().has_expr();
+        const unsigned worker_count = static_cast<unsigned>(
+            std::min<size_t>(WorkerCount(), group_count));
+        std::vector<std::vector<uint64_t>> local_refs(worker_count);
+        std::vector<char> worker_failed(worker_count, 0);
+        std::vector<std::thread> workers;
+        workers.reserve(worker_count);
+
+        for (unsigned worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+            workers.emplace_back([&, worker_idx] {
+                PredicateEvaluator evaluator;
+                std::vector<uint64_t>& refs = local_refs[worker_idx];
+                for (size_t group_idx = worker_idx; group_idx < group_count;
+                     group_idx += worker_count) {
+                    PaxGroup* group = store->group(group_idx);
+                    if (group == nullptr) continue;
+
+                    // Turn one 64-slot visibility word into row references for
+                    // the live slots that survive the optional predicate.
+                    for (uint32_t base = 0; base < PaxGroup::kRows;
+                         base += 64) {
+                        uint64_t visible_bits = 0;
+                        for (uint32_t bit = 0; bit < 64; ++bit) {
+                            if (group->IsVisible(base + bit)) {
+                                visible_bits |= uint64_t{1} << bit;
+                            }
+                        }
+
+                        while (visible_bits != 0) {
+                            const uint32_t bit = static_cast<uint32_t>(
+                                __builtin_ctzll(visible_bits));
+                            visible_bits &= visible_bits - 1;
+                            const uint32_t slot = base + bit;
+                            if (has_filter) {
+                                if (!evaluator.set_row_from_pax(
+                                        *group, slot,
+                                        scan.filter().num_columns())) {
+                                    worker_failed[worker_idx] = 1;
+                                    return;
+                                }
+                                if (!evaluator.evaluate(scan.filter().expr())) {
+                                    continue;
+                                }
+                            }
+                            refs.push_back(group_idx * PaxGroup::kRows + slot);
+                        }
+                    }
+                }
+            });
+        }
+
+        for (std::thread& worker : workers) worker.join();
+        for (char failed : worker_failed) {
+            if (failed) return fail("scan filter cannot read PAX columns");
+        }
+
+        size_t total_refs = 0;
+        for (const std::vector<uint64_t>& refs : local_refs) {
+            total_refs += refs.size();
+        }
+        output->refs[0].reserve(total_refs);
+        for (const std::vector<uint64_t>& refs : local_refs) {
+            output->refs[0].insert(output->refs[0].end(), refs.begin(),
+                                   refs.end());
+        }
+        return true;
+    }
+
+    bool RunNodes() {
+        results_.resize(request_.nodes_size());
+        for (int node_idx = 0; node_idx < request_.nodes_size(); ++node_idx) {
+            const pb::QueryBlockNode& node = request_.nodes(node_idx);
+            if (node.has_scan()) {
+                if (!RunScan(node.scan(), &results_[node_idx])) return false;
+                continue;
+            }
+            if (node.has_join()) {
+                return fail("query-block join is not implemented");
+            }
+            if (node.has_aggregate()) {
+                return fail("query-block aggregate is not implemented");
+            }
+            return fail("unknown query-block node");
+        }
+        return true;
+    }
+
     bool TablesAreStillQuiet() const {
         for (size_t table_idx = 0; table_idx < stores_.size(); ++table_idx) {
             PaxStore* store = stores_[table_idx];
@@ -131,11 +250,18 @@ class Executor {
         return true;
     }
 
+    unsigned WorkerCount() const {
+        const unsigned hardware_threads = std::thread::hardware_concurrency();
+        return std::min<unsigned>(hardware_threads == 0 ? 8 : hardware_threads,
+                                  32);
+    }
+
     LineairDB::Database* db_;
     const pb::TxExecuteQueryBlock::Request& request_;
     std::string error_;
     std::vector<PaxStore*> stores_;
     std::vector<std::vector<uint64_t>> write_counter_snapshots_;
+    std::vector<NodeResult> results_;
 };
 
 const std::string& default_error(const Executor& executor) {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -856,6 +856,16 @@ class Executor {
 
     using GroupMap = std::unordered_map<std::string, GroupState>;
 
+    static uint32_t FilterTableForAggregate(
+        const pb::QueryBlockAggFunc& function) {
+        if (!function.has_filter()) return function.arg_table();
+        if (function.kind() == pb::QueryBlockAggFunc::COUNT &&
+            !function.has_arg()) {
+            return function.arg_table();
+        }
+        return function.filter_table();
+    }
+
     bool AccumulateRange(const pb::QueryBlockAggregate& aggregate,
                          const NodeResult& input, size_t begin, size_t end,
                          GroupMap* groups) {
@@ -872,15 +882,24 @@ class Executor {
         }
 
         std::vector<int> aggregate_positions(aggregate_count, -1);
+        std::vector<int> filter_positions(aggregate_count, -1);
         for (int aggregate_idx = 0; aggregate_idx < aggregate_count;
              ++aggregate_idx) {
             const pb::QueryBlockAggFunc& function =
                 aggregate.aggs(aggregate_idx);
-            if (function.has_arg() || function.has_filter()) {
+            if (function.has_arg()) {
                 aggregate_positions[aggregate_idx] =
                     input.table_pos(function.arg_table());
                 if (aggregate_positions[aggregate_idx] < 0) {
                     return fail("aggregate table is not in aggregate input");
+                }
+            }
+            if (function.has_filter()) {
+                filter_positions[aggregate_idx] =
+                    input.table_pos(FilterTableForAggregate(function));
+                if (filter_positions[aggregate_idx] < 0) {
+                    return fail(
+                        "aggregate filter table is not in aggregate input");
                 }
             }
             if (function.has_arg() &&
@@ -941,8 +960,13 @@ class Executor {
                     input_pos < 0 || ref != kNullRowRef;
 
                 if (function.has_filter() && function.filter().has_expr()) {
-                    if (!has_arg_row) continue;
-                    PaxRowRef row = ToRowRef(function.arg_table(), ref);
+                    const int filter_pos = filter_positions[aggregate_idx];
+                    const uint64_t filter_ref =
+                        input.refs[filter_pos][row_idx];
+                    if (filter_ref == kNullRowRef) continue;
+                    const uint32_t filter_table =
+                        FilterTableForAggregate(function);
+                    PaxRowRef row = ToRowRef(filter_table, filter_ref);
                     if (row.group == nullptr ||
                         !evaluator.set_row_from_pax(
                             *row.group, row.slot,
@@ -1106,6 +1130,12 @@ class Executor {
                 return std::to_string(state.counts[aggregate_idx]);
             case pb::QueryBlockAggFunc::SUM:
                 if (state.counts[aggregate_idx] == 0) {
+                    if (function.zero_if_empty()) {
+                        DecimalValue zero;
+                        zero.scale = static_cast<int>(function.arg_scale());
+                        zero.is_null = false;
+                        return format_decimal_value(zero);
+                    }
                     *is_null = true;
                     return {};
                 }

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <cstdint>
 #include <exception>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -24,6 +25,8 @@ namespace {
 namespace pb = LineairDB::Protocol;
 using LineairDB::Pax::PaxGroup;
 using LineairDB::Pax::PaxStore;
+
+constexpr uint64_t kNullRowRef = std::numeric_limits<uint64_t>::max();
 
 void set_failure(pb::TxExecuteQueryBlock::Response* response,
                  const std::string& message) {
@@ -192,6 +195,7 @@ class Executor {
     }
 
     PaxRowRef ToRowRef(uint32_t table_idx, uint64_t ref) const {
+        if (ref == kNullRowRef) return PaxRowRef{};
         PaxStore* store = stores_[table_idx];
         return PaxRowRef{
             store->group(ref / PaxGroup::kRows),
@@ -305,20 +309,24 @@ class Executor {
         return true;
     }
 
-    void BuildJoinKey(const NodeResult& input,
+    bool BuildJoinKey(const NodeResult& input,
                       const std::vector<JoinKeyColumn>& key_columns,
                       size_t row_idx, std::string* key) const {
         key->clear();
         for (const JoinKeyColumn& column : key_columns) {
             const uint64_t ref = input.refs[column.ref_position][row_idx];
+            if (ref == kNullRowRef) return false;
             AppendJoinKeyPart(
                 key, extract_value_column(ToRowRef(column.table_idx, ref),
                                           column.column));
         }
+        return true;
     }
 
     bool RunJoin(const pb::QueryBlockJoin& join, NodeResult* output) {
-        if (join.type() != pb::QueryBlockJoin::INNER) {
+        const bool is_inner = join.type() == pb::QueryBlockJoin::INNER;
+        const bool is_left = join.type() == pb::QueryBlockJoin::LEFT;
+        if (!is_inner && !is_left) {
             return fail("unsupported query-block join type");
         }
         if (join.build_keys_size() != join.probe_keys_size() ||
@@ -329,9 +337,11 @@ class Executor {
             return fail("join child out of range");
         }
 
-        // INNER joins are symmetric; hash the smaller child at runtime even if
-        // the request named the larger child as build.
+        // INNER joins are symmetric; hash the smaller child at runtime. LEFT
+        // joins keep the request's build/probe sides because probe rows must be
+        // preserved when the build side has no match.
         const bool swap =
+            is_inner &&
             results_[join.build()].rows() > results_[join.probe()].rows();
         const NodeResult& build = results_[swap ? join.probe() : join.build()];
         const NodeResult& probe = results_[swap ? join.build() : join.probe()];
@@ -352,7 +362,9 @@ class Executor {
         hash_table.reserve(build.rows());
         std::string key;
         for (size_t row_idx = 0; row_idx < build.rows(); ++row_idx) {
-            BuildJoinKey(build, build_key_columns, row_idx, &key);
+            if (!BuildJoinKey(build, build_key_columns, row_idx, &key)) {
+                continue;
+            }
             hash_table[key].push_back(row_idx);
         }
 
@@ -385,10 +397,25 @@ class Executor {
                 const size_t end =
                     probe_rows * (worker_idx + 1) / worker_count;
                 for (size_t probe_idx = begin; probe_idx < end; ++probe_idx) {
-                    BuildJoinKey(probe, probe_key_columns, probe_idx,
-                                 &probe_key);
-                    const auto match = hash_table.find(probe_key);
-                    if (match == hash_table.end()) continue;
+                    const bool has_probe_key = BuildJoinKey(
+                        probe, probe_key_columns, probe_idx, &probe_key);
+                    const auto match = has_probe_key
+                                           ? hash_table.find(probe_key)
+                                           : hash_table.end();
+                    if (match == hash_table.end()) {
+                        if (!is_left) continue;
+                        for (size_t column_idx = 0;
+                             column_idx < probe.tables.size(); ++column_idx) {
+                            local.refs[column_idx].push_back(
+                                probe.refs[column_idx][probe_idx]);
+                        }
+                        for (size_t column_idx = 0;
+                             column_idx < build.tables.size(); ++column_idx) {
+                            local.refs[probe.tables.size() + column_idx]
+                                .push_back(kNullRowRef);
+                        }
+                        continue;
+                    }
 
                     for (const size_t build_idx : match->second) {
                         for (size_t column_idx = 0;
@@ -525,8 +552,11 @@ class Executor {
                 const int input_pos = aggregate_positions[aggregate_idx];
                 const uint64_t ref =
                     input_pos >= 0 ? input.refs[input_pos][row_idx] : 0;
+                const bool has_arg_row =
+                    input_pos < 0 || ref != kNullRowRef;
 
                 if (function.has_filter() && function.filter().has_expr()) {
+                    if (!has_arg_row) continue;
                     PaxRowRef row = ToRowRef(function.arg_table(), ref);
                     if (row.group == nullptr ||
                         !evaluator.set_row_from_pax(
@@ -541,6 +571,7 @@ class Executor {
 
                 switch (function.kind()) {
                     case pb::QueryBlockAggFunc::COUNT:
+                        if (function.has_arg() && !has_arg_row) break;
                         state->counts[aggregate_idx] += 1;
                         break;
                     case pb::QueryBlockAggFunc::SUM:

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -278,6 +278,160 @@ class Executor {
         return true;
     }
 
+    static void AppendJoinKeyPart(std::string* key, std::string_view value) {
+        const uint32_t length = static_cast<uint32_t>(value.size());
+        key->append(reinterpret_cast<const char*>(&length), sizeof(length));
+        key->append(value.data(), value.size());
+    }
+
+    struct JoinKeyColumn {
+        int ref_position = -1;
+        uint32_t table_idx = 0;
+        uint32_t column = 0;
+    };
+
+    bool ResolveJoinKeys(
+        const NodeResult& input,
+        const google::protobuf::RepeatedPtrField<pb::QueryBlockColumnRef>& keys,
+        std::vector<JoinKeyColumn>* resolved) const {
+        resolved->clear();
+        resolved->reserve(keys.size());
+        for (const pb::QueryBlockColumnRef& key : keys) {
+            const int position = input.table_pos(key.table_idx());
+            if (position < 0) return false;
+            resolved->push_back(
+                JoinKeyColumn{position, key.table_idx(), key.column()});
+        }
+        return true;
+    }
+
+    void BuildJoinKey(const NodeResult& input,
+                      const std::vector<JoinKeyColumn>& key_columns,
+                      size_t row_idx, std::string* key) const {
+        key->clear();
+        for (const JoinKeyColumn& column : key_columns) {
+            const uint64_t ref = input.refs[column.ref_position][row_idx];
+            AppendJoinKeyPart(
+                key, extract_value_column(ToRowRef(column.table_idx, ref),
+                                          column.column));
+        }
+    }
+
+    bool RunJoin(const pb::QueryBlockJoin& join, NodeResult* output) {
+        if (join.type() != pb::QueryBlockJoin::INNER) {
+            return fail("unsupported query-block join type");
+        }
+        if (join.build_keys_size() != join.probe_keys_size() ||
+            join.build_keys_size() == 0) {
+            return fail("join key arity");
+        }
+        if (join.build() >= results_.size() || join.probe() >= results_.size()) {
+            return fail("join child out of range");
+        }
+
+        // INNER joins are symmetric; hash the smaller child at runtime even if
+        // the request named the larger child as build.
+        const bool swap =
+            results_[join.build()].rows() > results_[join.probe()].rows();
+        const NodeResult& build = results_[swap ? join.probe() : join.build()];
+        const NodeResult& probe = results_[swap ? join.build() : join.probe()];
+        const auto& build_keys = swap ? join.probe_keys() : join.build_keys();
+        const auto& probe_keys = swap ? join.build_keys() : join.probe_keys();
+
+        std::vector<JoinKeyColumn> build_key_columns;
+        std::vector<JoinKeyColumn> probe_key_columns;
+        if (!ResolveJoinKeys(build, build_keys, &build_key_columns)) {
+            return fail("build key table is not in join input");
+        }
+        if (!ResolveJoinKeys(probe, probe_keys, &probe_key_columns)) {
+            return fail("probe key table is not in join input");
+        }
+
+        // Build a composite byte-key hash table from the chosen build child.
+        std::unordered_map<std::string, std::vector<size_t>> hash_table;
+        hash_table.reserve(build.rows());
+        std::string key;
+        for (size_t row_idx = 0; row_idx < build.rows(); ++row_idx) {
+            BuildJoinKey(build, build_key_columns, row_idx, &key);
+            hash_table[key].push_back(row_idx);
+        }
+
+        // Keep only row references in the joined tuple; later operators read
+        // column values directly from each table's PAX strips.
+        output->tables = probe.tables;
+        output->tables.insert(output->tables.end(), build.tables.begin(),
+                              build.tables.end());
+        output->refs.assign(output->tables.size(), {});
+
+        struct WorkerOutput {
+            std::vector<std::vector<uint64_t>> refs;
+        };
+
+        // Probe in independent row chunks and merge per-worker ref columns at
+        // the end to avoid synchronized appends on every match.
+        const size_t probe_rows = probe.rows();
+        const unsigned worker_count = static_cast<unsigned>(std::min<size_t>(
+            WorkerCount(), std::max<size_t>(probe_rows / 16384, 1)));
+        std::vector<WorkerOutput> local_outputs(worker_count);
+        std::vector<std::thread> workers;
+        workers.reserve(worker_count);
+
+        for (unsigned worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+            workers.emplace_back([&, worker_idx] {
+                WorkerOutput& local = local_outputs[worker_idx];
+                local.refs.assign(output->tables.size(), {});
+                std::string probe_key;
+                const size_t begin = probe_rows * worker_idx / worker_count;
+                const size_t end =
+                    probe_rows * (worker_idx + 1) / worker_count;
+                for (size_t probe_idx = begin; probe_idx < end; ++probe_idx) {
+                    BuildJoinKey(probe, probe_key_columns, probe_idx,
+                                 &probe_key);
+                    const auto match = hash_table.find(probe_key);
+                    if (match == hash_table.end()) continue;
+
+                    for (const size_t build_idx : match->second) {
+                        for (size_t column_idx = 0;
+                             column_idx < probe.tables.size(); ++column_idx) {
+                            local.refs[column_idx].push_back(
+                                probe.refs[column_idx][probe_idx]);
+                        }
+                        for (size_t column_idx = 0;
+                             column_idx < build.tables.size(); ++column_idx) {
+                            local.refs[probe.tables.size() + column_idx]
+                                .push_back(build.refs[column_idx][build_idx]);
+                        }
+                    }
+                }
+            });
+        }
+
+        for (std::thread& worker : workers) worker.join();
+
+        size_t total_rows = 0;
+        for (const WorkerOutput& local : local_outputs) {
+            total_rows += local.refs.empty() ? 0 : local.refs[0].size();
+        }
+        // Fan-out safety valve: reject the offload before materializing an
+        // unbounded intermediate and let the primary path run the query.
+        if (total_rows > (size_t{64} << 20)) {
+            return fail("join intermediate too large");
+        }
+
+        for (size_t column_idx = 0; column_idx < output->refs.size();
+             ++column_idx) {
+            output->refs[column_idx].reserve(total_rows);
+            for (const WorkerOutput& local : local_outputs) {
+                if (local.refs.empty()) continue;
+                output->refs[column_idx].insert(
+                    output->refs[column_idx].end(),
+                    local.refs[column_idx].begin(),
+                    local.refs[column_idx].end());
+            }
+        }
+        return true;
+    }
+
     struct GroupState {
         std::vector<std::string> keys;
         std::vector<uint64_t> counts;
@@ -730,7 +884,8 @@ class Executor {
                 continue;
             }
             if (node.has_join()) {
-                return fail("query-block join is not implemented");
+                if (!RunJoin(node.join(), &results_[node_idx])) return false;
+                continue;
             }
             if (node.has_aggregate()) {
                 if (node_idx != request_.nodes_size() - 1) {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <charconv>
 #include <cstdint>
 #include <exception>
 #include <limits>
@@ -35,6 +36,30 @@ constexpr uint32_t kNoExternalFilterTable =
     std::numeric_limits<uint32_t>::max();
 constexpr uint32_t kTaggedColumnShift = 16;
 constexpr uint32_t kTaggedColumnMask = (uint32_t{1} << kTaggedColumnShift) - 1;
+
+bool parse_int64_cell(std::string_view value, int64_t* parsed) {
+    if (parsed == nullptr || value.empty()) return false;
+    const char* first = value.data();
+    const char* last = value.data() + value.size();
+    const auto result = std::from_chars(first, last, *parsed);
+    return result.ec == std::errc() && result.ptr == last;
+}
+
+bool build_int64_key_set(const std::unordered_set<std::string>& source,
+                         std::unordered_set<int64_t>* target) {
+    if (target == nullptr) return false;
+    target->clear();
+    target->reserve(source.size());
+    for (const std::string& key : source) {
+        int64_t parsed = 0;
+        if (!parse_int64_cell(key, &parsed)) {
+            target->clear();
+            return false;
+        }
+        target->insert(parsed);
+    }
+    return true;
+}
 
 void set_failure(pb::TxExecuteQueryBlock::Response* response,
                  const std::string& message) {
@@ -530,11 +555,17 @@ class Executor {
 
     static bool CellMatchesKeySet(
         const PaxGroup* group, uint32_t slot, uint32_t column,
-        const std::unordered_set<std::string>* keys) {
+        const std::unordered_set<std::string>* keys,
+        const std::unordered_set<int64_t>* int_keys) {
         if (keys == nullptr) return true;
         if (group == nullptr) return false;
         const std::string_view value = group->cell(column + 1, slot);
         if (value.empty()) return false;
+        if (int_keys != nullptr) {
+            int64_t parsed = 0;
+            return parse_int64_cell(value, &parsed) &&
+                   int_keys->find(parsed) != int_keys->end();
+        }
         return keys->find(std::string(value)) != keys->end();
     }
 
@@ -566,6 +597,18 @@ class Executor {
             external_filter_table_ == scan.table_idx() &&
             external_keys_->size() <= kMaxRuntimeFilterKeys) {
             external_keys = external_keys_;
+        }
+        std::unordered_set<int64_t> semi_int_keys_storage;
+        const std::unordered_set<int64_t>* semi_int_keys = nullptr;
+        if (semi_keys != nullptr &&
+            build_int64_key_set(*semi_keys, &semi_int_keys_storage)) {
+            semi_int_keys = &semi_int_keys_storage;
+        }
+        std::unordered_set<int64_t> external_int_keys_storage;
+        const std::unordered_set<int64_t>* external_int_keys = nullptr;
+        if (external_keys != nullptr &&
+            build_int64_key_set(*external_keys, &external_int_keys_storage)) {
+            external_int_keys = &external_int_keys_storage;
         }
 
         const bool has_filter = scan.has_filter() && scan.filter().has_expr();
@@ -603,12 +646,12 @@ class Executor {
                             const uint32_t slot = base + bit;
                             if (!CellMatchesKeySet(
                                     group, slot, scan.semi().my_column(),
-                                    semi_keys)) {
+                                    semi_keys, semi_int_keys)) {
                                 continue;
                             }
                             if (!CellMatchesKeySet(
                                     group, slot, external_filter_column_,
-                                    external_keys)) {
+                                    external_keys, external_int_keys)) {
                                 continue;
                             }
                             if (has_filter) {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -72,6 +72,56 @@ DecimalValue divide_decimal_value(const DecimalValue& sum, uint64_t count,
     return result;
 }
 
+DecimalValue divide_decimal_values(const DecimalValue& lhs,
+                                   const DecimalValue& rhs,
+                                   int output_scale) {
+    DecimalValue result;
+    result.is_null = true;
+    if (lhs.is_null || rhs.is_null || rhs.mantissa == 0) return result;
+
+    __int128 numerator = lhs.mantissa;
+    __int128 denominator = rhs.mantissa;
+    bool negative = false;
+    if (numerator < 0) {
+        numerator = -numerator;
+        negative = !negative;
+    }
+    if (denominator < 0) {
+        denominator = -denominator;
+        negative = !negative;
+    }
+
+    // Scale the numerator to keep one extra decimal digit for half-up rounding.
+    const int scale_shift = output_scale + rhs.scale - lhs.scale + 1;
+    if (scale_shift > 0) {
+        numerator *= decimal_power_of_ten(scale_shift);
+    } else if (scale_shift < 0) {
+        numerator /= decimal_power_of_ten(-scale_shift);
+    }
+
+    __int128 quotient = numerator / denominator;
+    quotient = (quotient + 5) / 10;
+    result.mantissa = negative ? -quotient : quotient;
+    result.scale = output_scale;
+    result.is_null = false;
+    return result;
+}
+
+void round_decimal_value(DecimalValue* value, int output_scale) {
+    if (value == nullptr || value->is_null || value->scale <= output_scale) {
+        return;
+    }
+
+    const int drop = value->scale - output_scale;
+    const __int128 divisor = decimal_power_of_ten(drop);
+    __int128 mantissa = value->mantissa;
+    const bool negative = mantissa < 0;
+    if (negative) mantissa = -mantissa;
+    mantissa = (mantissa + divisor / 2) / divisor;
+    value->mantissa = negative ? -mantissa : mantissa;
+    value->scale = output_scale;
+}
+
 void append_result_field(std::string& row, std::string_view payload,
                          bool is_null) {
     if (is_null) {
@@ -1167,6 +1217,128 @@ class Executor {
         }
     }
 
+    bool EvaluateOutputExpression(const pb::FilterExpr& expression,
+                                  const pb::QueryBlockAggregate& aggregate,
+                                  const GroupState& state,
+                                  DecimalValue* result) {
+        if (result == nullptr) return fail("missing output expression result");
+
+        using FE = pb::FilterExpr;
+        switch (expression.op()) {
+            case FE::COLUMN_REF: {
+                const uint32_t ordinal = expression.column_index();
+                const uint32_t group_count =
+                    static_cast<uint32_t>(aggregate.group_columns_size());
+                if (ordinal < group_count) {
+                    *result = parse_decimal_value(state.keys[ordinal]);
+                    return true;
+                }
+
+                const uint32_t aggregate_idx = ordinal - group_count;
+                if (aggregate_idx >=
+                    static_cast<uint32_t>(aggregate.aggs_size())) {
+                    return fail("output expression ordinal out of range");
+                }
+                bool is_null = false;
+                const std::string value = AggregateValue(
+                    aggregate.aggs(aggregate_idx), state,
+                    static_cast<int>(aggregate_idx), &is_null);
+                if (is_null) {
+                    *result = DecimalValue{};
+                    result->is_null = true;
+                    return true;
+                }
+                *result = parse_decimal_value(value);
+                return true;
+            }
+            case FE::CONST_INT:
+                result->mantissa = expression.int_val();
+                result->scale = 0;
+                result->is_null = false;
+                return true;
+            case FE::CONST_UINT:
+                result->mantissa =
+                    static_cast<__int128>(expression.uint_val());
+                result->scale = 0;
+                result->is_null = false;
+                return true;
+            case FE::CONST_STRING:
+                *result = parse_decimal_value(expression.string_val());
+                return true;
+            case FE::CONST_NULL:
+                *result = DecimalValue{};
+                result->is_null = true;
+                return true;
+            case FE::OP_ADD:
+            case FE::OP_SUB: {
+                if (expression.children_size() != 2) {
+                    return fail("output expression arity mismatch");
+                }
+                DecimalValue lhs;
+                DecimalValue rhs;
+                if (!EvaluateOutputExpression(expression.children(0),
+                                              aggregate, state, &lhs) ||
+                    !EvaluateOutputExpression(expression.children(1),
+                                              aggregate, state, &rhs)) {
+                    return false;
+                }
+                if (expression.op() == FE::OP_SUB) {
+                    rhs.mantissa = -rhs.mantissa;
+                }
+                add_decimal_value(lhs, rhs);
+                *result = lhs;
+                return true;
+            }
+            case FE::OP_MUL: {
+                if (expression.children_size() != 2) {
+                    return fail("output expression arity mismatch");
+                }
+                DecimalValue lhs;
+                DecimalValue rhs;
+                if (!EvaluateOutputExpression(expression.children(0),
+                                              aggregate, state, &lhs) ||
+                    !EvaluateOutputExpression(expression.children(1),
+                                              aggregate, state, &rhs)) {
+                    return false;
+                }
+                result->mantissa = lhs.mantissa * rhs.mantissa;
+                result->scale = lhs.scale + rhs.scale;
+                result->is_null = lhs.is_null || rhs.is_null;
+                return true;
+            }
+            case FE::OP_DIV: {
+                if (expression.children_size() != 2) {
+                    return fail("output expression arity mismatch");
+                }
+                DecimalValue lhs;
+                DecimalValue rhs;
+                if (!EvaluateOutputExpression(expression.children(0),
+                                              aggregate, state, &lhs) ||
+                    !EvaluateOutputExpression(expression.children(1),
+                                              aggregate, state, &rhs)) {
+                    return false;
+                }
+                // Match MySQL DECIMAL division: left operand scale plus the
+                // default div_precision_increment, rounded half up.
+                *result = divide_decimal_values(lhs, rhs, lhs.scale + 4);
+                return true;
+            }
+            case FE::OP_NEG: {
+                if (expression.children_size() != 1) {
+                    return fail("output expression arity mismatch");
+                }
+                if (!EvaluateOutputExpression(expression.children(0),
+                                              aggregate, state, result)) {
+                    return false;
+                }
+                result->mantissa = -result->mantissa;
+                return true;
+            }
+            default:
+                return fail("unsupported output expression");
+        }
+    }
+
     bool AggregateRowValue(const pb::QueryBlockAggregate& aggregate,
                            int group_count, const GroupState& state,
                            uint32_t ordinal, std::string* value,
@@ -1428,6 +1600,22 @@ class Executor {
                                 static_cast<int>(expression.ordinal()),
                                 &is_null));
                             row.nulls.push_back(is_null);
+                            break;
+                        }
+                        case pb::QueryBlockOutputExpr::EXPR: {
+                            DecimalValue value;
+                            if (!EvaluateOutputExpression(
+                                    expression.expr(), aggregate, state,
+                                    &value)) {
+                                return false;
+                            }
+                            round_decimal_value(
+                                &value,
+                                static_cast<int>(expression.result_scale()));
+                            row.values.push_back(
+                                value.is_null ? std::string()
+                                              : format_decimal_value(value));
+                            row.nulls.push_back(value.is_null);
                             break;
                         }
                         default:

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -141,8 +141,9 @@ void append_result_field(std::string& row, std::string_view payload,
     row.append(payload.data(), payload.size());
 }
 
-// Materialized operator output. Each logical tuple is represented as one PAX row
-// reference per participating table.
+// Materialized operator output. Each logical tuple is represented as one row
+// reference per participating table. Real tables use PAX row references; virtual
+// tables produced by sub-blocks use result row numbers.
 struct NodeResult {
     std::vector<uint32_t> tables;
     std::vector<std::vector<uint64_t>> refs;
@@ -254,6 +255,9 @@ class Executor {
                 }
                 continue;
             }
+            if (node.has_sub_block()) {
+                continue;
+            }
             if (node.has_aggregate()) {
                 if (node.aggregate().input() >=
                     static_cast<uint32_t>(node_idx)) {
@@ -266,8 +270,56 @@ class Executor {
         return true;
     }
 
+    struct VirtualTable {
+        std::vector<std::vector<std::string>> values;
+        std::vector<std::vector<bool>> nulls;
+    };
+
+    bool IsVirtualTable(uint32_t table_idx) const {
+        return table_idx >= static_cast<uint32_t>(request_.tables_size());
+    }
+
+    const VirtualTable* FindVirtualTable(uint32_t table_idx) const {
+        if (!IsVirtualTable(table_idx)) return nullptr;
+        const uint32_t virtual_idx =
+            table_idx - static_cast<uint32_t>(request_.tables_size());
+        if (virtual_idx >= virtual_tables_.size()) return nullptr;
+        return &virtual_tables_[virtual_idx];
+    }
+
+    std::string_view ValueOf(uint32_t table_idx, uint64_t ref,
+                             uint32_t column) const {
+        if (ref == kNullRowRef) return {};
+        if (!IsVirtualTable(table_idx)) {
+            return extract_value_column(ToRowRef(table_idx, ref),
+                                        static_cast<int>(column));
+        }
+
+        const VirtualTable* table = FindVirtualTable(table_idx);
+        if (table == nullptr || ref >= table->values.size() ||
+            column >= table->values[ref].size()) {
+            return {};
+        }
+        return table->values[ref][column];
+    }
+
+    bool NullOf(uint32_t table_idx, uint64_t ref, uint32_t column) const {
+        if (ref == kNullRowRef) return true;
+        if (!IsVirtualTable(table_idx)) {
+            return IsNullColumn(ToRowRef(table_idx, ref), column);
+        }
+
+        const VirtualTable* table = FindVirtualTable(table_idx);
+        if (table == nullptr || ref >= table->nulls.size() ||
+            column >= table->nulls[ref].size()) {
+            return true;
+        }
+        return table->nulls[ref][column];
+    }
+
     PaxRowRef ToRowRef(uint32_t table_idx, uint64_t ref) const {
         if (ref == kNullRowRef) return PaxRowRef{};
+        if (table_idx >= stores_.size()) return PaxRowRef{};
         PaxStore* store = stores_[table_idx];
         return PaxRowRef{
             store->group(ref / PaxGroup::kRows),
@@ -324,8 +376,8 @@ class Executor {
 
     std::string_view GroupColumnValue(
         const pb::QueryBlockColumnRef& column, uint64_t ref) const {
-        std::string_view value = extract_value_column(
-            ToRowRef(column.table_idx(), ref), column.column());
+        std::string_view value =
+            ValueOf(column.table_idx(), ref, column.column());
         if (column.prefix_len() > 0 && value.size() > column.prefix_len()) {
             value = value.substr(0, column.prefix_len());
         }
@@ -339,9 +391,11 @@ class Executor {
         if (expression.op() != pb::FilterExpr::COLUMN_REF) return false;
         const DecodedColumnRef column = DecodeAggregateColumnRef(
             default_table_idx, expression.column_index());
-        PaxRowRef row = RowRefForTable(input, row_idx, column.table_idx);
-        if (row.group == nullptr) return false;
-        *value = extract_value_column(row, column.column);
+        const int position = input.table_pos(column.table_idx);
+        if (position < 0) return false;
+        const uint64_t ref = input.refs[position][row_idx];
+        if (NullOf(column.table_idx, ref, column.column)) return false;
+        *value = ValueOf(column.table_idx, ref, column.column);
         return true;
     }
 
@@ -508,6 +562,91 @@ class Executor {
         return true;
     }
 
+    bool DecodeSubBlockRow(const std::string& row,
+                           std::vector<std::string>* values,
+                           std::vector<bool>* nulls) {
+        if (values == nullptr || nulls == nullptr) {
+            return fail("sub-block row output missing");
+        }
+
+        values->clear();
+        nulls->clear();
+        size_t offset = 0;
+        bool first_field = true;
+        while (offset < row.size()) {
+            const auto byte_size =
+                static_cast<unsigned char>(row[offset]);
+            ++offset;
+
+            if (byte_size == 0xFF) {
+                if (!first_field) {
+                    values->emplace_back();
+                    nulls->push_back(true);
+                }
+                first_field = false;
+                continue;
+            }
+
+            if (offset + byte_size > row.size()) {
+                return fail("sub-block row is malformed");
+            }
+            size_t value_length = 0;
+            for (unsigned int byte_idx = 0; byte_idx < byte_size;
+                 ++byte_idx) {
+                value_length |=
+                    static_cast<size_t>(
+                        static_cast<unsigned char>(row[offset + byte_idx]))
+                    << (8 * byte_idx);
+            }
+            offset += byte_size;
+            if (offset + value_length > row.size()) {
+                return fail("sub-block row is malformed");
+            }
+
+            if (!first_field) {
+                values->emplace_back(row.data() + offset, value_length);
+                nulls->push_back(false);
+            }
+            first_field = false;
+            offset += value_length;
+        }
+        return true;
+    }
+
+    bool RunSubBlock(const pb::QueryBlockSubBlock& sub_block,
+                     NodeResult* output) {
+        pb::TxExecuteQueryBlock::Response response;
+        ExecuteQueryBlock(db_, sub_block.block(), &response);
+        if (!response.ok()) {
+            return fail(response.error().empty() ? "sub-block failed"
+                                                 : response.error());
+        }
+
+        VirtualTable table;
+        table.values.reserve(response.rows_size());
+        table.nulls.reserve(response.rows_size());
+        for (const std::string& row : response.rows()) {
+            std::vector<std::string> values;
+            std::vector<bool> nulls;
+            if (!DecodeSubBlockRow(row, &values, &nulls)) return false;
+            table.values.push_back(std::move(values));
+            table.nulls.push_back(std::move(nulls));
+        }
+
+        const uint32_t table_idx = static_cast<uint32_t>(
+            request_.tables_size() + virtual_tables_.size());
+        virtual_tables_.push_back(std::move(table));
+
+        output->tables = {table_idx};
+        output->refs.assign(1, {});
+        const size_t row_count = virtual_tables_.back().values.size();
+        output->refs[0].reserve(row_count);
+        for (size_t row_idx = 0; row_idx < row_count; ++row_idx) {
+            output->refs[0].push_back(row_idx);
+        }
+        return true;
+    }
+
     struct TupleFilterColumn {
         int ref_position = -1;
         uint32_t table_idx = 0;
@@ -554,11 +693,10 @@ class Executor {
                 continue;
             }
 
-            const PaxRowRef row = ToRowRef(column.table_idx, ref);
-            if (row.group == nullptr) return false;
             (*cells)[column_idx] =
-                extract_value_column(row, static_cast<int>(column.column));
-            (*nulls)[column_idx] = IsNullColumn(row, column.column);
+                ValueOf(column.table_idx, ref, column.column);
+            (*nulls)[column_idx] =
+                NullOf(column.table_idx, ref, column.column);
         }
         return true;
     }
@@ -675,10 +813,9 @@ class Executor {
         key->clear();
         for (const JoinKeyColumn& column : key_columns) {
             const uint64_t ref = input.refs[column.ref_position][row_idx];
-            if (ref == kNullRowRef) return false;
-            AppendJoinKeyPart(
-                key, extract_value_column(ToRowRef(column.table_idx, ref),
-                                          column.column));
+            if (NullOf(column.table_idx, ref, column.column)) return false;
+            AppendJoinKeyPart(key,
+                              ValueOf(column.table_idx, ref, column.column));
         }
         return true;
     }
@@ -817,12 +954,10 @@ class Executor {
                             continue;
                         }
 
-                        const PaxRowRef row = ToRowRef(column.table_idx, ref);
-                        if (row.group == nullptr) return false;
-                        residual_cells[column_idx] = extract_value_column(
-                            row, static_cast<int>(column.column));
+                        residual_cells[column_idx] =
+                            ValueOf(column.table_idx, ref, column.column);
                         residual_nulls[column_idx] =
-                            IsNullColumn(row, column.column);
+                            NullOf(column.table_idx, ref, column.column);
                     }
                     residual_evaluator.set_row_from_views(residual_cells,
                                                           residual_nulls);
@@ -964,6 +1099,36 @@ class Executor {
         return function.filter_table();
     }
 
+    bool BuildPredicateRowForTable(uint32_t table_idx, uint64_t ref,
+                                   uint32_t column_count,
+                                   std::vector<std::string_view>* cells,
+                                   std::vector<bool>* nulls) const {
+        if (cells == nullptr || nulls == nullptr) return false;
+        if (ref == kNullRowRef) return false;
+        if (!IsVirtualTable(table_idx)) {
+            const PaxRowRef row = ToRowRef(table_idx, ref);
+            if (row.group == nullptr ||
+                row.group->schema().field_count() <
+                    static_cast<size_t>(column_count) + 1) {
+                return false;
+            }
+        } else {
+            const VirtualTable* table = FindVirtualTable(table_idx);
+            if (table == nullptr || ref >= table->values.size()) {
+                return false;
+            }
+        }
+
+        cells->resize(column_count);
+        nulls->resize(column_count);
+        for (uint32_t column_idx = 0; column_idx < column_count;
+             ++column_idx) {
+            (*cells)[column_idx] = ValueOf(table_idx, ref, column_idx);
+            (*nulls)[column_idx] = NullOf(table_idx, ref, column_idx);
+        }
+        return true;
+    }
+
     bool AccumulateRange(const pb::QueryBlockAggregate& aggregate,
                          const NodeResult& input, size_t begin, size_t end,
                          GroupMap* groups) {
@@ -1010,6 +1175,8 @@ class Executor {
         PredicateEvaluator evaluator;
         std::string key_buffer;
         std::vector<std::string_view> group_values(group_count);
+        std::vector<std::string_view> filter_values;
+        std::vector<bool> filter_nulls;
         for (size_t row_idx = begin; row_idx < end; ++row_idx) {
             key_buffer.clear();
             for (int group_idx = 0; group_idx < group_count; ++group_idx) {
@@ -1064,13 +1231,14 @@ class Executor {
                     if (filter_ref == kNullRowRef) continue;
                     const uint32_t filter_table =
                         FilterTableForAggregate(function);
-                    PaxRowRef row = ToRowRef(filter_table, filter_ref);
-                    if (row.group == nullptr ||
-                        !evaluator.set_row_from_pax(
-                            *row.group, row.slot,
-                            function.filter().num_columns())) {
-                        return fail("aggregate filter cannot read PAX columns");
+                    if (!BuildPredicateRowForTable(
+                            filter_table, filter_ref,
+                            function.filter().num_columns(), &filter_values,
+                            &filter_nulls)) {
+                        return fail(
+                            "aggregate filter cannot read table columns");
                     }
+                    evaluator.set_row_from_views(filter_values, filter_nulls);
                     if (!evaluator.evaluate(function.filter().expr())) {
                         continue;
                     }
@@ -1698,6 +1866,12 @@ class Executor {
                 }
                 continue;
             }
+            if (node.has_sub_block()) {
+                if (!RunSubBlock(node.sub_block(), &results_[node_idx])) {
+                    return false;
+                }
+                continue;
+            }
             if (node.has_aggregate()) {
                 if (node_idx != request_.nodes_size() - 1) {
                     return fail("aggregate must be the root node");
@@ -1747,6 +1921,7 @@ class Executor {
     std::vector<uint64_t> slot_snapshots_;
     std::vector<uint64_t> overflow_snapshots_;
     std::vector<NodeResult> results_;
+    std::vector<VirtualTable> virtual_tables_;
 };
 
 const std::string& default_error(const Executor& executor) {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -941,7 +941,7 @@ class Executor {
             return fail("join key arity");
         }
         // Keyless INNER and LEFT joins are cross products. The proxy only emits
-        // them for one-row virtual inputs, where the SQL shape is explicit.
+        // them for small INNER inputs or one-row virtual LEFT inputs.
         if (join.build_keys_size() == 0 && !is_inner && !is_left) {
             return fail("join key arity");
         }

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -832,9 +832,9 @@ class Executor {
         if (join.build_keys_size() != join.probe_keys_size()) {
             return fail("join key arity");
         }
-        // A keyless INNER join is a cross product, used for one-row virtual
-        // derived inputs. Other join types need explicit keys for SQL shape.
-        if (join.build_keys_size() == 0 && !is_inner) {
+        // Keyless INNER and LEFT joins are cross products. The proxy only emits
+        // them for one-row virtual inputs, where the SQL shape is explicit.
+        if (join.build_keys_size() == 0 && !is_inner && !is_left) {
             return fail("join key arity");
         }
         if (join.build() >= results_.size() || join.probe() >= results_.size()) {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -27,6 +27,8 @@ using LineairDB::Pax::PaxGroup;
 using LineairDB::Pax::PaxStore;
 
 constexpr uint64_t kNullRowRef = std::numeric_limits<uint64_t>::max();
+constexpr uint32_t kTaggedColumnShift = 16;
+constexpr uint32_t kTaggedColumnMask = (uint32_t{1} << kTaggedColumnShift) - 1;
 
 void set_failure(pb::TxExecuteQueryBlock::Response* response,
                  const std::string& message) {
@@ -103,6 +105,11 @@ struct NodeResult {
         }
         return -1;
     }
+};
+
+struct DecodedColumnRef {
+    uint32_t table_idx = 0;
+    uint32_t column = 0;
 };
 
 class Executor {
@@ -201,6 +208,149 @@ class Executor {
             store->group(ref / PaxGroup::kRows),
             static_cast<uint32_t>(ref % PaxGroup::kRows),
         };
+    }
+
+    PaxRowRef RowRefForTable(const NodeResult& input, size_t row_idx,
+                             uint32_t table_idx) const {
+        const int position = input.table_pos(table_idx);
+        if (position < 0) return PaxRowRef{};
+        return ToRowRef(table_idx, input.refs[position][row_idx]);
+    }
+
+    static DecodedColumnRef DecodeAggregateColumnRef(
+        uint32_t default_table_idx, uint32_t encoded_column) {
+        if ((encoded_column >> kTaggedColumnShift) == 0) {
+            return DecodedColumnRef{default_table_idx, encoded_column};
+        }
+        return DecodedColumnRef{
+            encoded_column >> kTaggedColumnShift,
+            encoded_column & kTaggedColumnMask,
+        };
+    }
+
+    bool ValidateAggregateExpressionTables(
+        const pb::FilterExpr& expression, const NodeResult& input,
+        uint32_t default_table_idx) {
+        if (expression.op() == pb::FilterExpr::COLUMN_REF) {
+            const DecodedColumnRef column = DecodeAggregateColumnRef(
+                default_table_idx, expression.column_index());
+            if (input.table_pos(column.table_idx) < 0) {
+                return fail("aggregate expression table is not in input");
+            }
+        }
+        for (const pb::FilterExpr& child : expression.children()) {
+            if (!ValidateAggregateExpressionTables(child, input,
+                                                   default_table_idx)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    std::string_view GroupColumnValue(
+        const pb::QueryBlockColumnRef& column, uint64_t ref) const {
+        std::string_view value = extract_value_column(
+            ToRowRef(column.table_idx(), ref), column.column());
+        if (column.prefix_len() > 0 && value.size() > column.prefix_len()) {
+            value = value.substr(0, column.prefix_len());
+        }
+        return value;
+    }
+
+    bool ReadAggregateColumn(const pb::FilterExpr& expression,
+                             const NodeResult& input, size_t row_idx,
+                             uint32_t default_table_idx,
+                             std::string_view* value) const {
+        if (expression.op() != pb::FilterExpr::COLUMN_REF) return false;
+        const DecodedColumnRef column = DecodeAggregateColumnRef(
+            default_table_idx, expression.column_index());
+        PaxRowRef row = RowRefForTable(input, row_idx, column.table_idx);
+        if (row.group == nullptr) return false;
+        *value = extract_value_column(row, column.column);
+        return true;
+    }
+
+    DecimalValue EvaluateAggregateExpression(
+        const pb::FilterExpr& expression, const NodeResult& input,
+        size_t row_idx, uint32_t default_table_idx) const {
+        using FE = pb::FilterExpr;
+        switch (expression.op()) {
+            case FE::COLUMN_REF: {
+                std::string_view value;
+                if (!ReadAggregateColumn(expression, input, row_idx,
+                                         default_table_idx, &value)) {
+                    DecimalValue result;
+                    result.is_null = true;
+                    return result;
+                }
+                return parse_decimal_value(value);
+            }
+            case FE::CONST_INT: {
+                DecimalValue result;
+                result.mantissa = expression.int_val();
+                return result;
+            }
+            case FE::CONST_UINT: {
+                DecimalValue result;
+                result.mantissa =
+                    static_cast<__int128>(expression.uint_val());
+                return result;
+            }
+            case FE::OP_ADD:
+            case FE::OP_SUB: {
+                if (expression.children_size() != 2) {
+                    DecimalValue result;
+                    result.is_null = true;
+                    return result;
+                }
+                DecimalValue lhs = EvaluateAggregateExpression(
+                    expression.children(0), input, row_idx,
+                    default_table_idx);
+                DecimalValue rhs = EvaluateAggregateExpression(
+                    expression.children(1), input, row_idx,
+                    default_table_idx);
+                if (expression.op() == FE::OP_SUB) {
+                    rhs.mantissa = -rhs.mantissa;
+                }
+                add_decimal_value(lhs, rhs);
+                return lhs;
+            }
+            case FE::OP_MUL: {
+                if (expression.children_size() != 2) {
+                    DecimalValue result;
+                    result.is_null = true;
+                    return result;
+                }
+                DecimalValue lhs = EvaluateAggregateExpression(
+                    expression.children(0), input, row_idx,
+                    default_table_idx);
+                DecimalValue rhs = EvaluateAggregateExpression(
+                    expression.children(1), input, row_idx,
+                    default_table_idx);
+                DecimalValue result;
+                result.mantissa = lhs.mantissa * rhs.mantissa;
+                result.scale = lhs.scale + rhs.scale;
+                result.is_null = lhs.is_null || rhs.is_null;
+                return result;
+            }
+            case FE::OP_NEG: {
+                if (expression.children_size() != 1) {
+                    DecimalValue result;
+                    result.is_null = true;
+                    return result;
+                }
+                DecimalValue result = EvaluateAggregateExpression(
+                    expression.children(0), input, row_idx,
+                    default_table_idx);
+                result.mantissa = -result.mantissa;
+                return result;
+            }
+            default: {
+                DecimalValue result;
+                result.is_null = true;
+                return result;
+            }
+        }
     }
 
     bool RunScan(const pb::QueryBlockScan& scan, NodeResult* output) {
@@ -501,6 +651,11 @@ class Executor {
                     return fail("aggregate table is not in aggregate input");
                 }
             }
+            if (function.has_arg() &&
+                !ValidateAggregateExpressionTables(
+                    function.arg(), input, function.arg_table())) {
+                return false;
+            }
         }
 
         PredicateEvaluator evaluator;
@@ -513,9 +668,7 @@ class Executor {
                     aggregate.group_columns(group_idx);
                 const uint64_t ref =
                     input.refs[group_positions[group_idx]][row_idx];
-                group_values[group_idx] =
-                    extract_value_column(ToRowRef(column.table_idx(), ref),
-                                         column.column());
+                group_values[group_idx] = GroupColumnValue(column, ref);
                 const uint32_t length =
                     static_cast<uint32_t>(group_values[group_idx].size());
                 key_buffer.append(reinterpret_cast<const char*>(&length),
@@ -576,9 +729,9 @@ class Executor {
                         break;
                     case pb::QueryBlockAggFunc::SUM:
                     case pb::QueryBlockAggFunc::AVG: {
-                        DecimalValue value = evaluate_decimal_expression(
-                            function.arg(),
-                            ToRowRef(function.arg_table(), ref));
+                        DecimalValue value = EvaluateAggregateExpression(
+                            function.arg(), input, row_idx,
+                            function.arg_table());
                         if (value.is_null) break;
                         add_decimal_value(state->decimals[aggregate_idx],
                                           value);
@@ -590,9 +743,13 @@ class Executor {
                         const bool wants_max =
                             function.kind() == pb::QueryBlockAggFunc::MAX;
                         if (function.cmp_kind() == 1) {
-                            std::string_view value = extract_value_column(
-                                ToRowRef(function.arg_table(), ref),
-                                function.arg().column_index());
+                            std::string_view value;
+                            if (!ReadAggregateColumn(function.arg(), input,
+                                                     row_idx,
+                                                     function.arg_table(),
+                                                     &value)) {
+                                break;
+                            }
                             if (!state->has_value[aggregate_idx] ||
                                 (wants_max
                                      ? value >
@@ -605,9 +762,9 @@ class Executor {
                                     std::string(value);
                             }
                         } else {
-                            DecimalValue value = evaluate_decimal_expression(
-                                function.arg(),
-                                ToRowRef(function.arg_table(), ref));
+                            DecimalValue value = EvaluateAggregateExpression(
+                                function.arg(), input, row_idx,
+                                function.arg_table());
                             if (value.is_null) break;
                             if (!state->has_value[aggregate_idx] ||
                                 (wants_max

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -228,9 +228,6 @@ class Executor {
 
     bool PrepareTables() {
         if (db_ == nullptr) return fail("database is unavailable");
-        if (request_.tables_size() == 0) {
-            return fail("query block has no tables");
-        }
 
         stores_.assign(request_.tables_size(), nullptr);
         write_counter_snapshots_.assign(request_.tables_size(), {});

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <exception>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -32,6 +33,59 @@ void set_failure(pb::TxExecuteQueryBlock::Response* response,
     response->clear_rows();
 }
 
+__int128 decimal_power_of_ten(int exponent) {
+    __int128 value = 1;
+    while (exponent-- > 0) value *= 10;
+    return value;
+}
+
+// MySQL AVG uses the argument scale plus div_precision_increment, which is 4 in
+// the default configuration used by this build.
+DecimalValue divide_decimal_value(const DecimalValue& sum, uint64_t count,
+                                  int output_scale) {
+    DecimalValue result;
+    result.is_null = true;
+    if (sum.is_null || count == 0) return result;
+
+    __int128 numerator = sum.mantissa;
+    const bool negative = numerator < 0;
+    if (negative) numerator = -numerator;
+
+    // Keep one extra decimal digit for round-half-up after the divide.
+    const int extra_scale = output_scale - sum.scale + 1;
+    if (extra_scale > 0) {
+        numerator *= decimal_power_of_ten(extra_scale);
+    } else if (extra_scale < 0) {
+        numerator /= decimal_power_of_ten(-extra_scale);
+    }
+
+    __int128 quotient = numerator / static_cast<__int128>(count);
+    quotient = (quotient + 5) / 10;
+    result.mantissa = negative ? -quotient : quotient;
+    result.scale = output_scale;
+    result.is_null = false;
+    return result;
+}
+
+void append_result_field(std::string& row, std::string_view payload,
+                         bool is_null) {
+    if (is_null) {
+        row.push_back(static_cast<char>(0xFF));
+        return;
+    }
+
+    const size_t length = payload.size();
+    size_t byte_size = 1;
+    for (size_t value = length >> 8; value != 0; value >>= 8) {
+        ++byte_size;
+    }
+    row.push_back(static_cast<char>(byte_size));
+    for (size_t idx = 0; idx < byte_size; ++idx) {
+        row.push_back(static_cast<char>((length >> (8 * idx)) & 0xFF));
+    }
+    row.append(payload.data(), payload.size());
+}
+
 // Materialized operator output. Each logical tuple is represented as one PAX row
 // reference per participating table.
 struct NodeResult {
@@ -54,12 +108,12 @@ class Executor {
              const pb::TxExecuteQueryBlock::Request& request)
         : db_(db), request_(request) {}
 
-    bool Run() {
+    bool Run(pb::TxExecuteQueryBlock::Response* response) {
         if (!PrepareTables()) return false;
         if (!ValidateNodeOrder()) return false;
-        if (!RunNodes()) return false;
+        if (!RunNodes(response)) return false;
         if (!TablesAreStillQuiet()) return fail("concurrent modification");
-        return fail("query-block output is not implemented");
+        return true;
     }
 
     const std::string& error() const { return error_; }
@@ -230,6 +284,11 @@ class Executor {
         std::vector<DecimalValue> decimals;
         std::vector<std::string> strings;
         std::vector<bool> has_value;
+    };
+
+    struct OutputRow {
+        std::vector<std::string> values;
+        std::vector<bool> nulls;
     };
 
     using GroupMap = std::unordered_map<std::string, GroupState>;
@@ -463,7 +522,206 @@ class Executor {
             }
         }
     }
-    bool RunNodes() {
+
+    std::string AggregateValue(const pb::QueryBlockAggFunc& function,
+                               const GroupState& state, int aggregate_idx,
+                               bool* is_null) const {
+        *is_null = false;
+        switch (function.kind()) {
+            case pb::QueryBlockAggFunc::COUNT:
+                return std::to_string(state.counts[aggregate_idx]);
+            case pb::QueryBlockAggFunc::SUM:
+                if (state.counts[aggregate_idx] == 0) {
+                    *is_null = true;
+                    return {};
+                }
+                return format_decimal_value(state.decimals[aggregate_idx]);
+            case pb::QueryBlockAggFunc::AVG: {
+                if (state.counts[aggregate_idx] == 0) {
+                    *is_null = true;
+                    return {};
+                }
+                const int output_scale =
+                    static_cast<int>(function.arg_scale()) + 4;
+                return format_decimal_value(divide_decimal_value(
+                    state.decimals[aggregate_idx],
+                    state.counts[aggregate_idx], output_scale));
+            }
+            case pb::QueryBlockAggFunc::MIN:
+            case pb::QueryBlockAggFunc::MAX:
+                if (!state.has_value[aggregate_idx]) {
+                    *is_null = true;
+                    return {};
+                }
+                return function.cmp_kind() == 1
+                           ? state.strings[aggregate_idx]
+                           : format_decimal_value(
+                                 state.decimals[aggregate_idx]);
+            default:
+                *is_null = true;
+                return {};
+        }
+    }
+
+    bool SortOutputRows(std::vector<OutputRow>* output_rows) {
+        for (const pb::QueryBlockSortKey& key : request_.order_by()) {
+            if (key.output_ordinal() >=
+                static_cast<uint32_t>(request_.output_size())) {
+                return fail("order-by output ordinal out of range");
+            }
+        }
+
+        std::sort(output_rows->begin(), output_rows->end(),
+                  [&](const OutputRow& lhs, const OutputRow& rhs) {
+                      for (const pb::QueryBlockSortKey& key :
+                           request_.order_by()) {
+                          const uint32_t ordinal = key.output_ordinal();
+                          const bool lhs_null = lhs.nulls[ordinal];
+                          const bool rhs_null = rhs.nulls[ordinal];
+                          if (lhs_null != rhs_null) {
+                              return key.descending() ? rhs_null : lhs_null;
+                          }
+                          if (lhs_null) continue;
+
+                          int comparison = 0;
+                          if (key.cmp_kind() == 1) {
+                              comparison =
+                                  lhs.values[ordinal].compare(
+                                      rhs.values[ordinal]);
+                          } else {
+                              comparison = compare_decimal_values(
+                                  parse_decimal_value(lhs.values[ordinal]),
+                                  parse_decimal_value(rhs.values[ordinal]));
+                          }
+                          if (comparison != 0) {
+                              return key.descending() ? comparison > 0
+                                                      : comparison < 0;
+                          }
+                      }
+                      return false;
+                  });
+        return true;
+    }
+
+    void EmitOutputRows(
+        const std::vector<OutputRow>& output_rows,
+        pb::TxExecuteQueryBlock::Response* response) const {
+        const size_t begin =
+            std::min<size_t>(request_.offset(), output_rows.size());
+        const size_t end =
+            request_.limit() > 0
+                ? std::min<size_t>(begin + request_.limit(),
+                                   output_rows.size())
+                : output_rows.size();
+
+        std::string row_buffer;
+        for (size_t row_idx = begin; row_idx < end; ++row_idx) {
+            row_buffer.clear();
+            append_result_field(row_buffer, {}, false);
+            const OutputRow& row = output_rows[row_idx];
+            for (size_t column_idx = 0; column_idx < row.values.size();
+                 ++column_idx) {
+                append_result_field(row_buffer, row.values[column_idx],
+                                    row.nulls[column_idx]);
+            }
+            response->add_rows(row_buffer);
+        }
+    }
+
+    bool RunAggregateAndEmit(
+        const pb::QueryBlockAggregate& aggregate,
+        pb::TxExecuteQueryBlock::Response* response) {
+        const NodeResult& input = results_[aggregate.input()];
+        const size_t input_rows = input.rows();
+
+        GroupMap groups;
+        const unsigned worker_count = static_cast<unsigned>(std::min<size_t>(
+            WorkerCount(), std::max<size_t>(input_rows / 65536, 1)));
+        if (worker_count <= 1) {
+            if (!AccumulateRange(aggregate, input, 0, input_rows, &groups)) {
+                return false;
+            }
+        } else {
+            std::vector<GroupMap> local_groups(worker_count);
+            std::vector<char> worker_failed(worker_count, 0);
+            std::vector<std::thread> workers;
+            workers.reserve(worker_count);
+            for (unsigned worker_idx = 0; worker_idx < worker_count;
+                 ++worker_idx) {
+                workers.emplace_back([&, worker_idx] {
+                    const size_t begin =
+                        input_rows * worker_idx / worker_count;
+                    const size_t end =
+                        input_rows * (worker_idx + 1) / worker_count;
+                    if (!AccumulateRange(aggregate, input, begin, end,
+                                         &local_groups[worker_idx])) {
+                        worker_failed[worker_idx] = 1;
+                    }
+                });
+            }
+            for (std::thread& worker : workers) worker.join();
+            for (char failed : worker_failed) {
+                if (failed) return false;
+            }
+            for (GroupMap& local : local_groups) {
+                MergeGroups(&groups, &local, aggregate);
+            }
+        }
+
+        const int group_count = aggregate.group_columns_size();
+        if (group_count == 0 && groups.empty()) {
+            GroupState state;
+            state.counts.assign(aggregate.aggs_size(), 0);
+            state.decimals.assign(aggregate.aggs_size(), DecimalValue{});
+            state.strings.assign(aggregate.aggs_size(), {});
+            state.has_value.assign(aggregate.aggs_size(), false);
+            groups.emplace(std::string(), std::move(state));
+        }
+
+        std::vector<OutputRow> output_rows;
+        output_rows.reserve(groups.size());
+        for (auto& entry : groups) {
+            GroupState& state = entry.second;
+            OutputRow row;
+            row.values.reserve(request_.output_size());
+            row.nulls.reserve(request_.output_size());
+            for (const pb::QueryBlockOutputExpr& expression :
+                 request_.output()) {
+                switch (expression.source()) {
+                    case pb::QueryBlockOutputExpr::GROUP:
+                        if (expression.ordinal() >=
+                            static_cast<uint32_t>(group_count)) {
+                            return fail("group output ordinal out of range");
+                        }
+                        row.values.push_back(
+                            state.keys[expression.ordinal()]);
+                        row.nulls.push_back(false);
+                        break;
+                    case pb::QueryBlockOutputExpr::AGG: {
+                        if (expression.ordinal() >=
+                            static_cast<uint32_t>(aggregate.aggs_size())) {
+                            return fail("aggregate output ordinal out of range");
+                        }
+                        bool is_null = false;
+                        row.values.push_back(AggregateValue(
+                            aggregate.aggs(expression.ordinal()), state,
+                            static_cast<int>(expression.ordinal()), &is_null));
+                        row.nulls.push_back(is_null);
+                        break;
+                    }
+                    default:
+                        return fail("unsupported query-block output source");
+                }
+            }
+            output_rows.push_back(std::move(row));
+        }
+
+        if (!SortOutputRows(&output_rows)) return false;
+        EmitOutputRows(output_rows, response);
+        return true;
+    }
+
+    bool RunNodes(pb::TxExecuteQueryBlock::Response* response) {
         results_.resize(request_.nodes_size());
         for (int node_idx = 0; node_idx < request_.nodes_size(); ++node_idx) {
             const pb::QueryBlockNode& node = request_.nodes(node_idx);
@@ -475,11 +733,14 @@ class Executor {
                 return fail("query-block join is not implemented");
             }
             if (node.has_aggregate()) {
-                return fail("query-block aggregate is not implemented");
+                if (node_idx != request_.nodes_size() - 1) {
+                    return fail("aggregate must be the root node");
+                }
+                return RunAggregateAndEmit(node.aggregate(), response);
             }
             return fail("unknown query-block node");
         }
-        return true;
+        return fail("root must be an aggregate node");
     }
 
     bool TablesAreStillQuiet() const {
@@ -530,7 +791,7 @@ void ExecuteQueryBlock(
 
     try {
         Executor executor(db, request);
-        if (!executor.Run()) {
+        if (!executor.Run(response)) {
             set_failure(response, default_error(executor));
             return;
         }

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -829,8 +829,12 @@ class Executor {
         if (!is_inner && !is_left && !is_semi && !is_anti) {
             return fail("unsupported query-block join type");
         }
-        if (join.build_keys_size() != join.probe_keys_size() ||
-            join.build_keys_size() == 0) {
+        if (join.build_keys_size() != join.probe_keys_size()) {
+            return fail("join key arity");
+        }
+        // A keyless INNER join is a cross product, used for one-row virtual
+        // derived inputs. Other join types need explicit keys for SQL shape.
+        if (join.build_keys_size() == 0 && !is_inner) {
             return fail("join key arity");
         }
         if (join.build() >= results_.size() || join.probe() >= results_.size()) {

--- a/server/rpc/query_block_executor.cc
+++ b/server/rpc/query_block_executor.cc
@@ -10,6 +10,7 @@
 #include <string_view>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -28,6 +29,10 @@ using LineairDB::Pax::PaxGroup;
 using LineairDB::Pax::PaxStore;
 
 constexpr uint64_t kNullRowRef = std::numeric_limits<uint64_t>::max();
+// Very large runtime filters are not selective enough to justify probing.
+constexpr size_t kMaxRuntimeFilterKeys = size_t{4} << 20;
+constexpr uint32_t kNoExternalFilterTable =
+    std::numeric_limits<uint32_t>::max();
 constexpr uint32_t kTaggedColumnShift = 16;
 constexpr uint32_t kTaggedColumnMask = (uint32_t{1} << kTaggedColumnShift) - 1;
 
@@ -170,6 +175,16 @@ class Executor {
              const pb::TxExecuteQueryBlock::Request& request)
         : db_(db), request_(request) {}
 
+    Executor(LineairDB::Database* db,
+             const pb::TxExecuteQueryBlock::Request& request,
+             const std::unordered_set<std::string>* external_keys,
+             uint32_t external_filter_table, uint32_t external_filter_column)
+        : db_(db),
+          request_(request),
+          external_keys_(external_keys),
+          external_filter_table_(external_filter_table),
+          external_filter_column_(external_filter_column) {}
+
     bool Run(pb::TxExecuteQueryBlock::Response* response) {
         if (!PrepareTables()) return false;
         if (!ValidateNodeOrder()) return false;
@@ -240,6 +255,11 @@ class Executor {
                     static_cast<uint32_t>(request_.tables_size())) {
                     return fail("scan table out of range");
                 }
+                if (node.scan().has_semi() &&
+                    node.scan().semi().source_node() >=
+                        static_cast<uint32_t>(node_idx)) {
+                    return fail("scan semi-filter source order");
+                }
                 continue;
             }
             if (node.has_join()) {
@@ -257,6 +277,17 @@ class Executor {
                 continue;
             }
             if (node.has_sub_block()) {
+                if (node.sub_block().has_semi()) {
+                    if (node.sub_block().semi().source_node() >=
+                        static_cast<uint32_t>(node_idx)) {
+                        return fail("sub-block semi-filter source order");
+                    }
+                    if (node.sub_block().target_table() >=
+                        static_cast<uint32_t>(
+                            node.sub_block().block().tables_size())) {
+                        return fail("sub-block semi-filter target table");
+                    }
+                }
                 continue;
             }
             if (node.has_aggregate()) {
@@ -483,6 +514,41 @@ class Executor {
         }
     }
 
+    bool CollectSemiFilterKeys(
+        const pb::QueryBlockSemiFilter& semi,
+        std::unordered_set<std::string>* keys) {
+        if (keys == nullptr) return false;
+        if (semi.source_node() >= results_.size()) {
+            return fail("semi-filter source node out of range");
+        }
+
+        const NodeResult& source = results_[semi.source_node()];
+        const pb::QueryBlockColumnRef& column = semi.source_column();
+        const int position = source.table_pos(column.table_idx());
+        if (position < 0) return fail("semi-filter source table");
+
+        keys->clear();
+        keys->reserve(source.rows());
+        for (size_t row_idx = 0; row_idx < source.rows(); row_idx++) {
+            const uint64_t ref = source.refs[position][row_idx];
+            if (NullOf(column.table_idx(), ref, column.column())) continue;
+            std::string_view value = GroupColumnValue(column, ref);
+            keys->insert(std::string(value));
+        }
+        return true;
+    }
+
+    static bool CellMatchesKeySet(
+        const PaxGroup* group, uint32_t slot, uint32_t column,
+        const std::unordered_set<std::string>* keys) {
+        if (keys == nullptr) return true;
+        if (group == nullptr || IsNullColumn(PaxRowRef{group, slot}, column)) {
+            return false;
+        }
+        const std::string_view value = group->cell(column + 1, slot);
+        return keys->find(std::string(value)) != keys->end();
+    }
+
     bool RunScan(const pb::QueryBlockScan& scan, NodeResult* output) {
         if (scan.table_idx() >= static_cast<uint32_t>(request_.tables_size())) {
             return fail("scan table out of range");
@@ -494,6 +560,24 @@ class Executor {
         output->tables = {scan.table_idx()};
         output->refs.assign(1, {});
         if (group_count == 0) return true;
+
+        std::unordered_set<std::string> semi_keys_storage;
+        const std::unordered_set<std::string>* semi_keys = nullptr;
+        if (scan.has_semi()) {
+            if (!CollectSemiFilterKeys(scan.semi(), &semi_keys_storage)) {
+                return false;
+            }
+            if (semi_keys_storage.size() <= kMaxRuntimeFilterKeys) {
+                semi_keys = &semi_keys_storage;
+            }
+        }
+
+        const std::unordered_set<std::string>* external_keys = nullptr;
+        if (external_keys_ != nullptr &&
+            external_filter_table_ == scan.table_idx() &&
+            external_keys_->size() <= kMaxRuntimeFilterKeys) {
+            external_keys = external_keys_;
+        }
 
         const bool has_filter = scan.has_filter() && scan.filter().has_expr();
         const unsigned worker_count = static_cast<unsigned>(
@@ -528,6 +612,16 @@ class Executor {
                                 __builtin_ctzll(visible_bits));
                             visible_bits &= visible_bits - 1;
                             const uint32_t slot = base + bit;
+                            if (!CellMatchesKeySet(
+                                    group, slot, scan.semi().my_column(),
+                                    semi_keys)) {
+                                continue;
+                            }
+                            if (!CellMatchesKeySet(
+                                    group, slot, external_filter_column_,
+                                    external_keys)) {
+                                continue;
+                            }
                             if (has_filter) {
                                 if (!evaluator.set_row_from_pax(
                                         *group, slot,
@@ -617,10 +711,24 @@ class Executor {
     bool RunSubBlock(const pb::QueryBlockSubBlock& sub_block,
                      NodeResult* output) {
         pb::TxExecuteQueryBlock::Response response;
-        ExecuteQueryBlock(db_, sub_block.block(), &response);
-        if (!response.ok()) {
-            return fail(response.error().empty() ? "sub-block failed"
-                                                 : response.error());
+        if (sub_block.has_semi()) {
+            std::unordered_set<std::string> keys;
+            if (!CollectSemiFilterKeys(sub_block.semi(), &keys)) return false;
+
+            Executor child(db_, sub_block.block(), &keys,
+                           sub_block.target_table(),
+                           sub_block.target_column());
+            if (!child.Run(&response)) {
+                return fail(child.error().empty() ? "sub-block failed"
+                                                  : child.error());
+            }
+            response.set_ok(true);
+        } else {
+            ExecuteQueryBlock(db_, sub_block.block(), &response);
+            if (!response.ok()) {
+                return fail(response.error().empty() ? "sub-block failed"
+                                                     : response.error());
+            }
         }
 
         VirtualTable table;
@@ -2040,6 +2148,9 @@ class Executor {
 
     LineairDB::Database* db_;
     const pb::TxExecuteQueryBlock::Request& request_;
+    const std::unordered_set<std::string>* external_keys_ = nullptr;
+    uint32_t external_filter_table_ = kNoExternalFilterTable;
+    uint32_t external_filter_column_ = 0;
     std::string error_;
     std::vector<PaxStore*> stores_;
     std::vector<std::vector<uint64_t>> write_counter_snapshots_;

--- a/server/rpc/query_block_executor.hh
+++ b/server/rpc/query_block_executor.hh
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "lineairdb.pb.h"
+
+namespace LineairDB {
+class Database;
+}
+
+namespace query_block {
+
+/**
+ * @brief Execute a LineairDB query-block request on the server.
+ *
+ * The request is the protobuf operator tree built by the proxy from supported
+ * SELECT shapes. It is not SQL text and it is not MySQL's AccessPath or Query
+ * Execution Plan object. The executor runs accepted operators over LineairDB's
+ * PAX storage and returns final rows in the proxy row format.
+ */
+void ExecuteQueryBlock(
+    LineairDB::Database* db,
+    const LineairDB::Protocol::TxExecuteQueryBlock::Request& request,
+    LineairDB::Protocol::TxExecuteQueryBlock::Response* response);
+
+}  // namespace query_block

--- a/server/rpc/read_plan_executor.cc
+++ b/server/rpc/read_plan_executor.cc
@@ -132,7 +132,8 @@ const std::vector<uint32_t>* selected_columns_for_materialization(
     }
     selected_columns.assign(step.projection().field_indexes().begin(),
                             step.projection().field_indexes().end());
-    if (step.has_filter() && step.filter().has_expr()) {
+    if (step.has_filter() && step.filter().has_expr() &&
+        !is_aggregate_having_filter(step)) {
         collect_filter_columns(step.filter().expr(), selected_columns);
     }
     for (const auto& semijoin : step.semijoins()) {
@@ -181,8 +182,10 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
 
         // Step-level row filter: parseable non-matches are dropped; rows the
         // evaluator cannot parse are returned for MySQL to re-check.
+        const bool step_has_group_having = is_aggregate_having_filter(step);
         const bool step_has_filter =
-            step.has_filter() && step.filter().has_expr();
+            step.has_filter() && step.filter().has_expr() &&
+            !step_has_group_having;
         const auto* step_filter =
             step_has_filter ? &step.filter().expr() : nullptr;
         const uint32_t step_filter_cols =
@@ -625,8 +628,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             }
 
             // With a pushed filter, LIMIT must apply after filter evaluation.
-            const bool limit_after_filter =
-                step.has_filter() && step.filter().has_expr();
+            const bool limit_after_filter = step_has_filter;
             const uint64_t scan_limit_for_lineairdb =
                 limit_after_filter ? 0 : step.scan_limit();
             auto scan_result =
@@ -666,8 +668,9 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                     }
                     scan_result.rows = std::move(filtered);
                 }
-                aggregated = server_aggregate_scan(step.aggregate(),
-                                                   scan_result.rows, step_result);
+                aggregated = server_aggregate_scan(
+                    step.aggregate(), scan_result.rows, step_result,
+                    step_has_group_having ? &step.filter() : nullptr);
             }
             if (!aggregated) {
                 uint64_t emitted = 0;

--- a/server/rpc/read_plan_executor.cc
+++ b/server/rpc/read_plan_executor.cc
@@ -111,6 +111,17 @@ std::string build_plan_key(
     return key;
 }
 
+void collect_filter_columns(
+    const LineairDB::Protocol::FilterExpr& expr,
+    std::vector<uint32_t>& columns) {
+    if (expr.op() == LineairDB::Protocol::FilterExpr::COLUMN_REF) {
+        columns.push_back(expr.column_index());
+    }
+    for (const auto& child : expr.children()) {
+        collect_filter_columns(child, columns);
+    }
+}
+
 const std::vector<uint32_t>* selected_columns_for_materialization(
     const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,
     std::vector<uint32_t>& selected_columns) {
@@ -121,6 +132,20 @@ const std::vector<uint32_t>* selected_columns_for_materialization(
     }
     selected_columns.assign(step.projection().field_indexes().begin(),
                             step.projection().field_indexes().end());
+    if (step.has_filter() && step.filter().has_expr()) {
+        collect_filter_columns(step.filter().expr(), selected_columns);
+    }
+    for (const auto& semijoin : step.semijoins()) {
+        selected_columns.push_back(semijoin.probe_column());
+    }
+    std::sort(selected_columns.begin(), selected_columns.end());
+    selected_columns.erase(
+        std::unique(selected_columns.begin(), selected_columns.end()),
+        selected_columns.end());
+    if (step.projection().num_columns() > 0 &&
+        selected_columns.size() >= step.projection().num_columns()) {
+        return nullptr;
+    }
     return &selected_columns;
 }
 
@@ -177,10 +202,11 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
         const std::vector<uint32_t>* selected_columns_for_reads =
             selected_columns_for_materialization(step, selected_columns);
 
-        // PAX-backed reads can materialize only the selected column payloads
-        // while keeping the full row shape. Projection then trims emitted
-        // VALUES to the kept columns; malformed rows fail the plan instead of
-        // mixing full and projected layouts.
+        // PAX-backed reads can materialize only the selected payloads needed
+        // for server-side filtering and final projection while keeping the
+        // full row shape. Projection then trims emitted VALUES to the kept
+        // columns; malformed rows fail the plan instead of mixing full and
+        // projected layouts.
         bool projection_failed = false;
         auto project_value = [&](std::string&& v) -> std::string {
             if (!step_has_projection || v.empty()) return std::move(v);

--- a/server/rpc/read_plan_executor.cc
+++ b/server/rpc/read_plan_executor.cc
@@ -540,6 +540,11 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             if (!step.for_each() && step.scan_limit() == 0 &&
                 !step.reverse_scan() && step.has_aggregate() &&
                 step.aggregate().aggs_size() > 0) {
+                if (parallel_primary_pax_aggregate_scan(
+                        db_manager_->get_database().get(), step, start_key,
+                        end_key, step_result)) {
+                    continue;
+                }
                 if (parallel_primary_aggregate_scan(
                         db_manager_->get_database().get(), step, start_key,
                         end_key, step_result)) {

--- a/server/rpc/read_plan_executor.cc
+++ b/server/rpc/read_plan_executor.cc
@@ -222,6 +222,49 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             return std::move(v);
         };
 
+        // Build membership sets from earlier source steps, then drop probe
+        // rows whose join key is absent. This is a plan-local reduction, not a
+        // row predicate, so rejected rows are not negative-cache material.
+        std::vector<SemijoinReduction> semijoin_reductions;
+        const int this_step_idx =
+            static_cast<int>(previous_results.size()) - 1;
+        for (const auto& sj : step.semijoins()) {
+            const int source_step = static_cast<int>(sj.source_step());
+            if (source_step < 0 || source_step >= this_step_idx) continue;
+            SemijoinReduction reduction;
+            reduction.probe_column = sj.probe_column();
+            const bool source_filter_on =
+                sj.has_source_filter() && sj.source_filter().has_expr();
+            const uint32_t source_filter_columns =
+                source_filter_on ? sj.source_filter().num_columns() : 0;
+            for (const auto& value :
+                 previous_results[source_step]->scan_values()) {
+                if (value.empty()) continue;
+                if (source_filter_on) {
+                    PredicateEvaluator evaluator;
+                    if (evaluator.parse_row(value.data(), value.size(),
+                                            source_filter_columns) &&
+                        !evaluator.evaluate(sj.source_filter().expr())) {
+                        continue;
+                    }
+                }
+                auto column = extract_value_column(value, sj.source_column());
+                if (!column.empty()) reduction.keys.emplace(column);
+            }
+            semijoin_reductions.push_back(std::move(reduction));
+        }
+        auto semijoin_rejects = [&](const std::string& value) -> bool {
+            for (const auto& reduction : semijoin_reductions) {
+                auto column =
+                    extract_value_column(value, reduction.probe_column);
+                if (reduction.keys.find(std::string(column)) ==
+                    reduction.keys.end()) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
         if (step.for_each()) {
             // Anti-join probe: it only needs a match to exist. Stop after the
             // first surviving row. No scan_limit -- index_next reports a clean
@@ -235,44 +278,6 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                 source_step >= static_cast<int>(previous_results.size()) - 1) {
                 continue;
             }
-
-            // Build membership sets from earlier source steps, then drop
-            // probe rows whose join key is absent.
-            std::vector<SemijoinReduction> semijoin_reductions;
-            const int this_step_idx =
-                static_cast<int>(previous_results.size()) - 1;
-            for (const auto& sj : step.semijoins()) {
-                const int ss = static_cast<int>(sj.source_step());
-                if (ss < 0 || ss >= this_step_idx) continue;
-                SemijoinReduction reduction;
-                reduction.probe_column = sj.probe_column();
-                const bool sf_on =
-                    sj.has_source_filter() && sj.source_filter().has_expr();
-                const uint32_t sf_cols =
-                    sf_on ? sj.source_filter().num_columns() : 0;
-                for (const auto& v : previous_results[ss]->scan_values()) {
-                    if (v.empty()) continue;
-                    if (sf_on) {
-                        PredicateEvaluator se;
-                        if (se.parse_row(v.data(), v.size(), sf_cols) &&
-                            !se.evaluate(sj.source_filter().expr()))
-                            continue;
-                    }
-                    auto col = extract_value_column(v, sj.source_column());
-                    if (!col.empty()) reduction.keys.emplace(col);
-                }
-                semijoin_reductions.push_back(std::move(reduction));
-            }
-            auto sj_reject = [&](const std::string& value) -> bool {
-                for (const auto& reduction : semijoin_reductions) {
-                    auto col =
-                        extract_value_column(value, reduction.probe_column);
-                    if (reduction.keys.find(std::string(col)) ==
-                        reduction.keys.end())
-                        return true;  // no join partner -> drop
-                }
-                return false;
-            };
 
             const auto* source = previous_results[source_step];
             const int row_count =
@@ -377,7 +382,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                                         if (!worker_row_passes(r.value))
                                             continue;
                                         if (!semijoin_reductions.empty() &&
-                                            sj_reject(r.value))
+                                            semijoin_rejects(r.value))
                                             continue;
                                         out.keys.push_back(std::move(r.key));
                                         out.values.push_back(worker_project(
@@ -402,7 +407,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                                         if (!worker_row_passes(r.value))
                                             continue;
                                         if (!semijoin_reductions.empty() &&
-                                            sj_reject(r.value))
+                                            semijoin_rejects(r.value))
                                             continue;
                                         out.secondary_keys.push_back(
                                             std::move(r.secondary_key));
@@ -425,7 +430,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                                 out.tids.push_back(read_result.tid);
                                 if (read_result.found &&
                                     !(!semijoin_reductions.empty() &&
-                                      sj_reject(read_result.value))) {
+                                      semijoin_rejects(read_result.value))) {
                                     out.values.push_back(worker_project(
                                         std::move(read_result.value)));
                                 } else {
@@ -500,7 +505,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                         for (auto& r : scan_result.rows) {
                             if (!row_passes(r.value)) continue;
                             if (!semijoin_reductions.empty() &&
-                                sj_reject(r.value))
+                                semijoin_rejects(r.value))
                                 continue;
                             step_result->add_scan_keys(std::move(r.key));
                             step_result->add_scan_values(
@@ -525,7 +530,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                         for (auto& r : scan_result.rows) {
                             if (!row_passes(r.value)) continue;
                             if (!semijoin_reductions.empty() &&
-                                sj_reject(r.value))
+                                semijoin_rejects(r.value))
                                 continue;
                             step_result->add_secondary_keys(
                                 std::move(r.secondary_key));
@@ -552,7 +557,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                 step_result->add_scan_tids(read_result.tid);
                 if (read_result.found &&
                     !(!semijoin_reductions.empty() &&
-                      sj_reject(read_result.value))) {
+                      semijoin_rejects(read_result.value))) {
                     step_result->add_scan_values(
                         project_value(std::move(read_result.value)));
                 } else {
@@ -607,7 +612,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             if (!(step.has_aggregate() && step.aggregate().aggs_size() > 0)) {
                 if (parallel_primary_pax_row_ref_scan(
                         db_manager_->get_database().get(), step, start_key,
-                        end_key, step_result, projection_failed)) {
+                        end_key, step_result, projection_failed,
+                        semijoin_reductions)) {
                     if (projection_failed) {
                         response.set_ok(false);
                         flat_plan::encode_to_string(response, result);
@@ -619,6 +625,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             if (!step.for_each() && step.scan_limit() == 0 &&
                 !step.reverse_scan() &&
                 !(step.has_aggregate() && step.aggregate().aggs_size() > 0) &&
+                semijoin_reductions.empty() &&
                 step.has_filter() && step.filter().has_expr()) {
                 if (parallel_primary_filter_scan(
                         db_manager_->get_database().get(), step, start_key,
@@ -680,6 +687,10 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                         step_result->add_filtered_keys(std::move(row.key));
                         continue;
                     }
+                    if (!semijoin_reductions.empty() &&
+                        semijoin_rejects(row.value)) {
+                        continue;
+                    }
                     step_result->add_scan_keys(std::move(row.key));
                     step_result->add_scan_values(project_value(std::move(row.value)));
                     step_result->add_scan_tids(row.tid);
@@ -706,6 +717,10 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                 if (!row_passes(row.value)) {
                     // Secondary scans report rejected rows by primary key.
                     step_result->add_filtered_keys(std::move(row.primary_key));
+                    continue;
+                }
+                if (!semijoin_reductions.empty() &&
+                    semijoin_rejects(row.value)) {
                     continue;
                 }
                 step_result->add_secondary_keys(std::move(row.secondary_key));

--- a/server/rpc/read_plan_executor.cc
+++ b/server/rpc/read_plan_executor.cc
@@ -551,6 +551,18 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                     continue;
                 }
             }
+            if (!(step.has_aggregate() && step.aggregate().aggs_size() > 0)) {
+                if (parallel_primary_pax_row_ref_scan(
+                        db_manager_->get_database().get(), step, start_key,
+                        end_key, step_result, projection_failed)) {
+                    if (projection_failed) {
+                        response.set_ok(false);
+                        flat_plan::encode_to_string(response, result);
+                        return;
+                    }
+                    continue;
+                }
+            }
             if (!step.for_each() && step.scan_limit() == 0 &&
                 !step.reverse_scan() &&
                 !(step.has_aggregate() && step.aggregate().aggs_size() > 0) &&

--- a/server/rpc/read_plan_executor.cc
+++ b/server/rpc/read_plan_executor.cc
@@ -238,18 +238,14 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
 
             // Build membership sets from earlier source steps, then drop
             // probe rows whose join key is absent.
-            struct FeSemijoin {
-                std::unordered_set<std::string> keys;
-                uint32_t probe_column;
-            };
-            std::vector<FeSemijoin> fe_semijoins;
+            std::vector<SemijoinReduction> semijoin_reductions;
             const int this_step_idx =
                 static_cast<int>(previous_results.size()) - 1;
             for (const auto& sj : step.semijoins()) {
                 const int ss = static_cast<int>(sj.source_step());
                 if (ss < 0 || ss >= this_step_idx) continue;
-                FeSemijoin fsj;
-                fsj.probe_column = sj.probe_column();
+                SemijoinReduction reduction;
+                reduction.probe_column = sj.probe_column();
                 const bool sf_on =
                     sj.has_source_filter() && sj.source_filter().has_expr();
                 const uint32_t sf_cols =
@@ -263,14 +259,16 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                             continue;
                     }
                     auto col = extract_value_column(v, sj.source_column());
-                    if (!col.empty()) fsj.keys.emplace(col);
+                    if (!col.empty()) reduction.keys.emplace(col);
                 }
-                fe_semijoins.push_back(std::move(fsj));
+                semijoin_reductions.push_back(std::move(reduction));
             }
             auto sj_reject = [&](const std::string& value) -> bool {
-                for (const auto& fsj : fe_semijoins) {
-                    auto col = extract_value_column(value, fsj.probe_column);
-                    if (fsj.keys.find(std::string(col)) == fsj.keys.end())
+                for (const auto& reduction : semijoin_reductions) {
+                    auto col =
+                        extract_value_column(value, reduction.probe_column);
+                    if (reduction.keys.find(std::string(col)) ==
+                        reduction.keys.end())
                         return true;  // no join partner -> drop
                 }
                 return false;
@@ -378,7 +376,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                                     for (auto& r : scan_result.rows) {
                                         if (!worker_row_passes(r.value))
                                             continue;
-                                        if (!fe_semijoins.empty() &&
+                                        if (!semijoin_reductions.empty() &&
                                             sj_reject(r.value))
                                             continue;
                                         out.keys.push_back(std::move(r.key));
@@ -403,7 +401,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                                     for (auto& r : scan_result.rows) {
                                         if (!worker_row_passes(r.value))
                                             continue;
-                                        if (!fe_semijoins.empty() &&
+                                        if (!semijoin_reductions.empty() &&
                                             sj_reject(r.value))
                                             continue;
                                         out.secondary_keys.push_back(
@@ -426,7 +424,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                                 out.keys.push_back(row_key);
                                 out.tids.push_back(read_result.tid);
                                 if (read_result.found &&
-                                    !(!fe_semijoins.empty() &&
+                                    !(!semijoin_reductions.empty() &&
                                       sj_reject(read_result.value))) {
                                     out.values.push_back(worker_project(
                                         std::move(read_result.value)));
@@ -501,7 +499,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                         }
                         for (auto& r : scan_result.rows) {
                             if (!row_passes(r.value)) continue;
-                            if (!fe_semijoins.empty() && sj_reject(r.value))
+                            if (!semijoin_reductions.empty() &&
+                                sj_reject(r.value))
                                 continue;
                             step_result->add_scan_keys(std::move(r.key));
                             step_result->add_scan_values(
@@ -525,7 +524,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                         }
                         for (auto& r : scan_result.rows) {
                             if (!row_passes(r.value)) continue;
-                            if (!fe_semijoins.empty() && sj_reject(r.value))
+                            if (!semijoin_reductions.empty() &&
+                                sj_reject(r.value))
                                 continue;
                             step_result->add_secondary_keys(
                                 std::move(r.secondary_key));
@@ -551,7 +551,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                 step_result->add_scan_keys(row_key);
                 step_result->add_scan_tids(read_result.tid);
                 if (read_result.found &&
-                    !(!fe_semijoins.empty() &&
+                    !(!semijoin_reductions.empty() &&
                       sj_reject(read_result.value))) {
                     step_result->add_scan_values(
                         project_value(std::move(read_result.value)));

--- a/server/rpc/read_plan_executor.cc
+++ b/server/rpc/read_plan_executor.cc
@@ -111,6 +111,19 @@ std::string build_plan_key(
     return key;
 }
 
+const std::vector<uint32_t>* selected_columns_for_materialization(
+    const LineairDB::Protocol::TxExecuteReadPlan::PlanStep& step,
+    std::vector<uint32_t>& selected_columns) {
+    selected_columns.clear();
+    if (!step.has_projection() ||
+        step.projection().field_indexes_size() == 0) {
+        return nullptr;
+    }
+    selected_columns.assign(step.projection().field_indexes().begin(),
+                            step.projection().field_indexes().end());
+    return &selected_columns;
+}
+
 }  // namespace
 
 void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
@@ -159,10 +172,15 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             return step_eval.evaluate(*step_filter);
         };
 
-        // Filters read the full row. Projection then trims emitted VALUES to
-        // the kept columns; malformed rows fail the plan instead of mixing
-        // full and projected layouts.
         const bool step_has_projection = step.has_projection();
+        std::vector<uint32_t> selected_columns;
+        const std::vector<uint32_t>* selected_columns_for_reads =
+            selected_columns_for_materialization(step, selected_columns);
+
+        // PAX-backed reads can materialize only the selected column payloads
+        // while keeping the full row shape. Projection then trims emitted
+        // VALUES to the kept columns; malformed rows fail the plan instead of
+        // mixing full and projected layouts.
         bool projection_failed = false;
         auto project_value = [&](std::string&& v) -> std::string {
             if (!step_has_projection || v.empty()) return std::move(v);
@@ -322,7 +340,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                                         db->StatelessRangeScan(
                                             step.table_name(), row_key,
                                             row_end, step.scan_limit(),
-                                            step.reverse_scan());
+                                            step.reverse_scan(),
+                                            selected_columns_for_reads);
                                     if (!scan_result.ok) {
                                         failed[worker_index] = 1;
                                         break;
@@ -346,7 +365,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                                             step.table_name(),
                                             step.index_name(), row_key,
                                             row_end, step.scan_limit(),
-                                            step.reverse_scan());
+                                            step.reverse_scan(),
+                                            selected_columns_for_reads);
                                     if (!scan_result.ok) {
                                         failed[worker_index] = 1;
                                         break;
@@ -372,7 +392,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                             } else {
                                 auto read_result =
                                     db->StatelessRead(step.table_name(),
-                                                      row_key);
+                                                      row_key,
+                                                      selected_columns_for_reads);
                                 out.keys.push_back(row_key);
                                 out.tids.push_back(read_result.tid);
                                 if (read_result.found &&
@@ -442,7 +463,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                         auto scan_result =
                             db_manager_->get_database()->StatelessRangeScan(
                                 step.table_name(), row_key, row_end,
-                                step.scan_limit(), step.reverse_scan());
+                                step.scan_limit(), step.reverse_scan(),
+                                selected_columns_for_reads);
                         if (!scan_result.ok) {
                             response.set_ok(false);
                             flat_plan::encode_to_string(response, result);
@@ -465,7 +487,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
                                 ->StatelessSecondaryRangeScan(
                                     step.table_name(), step.index_name(),
                                     row_key, row_end, step.scan_limit(),
-                                    step.reverse_scan());
+                                    step.reverse_scan(),
+                                    selected_columns_for_reads);
                         if (!scan_result.ok) {
                             response.set_ok(false);
                             flat_plan::encode_to_string(response, result);
@@ -494,7 +517,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
 
                 auto read_result =
                     db_manager_->get_database()->StatelessRead(
-                        step.table_name(), row_key);
+                        step.table_name(), row_key,
+                        selected_columns_for_reads);
                 step_result->add_scan_keys(row_key);
                 step_result->add_scan_tids(read_result.tid);
                 if (read_result.found &&
@@ -518,7 +542,7 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
         if (!step.is_scan()) {
             auto read_result =
                 db_manager_->get_database()->StatelessRead(
-                    step.table_name(), start_key);
+                    step.table_name(), start_key, selected_columns_for_reads);
             step_result->set_actual_key(start_key);
             step_result->set_actual_start_key(start_key);
             step_result->set_found(read_result.found);
@@ -582,7 +606,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             auto scan_result =
                 db_manager_->get_database()->StatelessRangeScan(
                     step.table_name(), start_key, end_key,
-                    scan_limit_for_lineairdb, step.reverse_scan());
+                    scan_limit_for_lineairdb, step.reverse_scan(),
+                    selected_columns_for_reads);
             if (!scan_result.ok) {
                 response.set_ok(false);
                 flat_plan::encode_to_string(response, result);
@@ -641,7 +666,8 @@ void LineairDBRpc::handleTxExecuteReadPlan(const std::string& message,
             auto scan_result =
                 db_manager_->get_database()->StatelessSecondaryRangeScan(
                     step.table_name(), step.index_name(), start_key, end_key,
-                    step.scan_limit(), step.reverse_scan());
+                    step.scan_limit(), step.reverse_scan(),
+                    selected_columns_for_reads);
             if (!scan_result.ok) {
                 response.set_ok(false);
                 flat_plan::encode_to_string(response, result);

--- a/server/rpc/row_codec.cc
+++ b/server/rpc/row_codec.cc
@@ -86,6 +86,17 @@ std::string_view extract_value_column(const std::string& row,
     return {};
 }
 
+std::string_view extract_value_column(const PaxRowRef& row, int column_index) {
+    if (row.group == nullptr || column_index < 0 ||
+        row.slot >= LineairDB::Pax::PaxGroup::kRows) {
+        return {};
+    }
+
+    const size_t field_index = static_cast<size_t>(column_index) + 1;
+    if (field_index >= row.group->schema().field_count()) return {};
+    return row.group->cell(field_index, row.slot);
+}
+
 std::string encode_int_key_part(int64_t value) {
     const auto encoded = static_cast<uint32_t>(static_cast<int32_t>(value)) ^
                          0x80000000U;

--- a/server/rpc/row_codec.hh
+++ b/server/rpc/row_codec.hh
@@ -5,6 +5,7 @@
 #include <string_view>
 
 #include <google/protobuf/repeated_field.h>
+#include <lineairdb/pax_store.h>
 
 // Byte-level encode/decode helpers shared across the RPC handlers:
 // LineairDBField-format row access plus the int-keyed primary-key layout
@@ -12,6 +13,17 @@
 
 // Bump the byte string to its lexicographic successor; returns empty on overflow.
 std::string next_lexicographic_key(std::string key);
+
+/**
+ * @brief Borrowed view of one row stored in a PAX group.
+ *
+ * Server-side evaluators use this to read column values from PAX strips without
+ * materializing a full LineairDBField-format row.
+ */
+struct PaxRowRef {
+    const LineairDB::Pax::PaxGroup* group = nullptr;
+    uint32_t slot = 0;
+};
 
 /**
  * @brief Trim a serialized row value to the projected columns.
@@ -26,9 +38,16 @@ bool trim_row_value(const std::string& full,
                     const google::protobuf::RepeatedField<uint32_t>& kept,
                     uint32_t num_columns, std::string& out);
 
-// Return the bytes of column `column_index` from a serialized MySQL row payload.
+/**
+ * @brief Return the bytes of a column from a serialized MySQL row payload.
+ */
 std::string_view extract_value_column(const std::string& row,
                                       int column_index);
+
+/**
+ * @brief Return the bytes of a column from a PAX row slot.
+ */
+std::string_view extract_value_column(const PaxRowRef& row, int column_index);
 
 /**
  * @brief Build an int-keyed primary-key part in LineairDB's byte layout.

--- a/server/storage/database_manager.cc
+++ b/server/storage/database_manager.cc
@@ -23,6 +23,7 @@ DatabaseManager::DatabaseManager() {
     conf.max_thread           = 1;
     conf.concurrency_control_protocol = LineairDB::Config::ConcurrencyControl::Silo;
     conf.index_structure = LineairDB::Config::IndexStructure::Masstree;
+    conf.enable_pax_storage = true;
     database_ = std::make_shared<LineairDB::Database>(conf);
     LOG_INFO("Database manager initialized");
 }


### PR DESCRIPTION
## Summary

- Merges the PAX feature branch into main. This is a fast-forward: main's tip is an ancestor of this branch, and the content was already reviewed as PRs #37-#40.
- The server stores primary rows in PAX (column-strip) format. This is a design decision: PAX is the default storage layout, and there is no configuration switch back to the heap-only layout. Rows that do not fit their declared cell widths (and tables with very wide fields) keep using the per-row heap path.
- Adds a second MySQL plugin, LINEAIRDB_COLUMNAR (secondary engine). It is declared in the same plugin library as LINEAIRDB and registers when the library loads at mysqld start. Queries on tables with `SECONDARY_ENGINE=LINEAIRDB_COLUMNAR` and `SECONDARY_LOAD` can be offloaded to a query-block executor on the server. Tables that do not opt in keep the normal row path.
- Adds the TPC-H query set and a wall-time harness under `bench/`.

## Why

- We want analytical scans over live transactional data without stale reads. The row-store read path cannot scan large tables column-wise. PAX plus the secondary engine gives the server a fast scan/aggregate path while keeping the storage engine's existing strict-serializable transaction behavior.

## Details

- Server: PAX schemas are installed at CREATE TABLE from field widths sent by the proxy. A query-block executor (scan, filter, join, aggregate, sort) runs behind the new opcode `TX_EXECUTE_QUERY_BLOCK`.
- Proxy: maps eligible optimizer plans to query-block requests, and rejects any shape it cannot express. Rejected shapes fall back to the row path; under forced secondary mode the statement errors instead.
- PAX cells store the same ASCII payload bytes as the previous row format, split per column. Reads return byte-identical values.
- `proto/lineairdb.proto` changes are append-only (new opcode and messages). No existing field is renumbered.
- Point reads of PAX rows gather from strips into a scratch buffer. The write path scatters row fields into strips at insert.