### PR TITLE
feat: DuckDB executor bridge for the columnar secondary engine

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,7 @@
 	url = https://github.com/Noxy3301/benchbase.git
 	branch = research/helios
 	ignore = dirty
+[submodule "third_party/duckdb"]
+	path = third_party/duckdb
+	url = https://github.com/duckdb/duckdb.git
+	ignore = dirty

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -934,12 +934,13 @@ message TxExecuteSqlDuckdb {
                                            // (TABLE_SHARE::table_name),
                                            // e.g. "lineitem"
         string db_name = 4;                // TABLE_SHARE::db, e.g. "benchbase".
-                                           // The server exposes the table both
-                                           // bare and schema-qualified
-                                           // ("db"."table"); db-qualified
-                                           // references from MySQL's view
-                                           // expansion resolve without
-                                           // rewriting.
+                                           // Informational: the server
+                                           // registers only the bare sql_name
+                                           // view, and the proxy strips
+                                           // db-qualification from table
+                                           // references in the SQL text (see
+                                           // RegisterPaxView in
+                                           // duckdb_bridge_executor.cc).
         repeated ColumnDesc columns = 2;   // TABLE::field[] order
     }
     message Request {

--- a/proto/lineairdb.proto
+++ b/proto/lineairdb.proto
@@ -56,6 +56,11 @@ enum OpCode {
     // Secondary-engine computation pushdown.
     // Executes a query-block operator tree on the LineairDB server.
     TX_EXECUTE_QUERY_BLOCK = 36;
+
+    // Executes raw SQL text on the server's embedded DuckDB executor, which
+    // reads PAX storage in place. Sent only when HELIOS_DUCKDB_BRIDGE is set
+    // on the proxy.
+    TX_EXECUTE_SQL_DUCKDB = 37;
 }
 
 enum BatchOpType {
@@ -902,4 +907,48 @@ message AggregateSpec {
     uint32 num_columns = 1;                            // table->s->fields (row parse)
     repeated uint32 group_columns = 2 [packed = true]; // 0-based field indices (GROUP BY)
     repeated AggFunc aggs = 3;
+}
+
+// DuckDB bridge: executes verbatim client SQL text on the LineairDB server
+// through the embedded DuckDB executor, which reads the server's PAX storage
+// in place. Coverage is not limited to the query shapes TX_EXECUTE_QUERY_BLOCK
+// recognizes. Sent only when HELIOS_DUCKDB_BRIDGE is set on the proxy.
+//
+// Each request carries per-table PAX cell metadata (kind/width/scale); the
+// server persists none of it. The proxy derives the metadata from
+// TABLE::field[] with the computation used at CREATE TABLE time, and it
+// matches the server-side PAX layout while the table's schema is unchanged.
+message TxExecuteSqlDuckdb {
+    // Mirrors LineairDB::Pax::FieldKind (pax_store.h): 0=UNTYPED, 1=INT32,
+    // 2=INT64, 3=DATE, 4=DEC64.
+    message ColumnDesc {
+        string name = 1;         // TABLE::field[i]->field_name
+        uint32 pax_kind = 2;
+        uint32 pax_width = 3;    // PAX cell payload width (bytes)
+        int32 pax_scale = 4;     // FK_DEC64 only
+    }
+    message TableDesc {
+        string table_name = 1;             // PaxStore lookup key
+                                           // (TABLE_SHARE::normalized_path)
+        string sql_name = 3;               // bare name the SQL text uses
+                                           // (TABLE_SHARE::table_name),
+                                           // e.g. "lineitem"
+        string db_name = 4;                // TABLE_SHARE::db, e.g. "benchbase".
+                                           // The server exposes the table both
+                                           // bare and schema-qualified
+                                           // ("db"."table"); db-qualified
+                                           // references from MySQL's view
+                                           // expansion resolve without
+                                           // rewriting.
+        repeated ColumnDesc columns = 2;   // TABLE::field[] order
+    }
+    message Request {
+        string sql = 1;                // verbatim client SQL text (thd->query())
+        repeated TableDesc tables = 2; // every base table the query touches
+    }
+    message Response {
+        bool ok = 1;
+        string error = 2;
+        repeated bytes rows = 3;  // proxy row format, DuckDB result order
+    }
 }

--- a/proxy/CMakeLists.txt
+++ b/proxy/CMakeLists.txt
@@ -56,6 +56,7 @@ set(LINEAIRDB_SOURCES ha_lineairdb.cc ha_lineairdb.hh
                       lineairdb_index_search.cc lineairdb_index_search.hh
                       lineairdb_prefetch.cc lineairdb_prefetch.hh
                       lineairdb_autogen.cc lineairdb_autogen.hh
+                      duckdb_sql_rewrite.cc duckdb_sql_rewrite.hh
                       rpc_trace.cc rpc_trace.hh)
 add_definitions(-DMYSQL_SERVER)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error -Wextra -mcx16 -fPIC")

--- a/proxy/ddl.cc
+++ b/proxy/ddl.cc
@@ -31,38 +31,11 @@ constexpr bool kFence = false;
 constexpr uint64_t kBackfillWriteChunkRows = 2000;
 constexpr size_t kBackfillParallelWorkers = 16;
 
-// PAX typed-cell kinds (mirror LineairDB::Pax::FieldKind in pax_store.h; the
-// proxy is PAX-oblivious so the values are duplicated by design, kept in sync).
-namespace pax_kind {
-constexpr uint32_t UNTYPED = 0;
-constexpr uint32_t INT32 = 1;                   // 4-byte LE signed int
-constexpr uint32_t INT64 = 2;                   // 8-byte LE signed int
-constexpr uint32_t DATE = 3;                    // 4-byte LE YYYYMMDD
-constexpr uint32_t DEC64 = 4;                   // 8-byte LE scaled int (DEC64)
-}  // namespace pax_kind
+}  // namespace
 
-/**
-  @brief Computes PAX cell widths, kinds, and scales for the encoded row fields
-  of `table`.
-
-  @details LineairDB rows store each MySQL field as the string payload produced
-  by Field::val_str(). The returned vector contains one maximum payload width
-  per encoded row field: entry 0 is the row null-flags field, and the remaining
-  entries follow TABLE::field order. For an UNTYPED field the width is a safe
-  upper bound on the val_str bytes; for a typed field (INT family, DATE) the
-  width is the fixed binary payload width (4/8) and the kind tells the engine to
-  parse val_str once at scatter and reformat it at gather. A table with any
-  field wider than the PAX cell cap returns an empty vector so CREATE TABLE
-  keeps the ordinary row layout instead of reserving very wide cells for every
-  row. When non-null, `kinds`/`scales` are filled in lockstep with the returned
-  widths.
-
-  @return Per-field maximum payload widths, or an empty vector when the table
-  should not use PAX storage.
-*/
 std::vector<uint32_t> compute_pax_field_widths(
-    TABLE *table, std::vector<uint32_t> *kinds = nullptr,
-    std::vector<int32_t> *scales = nullptr) {
+    TABLE *table, std::vector<uint32_t> *kinds,
+    std::vector<int32_t> *scales) {
   // Keep fixed-width cells bounded for variable-width columns such as TEXT.
   constexpr uint32_t kMaxCellBytes = 2048;
 
@@ -200,8 +173,6 @@ std::vector<uint32_t> compute_pax_field_widths(
 
   return widths;
 }
-
-}  // namespace
 
 void ha_lineairdb::set_key_and_key_part_info(const TABLE *const table) {
   key_info = table->key_info;

--- a/proxy/duckdb_sql_rewrite.cc
+++ b/proxy/duckdb_sql_rewrite.cc
@@ -1,0 +1,150 @@
+#include "duckdb_sql_rewrite.hh"
+
+#include <cctype>
+#include <vector>
+
+std::string ConvertBacktickIdentifiers(const std::string &sql) {
+  std::string out;
+  out.reserve(sql.size() + 8);
+  bool in_string = false;
+  std::string word;      // most recently completed identifier/keyword token
+  bool in_word = false;  // currently inside such a token
+  // Stack of currently-open '(': true if it opened a call to EXTRACT/TRIM/
+  // SUBSTRING/SUBSTR (see the header for why these four). Only the TOP
+  // (innermost, not-yet-closed) entry matters: it tells what kind of paren
+  // the current position is directly inside. A subquery nested inside
+  // EXTRACT(... FROM (SELECT ... FROM t ...)) opens its own '(' (pushed as
+  // false: the word before it is "from", not one of the four names), and
+  // inside that subquery its own "from"/"join" keywords introduce ordinary
+  // table references again, regardless of the outer EXTRACT further down
+  // the stack. A second EXTRACT inside that subquery pushes a fresh true on
+  // top and correctly re-suppresses for its own FROM argument.
+  std::vector<bool> paren_is_keyword_fn;
+  auto inside_keyword_fn = [&]() {
+    return !paren_is_keyword_fn.empty() && paren_is_keyword_fn.back();
+  };
+  size_t i = 0;
+  while (i < sql.size()) {
+    const char c = sql[i];
+    if (in_string) {
+      out.push_back(c);
+      if (c == '\\' && i + 1 < sql.size()) {
+        out.push_back(sql[i + 1]);
+        i += 2;
+        continue;
+      }
+      if (c == '\'') {
+        if (i + 1 < sql.size() && sql[i + 1] == '\'') {
+          out.push_back(sql[i + 1]);
+          i += 2;
+          continue;
+        }
+        in_string = false;
+      }
+      i++;
+      continue;
+    }
+    if (c == '\'') {
+      in_string = true;
+      out.push_back(c);
+      i++;
+      word.clear();
+      in_word = false;
+      continue;
+    }
+    if (c == '`') {
+      const bool is_table_position =
+          !inside_keyword_fn() && (word == "from" || word == "join");
+      word.clear();
+      in_word = false;
+
+      std::vector<std::string> parts;
+      while (i < sql.size() && sql[i] == '`') {
+        i++;  // opening backtick
+        std::string identifier;
+        while (i < sql.size()) {
+          if (sql[i] == '`') {
+            if (i + 1 < sql.size() && sql[i + 1] == '`') {
+              identifier.push_back('`');  // `` escape -> literal backtick
+              i += 2;
+              continue;
+            }
+            i++;  // closing backtick
+            break;
+          }
+          identifier.push_back(sql[i]);
+          i++;
+        }
+        parts.push_back(std::move(identifier));
+        if (i < sql.size() && sql[i] == '.' && i + 1 < sql.size() &&
+            sql[i + 1] == '`') {
+          i++;  // consume '.'; loop continues into the next qualified part
+        } else {
+          break;
+        }
+      }
+
+      size_t keep_from = 0;  // index of first part to emit
+      if (is_table_position) {
+        keep_from = parts.size() - 1;  // table ref: keep only the bare name
+      } else if (parts.size() >= 3) {
+        keep_from = 1;  // db.table.column: drop only the leading db
+      }
+      for (size_t part_index = keep_from; part_index < parts.size();
+           part_index++) {
+        if (part_index != keep_from) out.push_back('.');
+        out.push_back('"');
+        for (char part_char : parts[part_index]) {
+          if (part_char == '"') out.push_back('"');  // escape embedded " as ""
+          out.push_back(part_char);
+        }
+        out.push_back('"');
+      }
+      continue;
+    }
+    if (c == '(') {
+      paren_is_keyword_fn.push_back(word == "extract" || word == "trim" ||
+                                    word == "substring" || word == "substr");
+      // `word` is deliberately NOT cleared here (only `in_word`, so the next
+      // alpha run starts fresh rather than appending onto this one). MySQL
+      // prints a multi-table FROM list as `from (`t1` `a` join `t2` `b` on
+      // (...))` -- the '(' immediately after "from"/"join" has no
+      // intervening word, and clearing `word` would make the backtick
+      // handler see word=="" instead of "from"/"join" and leave the FIRST
+      // table's db qualifier in place, which DuckDB's single-schema catalog
+      // rejects. Leaving `word` intact is safe: a fresh alpha run (the
+      // normal case, e.g. `extract(year ...`) clears and rebuilds it via
+      // the `if (!in_word) word.clear()` branch below.
+      in_word = false;
+      out.push_back(c);
+      i++;
+      continue;
+    }
+    if (c == ')') {
+      if (!paren_is_keyword_fn.empty()) paren_is_keyword_fn.pop_back();
+      out.push_back(c);
+      i++;
+      continue;
+    }
+    // SQL identifiers/keywords are [A-Za-z_][A-Za-z0-9_]*: underscore and
+    // digits continue the token. Breaking the token on '_' would truncate an
+    // identifier ending in "_join"/"_from" (a UDF name like `my_join` or
+    // `date_from`, or the STRAIGHT_JOIN keyword) down to its last segment,
+    // which then spuriously equals the literal keyword "join"/"from" and
+    // makes the NEXT backtick chain read as a table position. With real
+    // identifier lexing, `word` holds the complete token, and equality
+    // against "from"/"join"/"extract"/"trim"/"substring"/"substr" succeeds
+    // only when the token IS that keyword.
+    if (std::isalnum(static_cast<unsigned char>(c)) || c == '_') {
+      if (!in_word) word.clear();
+      word.push_back(
+          static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+      in_word = true;
+    } else {
+      in_word = false;  // word (if any) persists as "most recently completed"
+    }
+    out.push_back(c);
+    i++;
+  }
+  return out;
+}

--- a/proxy/duckdb_sql_rewrite.hh
+++ b/proxy/duckdb_sql_rewrite.hh
@@ -1,0 +1,43 @@
+#ifndef DUCKDB_SQL_REWRITE_HH
+#define DUCKDB_SQL_REWRITE_HH
+
+#include <string>
+
+/**
+ * @brief Rewrites a MySQL-printed SQL fragment into DuckDB-parseable form.
+ *
+ * @details Two rewrites in one lexical pass:
+ * - quoting: backtick identifiers become double-quoted (`x` -> "x");
+ * - qualification: table references lose every qualifier
+ *   (`db`.`table` -> "table"); the bridge's DuckDB catalog registers bare
+ *   table names only (see RegisterPaxView in duckdb_bridge_executor.cc).
+ *
+ * The input is always MySQL printer output (Table_ref::view_body_utf8,
+ * used for view->CTE expansion), never client SQL: the printer's
+ * conventions are fixed, which is what makes the position rules below
+ * sound.
+ *
+ * Table/column classification, by syntax alone (no catalog access):
+ * - chain directly after "from"/"join": table reference, keep the last
+ *   part (the printer emits these keywords lowercase for every FROM-clause
+ *   list, including comma lists: `from (`t1` `a` join `t2` `b`)`);
+ * - 3-part chain elsewhere (`db`.`table`.`column`): drop the leading db;
+ * - 2-part chain elsewhere (`alias`.`column`): untouched -- collapsing it
+ *   would turn a correlated predicate `t2`.`x` = `t1`.`x` into x = x.
+ *
+ * Guards:
+ * - EXTRACT/TRIM/SUBSTRING/SUBSTR use FROM as an argument separator; a
+ *   paren stack keyed on the innermost open call excludes them from the
+ *   table-position rule. NTH_VALUE's FROM {FIRST|LAST} never appears in
+ *   printed output and is not covered.
+ * - Reprinting the live view tree with QT_NO_DB is not a substitute for
+ *   this rewrite: the post-optimization tree prints Item_cache artifacts
+ *   ("<cache>(expr)") and ON-less semi joins, which DuckDB cannot parse;
+ *   view_body_utf8 is a pre-optimization snapshot free of both.
+ *
+ * @param sql MySQL-printed SQL fragment.
+ * @return The fragment in DuckDB identifier syntax.
+ */
+std::string ConvertBacktickIdentifiers(const std::string &sql);
+
+#endif  // DUCKDB_SQL_REWRITE_HH

--- a/proxy/ha_lineairdb_columnar.cc
+++ b/proxy/ha_lineairdb_columnar.cc
@@ -2,7 +2,10 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cctype>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <map>
@@ -10,6 +13,7 @@
 #include <mutex>
 #include <set>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -41,7 +45,9 @@
 #include "thr_lock.h"
 
 #include "aggregate_pushdown.hh"
+#include "duckdb_sql_rewrite.hh"
 #include "lineairdb.pb.h"
+#include "lineairdb_field_types.h"
 #include "lineairdb_proxy.hh"
 #include "lineairdb_pushdown.hh"
 
@@ -195,6 +201,11 @@ class ColumnarExecutionContext : public Secondary_engine_execution_context {
   LineairDB::Protocol::TxExecuteQueryBlock::Request query_block_request;
   bool query_block_ready = false;
 
+  // DuckDB bridge request: built in OptimizeSecondaryEngine, consumed by
+  // ExecuteDuckdbBridge. Mutually exclusive with query_block_request above.
+  LineairDB::Protocol::TxExecuteSqlDuckdb::Request duckdb_request;
+  bool duckdb_ready = false;
+
  private:
   const JOIN *current_join_ = nullptr;
   double best_cost_ = 0.0;
@@ -238,6 +249,83 @@ struct DecodedField {
     offset += len;
   }
 
+  return true;
+}
+
+/**
+ * @brief Rounds an ASCII decimal literal to exactly `target_scale`
+ * fractional digits using string/integer arithmetic only.
+ *
+ * @details DuckDB evaluates DECIMAL division (including AVG) in DOUBLE by
+ * design, so its text output does not follow MySQL's exact-decimal scale
+ * rules. `item->decimals` carries MySQL's authoritative scale for each
+ * output column; reformatting to it restores the row-format contract for
+ * any decimal-division shape. Inputs already at or below `target_scale`
+ * are only zero-padded.
+ *
+ * @return false when the input is not a plain [+-]?digits(.digits)?
+ * literal; the caller keeps the original text.
+ */
+bool RoundDecimalText(const char *ptr, size_t len, uint32_t target_scale,
+                      std::string *out) {
+  if (len == 0) return false;
+  size_t pos = 0;
+  bool negative = false;
+  if (ptr[0] == '+' || ptr[0] == '-') {
+    negative = (ptr[0] == '-');
+    pos = 1;
+  }
+  size_t dot = std::string::npos;
+  for (size_t i = pos; i < len; i++) {
+    if (ptr[i] == '.' && dot == std::string::npos) {
+      dot = i;
+    } else if (!std::isdigit(static_cast<unsigned char>(ptr[i]))) {
+      return false;  // not a plain decimal literal: leave text unchanged
+    }
+  }
+
+  std::string int_part(ptr + pos, dot == std::string::npos ? len - pos : dot - pos);
+  std::string frac_part = dot == std::string::npos
+                              ? std::string()
+                              : std::string(ptr + dot + 1, len - dot - 1);
+  if (int_part.empty()) int_part = "0";
+
+  if (frac_part.size() <= target_scale) {
+    frac_part.append(target_scale - frac_part.size(), '0');
+    *out = (negative ? "-" : "") + int_part +
+           (target_scale > 0 ? "." + frac_part : "");
+    return true;
+  }
+
+  // Round-half-up (away from zero) at position target_scale, matching
+  // MySQL's decimal display rounding convention.
+  const bool round_up = frac_part[target_scale] >= '5';
+  frac_part.resize(target_scale);
+  if (round_up) {
+    int i = static_cast<int>(frac_part.size()) - 1;
+    for (; i >= 0; i--) {
+      if (frac_part[i] == '9') {
+        frac_part[i] = '0';
+      } else {
+        frac_part[i]++;
+        break;
+      }
+    }
+    if (i < 0) {  // carried out of the fractional part into int_part
+      int j = static_cast<int>(int_part.size()) - 1;
+      for (; j >= 0; j--) {
+        if (int_part[j] == '9') {
+          int_part[j] = '0';
+        } else {
+          int_part[j]++;
+          break;
+        }
+      }
+      if (j < 0) int_part.insert(int_part.begin(), '1');
+    }
+  }
+  *out = (negative ? "-" : "") + int_part +
+         (target_scale > 0 ? "." + frac_part : "");
   return true;
 }
 
@@ -3951,6 +4039,313 @@ bool RecognizeQueryBlock(JOIN *join, ColumnarExecutionContext *ctx,
 }
 
 /**
+ * @brief HELIOS_DUCKDB_BRIDGE opt-in gate. Anything but exactly "1" leaves
+ * the query-block pushdown path in control.
+ */
+bool DuckdbBridgeEnabled() {
+  const char *v = std::getenv("HELIOS_DUCKDB_BRIDGE");
+  return v != nullptr && v[0] == '1' && v[1] == '\0';
+}
+
+/**
+ * @brief Recursively collects every real base table under `lex` into `req`,
+ * expanding each referenced SQL VIEW into a CTE appended to `cte_prefix`.
+ *
+ * @details The statement text shipped to DuckDB is thd->query(), which
+ * cannot resolve view names by itself. Each view's resolved body
+ * (Table_ref::view_body_utf8, the SHOW CREATE VIEW printout) is inlined as
+ * a WITH entry instead, after identifier rewriting
+ * (ConvertBacktickIdentifiers). Expansion recurses into the view's own LEX
+ * first, so nested CTEs appear in dependency order. Returns false on any
+ * table the bridge cannot serve.
+ *
+ * @param seen_tables Dedups base tables by PaxStore key across the whole
+ * statement (self-joins, direct plus through-view references).
+ * @param seen_views Dedups view expansions; a view referenced twice gets
+ * one CTE.
+ */
+bool CollectBaseTables(THD *thd, LEX *lex,
+                       LineairDB::Protocol::TxExecuteSqlDuckdb::Request *req,
+                       std::set<std::string> *seen_tables,
+                       std::set<std::string> *seen_views,
+                       std::string *cte_prefix, const char **why) {
+  // Expands one genuine SQL VIEW's Table_ref into a `WITH "name"(...) AS
+  // (...)` CTE fragment (dependency-ordered: nested views/tables first).
+  // Factored out because a view reaches this function's loop below in two
+  // different shapes -- see the referencing_view walk beneath it for why.
+  auto expand_view = [&](Table_ref *view_tr) -> bool {
+    const std::string view_name(view_tr->table_name);
+    if (!seen_views->insert(view_name).second) return true;  // already expanded
+
+    if (view_tr->view_body_utf8.str == nullptr ||
+        view_tr->view_body_utf8.length == 0) {
+      *why = "view has no resolved body text";
+      return false;
+    }
+
+    if (!CollectBaseTables(thd, view_tr->view_query(), req, seen_tables,
+                          seen_views, cte_prefix, why)) {
+      return false;  // nested views/tables first: dependency order
+    }
+
+    // view_body_utf8 is the pre-resolution snapshot MySQL bakes at CREATE
+    // VIEW time. Do not print the live derived_query_expression() instead:
+    // the optimized tree renders post-transform artifacts ("<cache>(expr)"
+    // wrappers, semijoin text without an ON clause) that DuckDB cannot
+    // parse and that no print flag suppresses.
+    const std::string body = ConvertBacktickIdentifiers(std::string(
+        view_tr->view_body_utf8.str, view_tr->view_body_utf8.length));
+
+    cte_prefix->append(cte_prefix->empty() ? "WITH \"" : ", \"");
+    cte_prefix->append(view_name);
+    cte_prefix->push_back('"');
+    if (const Create_col_name_list *cols = view_tr->derived_column_names()) {
+      cte_prefix->push_back('(');
+      for (size_t i = 0; i < cols->size(); i++) {
+        if (i != 0) cte_prefix->append(", ");
+        cte_prefix->push_back('"');
+        cte_prefix->append((*cols)[i].str, (*cols)[i].length);
+        cte_prefix->push_back('"');
+      }
+      cte_prefix->push_back(')');
+    }
+    cte_prefix->append(" AS (");
+    cte_prefix->append(body);
+    cte_prefix->push_back(')');
+    return true;
+  };
+
+  for (Query_block *qbi = lex->all_query_blocks_list; qbi != nullptr;
+       qbi = qbi->next_select_in_list()) {
+    for (Table_ref *tr = qbi->leaf_tables; tr != nullptr; tr = tr->next_leaf) {
+      if (tr->is_view()) {
+        if (!expand_view(tr)) return false;
+        continue;
+      }
+
+      // A merged (mergeable) view leaves no is_view() leaf: MySQL splices
+      // its base tables into the outer leaf_tables, each linking back to
+      // the view through Table_ref::referencing_view. Recover the original
+      // view Table_ref through that chain (nested views give multiple
+      // links) and expand it like a view leaf; the spliced table itself is
+      // re-found through the view's own LEX and deduped by seen_tables.
+      //
+      // The seen_views check must gate this branch: referencing_view is
+      // also set on leaves visited while expanding a NON-merged view's own
+      // body. That view is already in seen_views, and expanding it here
+      // would short-circuit and skip registering this leaf as a base table.
+      Table_ref *outer_view = nullptr;
+      for (Table_ref *anc = tr->referencing_view; anc != nullptr;
+           anc = anc->referencing_view) {
+        if (anc->is_view()) outer_view = anc;
+      }
+      if (outer_view != nullptr &&
+          seen_views->find(std::string(outer_view->table_name)) ==
+              seen_views->end()) {
+        if (!expand_view(outer_view)) return false;
+        continue;
+      }
+
+      if (tr->is_view_or_derived()) continue;  // synthetic/materialized leaf
+
+      TABLE *table = tr->table;
+      if (table == nullptr || table->s == nullptr) {
+        *why = "table has no open TABLE";
+        return false;
+      }
+
+      const std::string table_key = table->s->normalized_path.str;
+      if (!seen_tables->insert(table_key).second) {
+        continue;  // same base table already added (self-join or repeated
+                   // reference across query blocks / view expansions)
+      }
+
+      // Recomputes the identical widths/kinds/scales ha_lineairdb::create()
+      // sent to DB_CREATE_TABLE for this table (same pure function of TABLE
+      // metadata; see lineairdb_field_types.h). An empty result means the
+      // table is not PAX-eligible (falls back to ordinary row storage),
+      // which the DuckDB bridge cannot read -- reject rather than guess.
+      std::vector<uint32_t> pax_kinds;
+      std::vector<int32_t> pax_scales;
+      std::vector<uint32_t> pax_widths =
+          compute_pax_field_widths(table, &pax_kinds, &pax_scales);
+      if (pax_widths.empty()) {
+        *why = "table is not PAX-eligible";
+        return false;
+      }
+
+      auto *table_desc = req->add_tables();
+      table_desc->set_table_name(table_key);
+      table_desc->set_sql_name(table->s->table_name.str);
+      table_desc->set_db_name(table->s->db.str);
+      for (uint i = 0; i < table->s->fields; i++) {
+        Field *field = table->field[i];
+        auto *col = table_desc->add_columns();
+        col->set_name(field->field_name == nullptr ? "" : field->field_name);
+        // Index i+1: entry 0 of the widths/kinds/scales vectors is the row
+        // null-flags field, not a named column.
+        col->set_pax_kind(pax_kinds[i + 1]);
+        col->set_pax_width(pax_widths[i + 1]);
+        col->set_pax_scale(pax_scales[i + 1]);
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * @brief Build a TxExecuteSqlDuckdb request from the verbatim client SQL
+ * text plus this query block's base tables.
+ *
+ * Alternative to RecognizeQueryBlock / BuildQueryBlockRequest above:
+ * instead of lowering a recognized plan shape into the query-block IR, it
+ * forwards the client's SQL text (prefixed with view CTEs, see
+ * CollectBaseTables) for the server's embedded DuckDB to parse and execute
+ * against live PAX storage. The only shape requirement is PAX-eligible
+ * metadata for every base table.
+ */
+bool BuildDuckdbBridgeRequest(
+    THD *thd, Query_block *qb,
+    LineairDB::Protocol::TxExecuteSqlDuckdb::Request *req,
+    const char **why) {
+  req->Clear();
+  if (qb == nullptr || qb->outer_query_block() != nullptr) {
+    *why = "not top-level";
+    return false;
+  }
+
+  const LEX_CSTRING query = thd->query();
+  if (query.str == nullptr || query.length == 0) {
+    *why = "no query text";
+    return false;
+  }
+
+  // Walk every query block in the statement (all_query_blocks_list), not
+  // just qb->leaf_tables: the optimizer can hide a subquery's base tables
+  // behind a materialized/derived leaf of the outer block, while the
+  // subquery's own Query_block still lists them directly. DuckDB re-parses
+  // the raw SQL, so it needs the real base tables and never MySQL's
+  // internal materializations (those have no PAX store). SQL VIEW leaves
+  // are expanded into CTEs (CollectBaseTables).
+  std::set<std::string> seen_tables;   // dedup by normalized_path
+  std::set<std::string> seen_views;    // dedup view expansions
+  std::string cte_prefix;
+  if (!CollectBaseTables(thd, thd->lex, req, &seen_tables, &seen_views,
+                        &cte_prefix, why)) {
+    return false;
+  }
+  if (req->tables_size() == 0) {
+    *why = "no base tables";
+    return false;
+  }
+
+  std::string sql;
+  sql.reserve(cte_prefix.size() + 1 + query.length);
+  if (!cte_prefix.empty()) {
+    sql.append(cte_prefix);
+    sql.push_back(' ');
+  }
+  sql.append(query.str, query.length);
+  req->set_sql(sql);
+  // Enabled when set to anything but empty or "0", matching ENABLE_RPC_TRACE
+  const char *debug = std::getenv("ENABLE_DUCKDB_BRIDGE_DEBUG");
+  if (debug != nullptr && debug[0] != '\0' && std::string_view(debug) != "0") {
+    std::fprintf(stderr, "[duckdb_bridge] sql=[%s]\n", sql.c_str());
+  }
+
+  return true;
+}
+
+/**
+ * @brief Execute the HELIOS_DUCKDB_BRIDGE SQL text built by
+ * BuildDuckdbBridgeRequest.
+ *
+ * Mirrors ExecuteColumnarAggregate's value-carrier mechanism below: MySQL
+ * has already sent result-set metadata for the original SELECT list, so
+ * this override only needs to ship value-only Item carriers that match it.
+ * The response rows use the same "proxy row format" as
+ * TX_EXECUTE_QUERY_BLOCK's response, so the decode loop is identical.
+ */
+bool ExecuteDuckdbBridge(JOIN *join, Query_result *result) {
+  THD *thd = join->thd;
+  auto *ctx = static_cast<ColumnarExecutionContext *>(
+      thd->lex->secondary_engine_execution_context());
+  if (ctx == nullptr || !ctx->duckdb_ready) {
+    return RaiseColumnarError(thd,
+                              "LINEAIRDB_COLUMNAR: no duckdb-bridge plan");
+  }
+
+  std::shared_ptr<LineairDBProxy> proxy = lineairdb::acquire_shared_proxy(thd);
+  if (!proxy) {
+    return RaiseColumnarError(thd, "LINEAIRDB_COLUMNAR: no server connection");
+  }
+
+  LineairDB::Protocol::TxExecuteSqlDuckdb::Response rpc;
+  if (!proxy->tx_execute_sql_duckdb(ctx->duckdb_request, &rpc) || !rpc.ok()) {
+    char message[192];
+    snprintf(message, sizeof(message), "LINEAIRDB_COLUMNAR duckdb-bridge: %s",
+             rpc.error().empty() ? "duckdb bridge RPC failed"
+                                 : rpc.error().c_str());
+    return RaiseColumnarError(thd, message);
+  }
+
+  mem_root_deque<Item *> output_items(thd->mem_root);
+  std::vector<ItemColumnarValue *> values;
+  // Parallel to `values`: MySQL's authoritative decimal scale per output
+  // expression, or DECIMAL_NOT_SPECIFIED for "don't touch". DuckDB returns
+  // decimal-division results as DOUBLE text; RoundDecimalText reformats
+  // those columns back to this scale.
+  std::vector<uint32_t> target_scale;
+  for (Item *item : VisibleFields(join->query_block->fields)) {
+    auto *value = new (thd->mem_root) ItemColumnarValue(item);
+    if (value == nullptr) return true;
+    values.push_back(value);
+    output_items.push_back(value);
+
+    const Item_result rt = item->result_type();
+    const bool fixed_scale_numeric =
+        (rt == DECIMAL_RESULT || rt == REAL_RESULT) &&
+        item->decimals <= DECIMAL_MAX_SCALE;
+    target_scale.push_back(fixed_scale_numeric
+                                ? static_cast<uint32_t>(item->decimals)
+                                : static_cast<uint32_t>(DECIMAL_NOT_SPECIFIED));
+  }
+
+  std::vector<DecodedField> fields;
+  std::string rounded;
+  const size_t expected = 1 + values.size();
+  for (const std::string &row : rpc.rows()) {
+    if (!DecodeRowFields(row, &fields) || fields.size() != expected) {
+      return RaiseColumnarError(
+          thd,
+          "LINEAIRDB_COLUMNAR duckdb-bridge: malformed row (DuckDB result "
+          "column count may not match the original SELECT list)");
+    }
+
+    // Field 0 is a placeholder for the proxy row null-flags field. The
+    // server emits one following field per DuckDB output column.
+    for (size_t i = 0; i < values.size(); i++) {
+      const DecodedField &field = fields[1 + i];
+      if (!field.empty) {
+        if (target_scale[i] != static_cast<uint32_t>(DECIMAL_NOT_SPECIFIED) &&
+            RoundDecimalText(field.ptr, field.len, target_scale[i], &rounded)) {
+          values[i]->set_value(rounded.data(), rounded.size());
+        } else {
+          values[i]->set_value(field.ptr, field.len);
+        }
+        continue;
+      }
+      values[i]->set_null_value();
+    }
+
+    if (result->send_data(thd, output_items)) return true;
+    ++join->send_records;
+  }
+
+  return false;
+}
+
+/**
  * @brief Execute a recognized aggregate block through LineairDB.
  *
  * MySQL has already sent result-set metadata for the original SELECT list. This
@@ -4037,8 +4432,31 @@ bool OptimizeSecondaryEngine(THD *, LEX *lex) {
 
   Query_block *query_block = lex->unit->first_query_block();
   JOIN *join = query_block != nullptr ? query_block->join : nullptr;
+  if (join == nullptr) {
+    return RaiseColumnarError(lex->thd,
+                              "LINEAIRDB_COLUMNAR unsupported shape: no JOIN");
+  }
+
+  // HELIOS_DUCKDB_BRIDGE opt-in: route a statement that already qualified
+  // for secondary-engine offload through the DuckDB bridge instead of the
+  // query-block recognizer. Unset (the default), this branch never runs.
+  if (DuckdbBridgeEnabled()) {
+    const char *why = "?";
+    if (!BuildDuckdbBridgeRequest(lex->thd, query_block, &ctx->duckdb_request,
+                                  &why)) {
+      char message[192];
+      snprintf(message, sizeof(message),
+               "LINEAIRDB_COLUMNAR duckdb-bridge unsupported shape: %s",
+               why ? why : "?");
+      return RaiseColumnarError(lex->thd, message);
+    }
+    ctx->duckdb_ready = true;
+    join->override_executor_func = ExecuteDuckdbBridge;
+    return false;
+  }
+
   const char *why = "no JOIN";
-  if (join == nullptr || !RecognizeQueryBlock(join, ctx, &why)) {
+  if (!RecognizeQueryBlock(join, ctx, &why)) {
     char message[128];
     snprintf(message, sizeof(message),
              "LINEAIRDB_COLUMNAR unsupported shape: %s", why ? why : "?");

--- a/proxy/lineairdb_field_types.h
+++ b/proxy/lineairdb_field_types.h
@@ -1,10 +1,61 @@
-#ifndef LINEAIRDB_FIELD_TYPES_INCLUDED
-#define LINEAIRDB_FIELD_TYPES_INCLUDED
+#ifndef LINEAIRDB_FIELD_TYPES_H
+#define LINEAIRDB_FIELD_TYPES_H
+
+#include <cstdint>
+#include <vector>
 
 #include "field_types.h"
 
+struct TABLE;
+
 /**
- * LineairDB internal field types
+ * @brief PAX typed-cell kind constants.
+ *
+ * @details Mirror of LineairDB::Pax::FieldKind (pax_store.h). The proxy is
+ * PAX-oblivious; the values are duplicated by design and kept in sync.
+ */
+namespace pax_kind {
+constexpr uint32_t UNTYPED = 0;                 // verbatim byte layout
+constexpr uint32_t INT32 = 1;                   // 4-byte LE signed int
+constexpr uint32_t INT64 = 2;                   // 8-byte LE signed int
+constexpr uint32_t DATE = 3;                    // 4-byte LE YYYYMMDD
+constexpr uint32_t DEC64 = 4;                   // 8-byte LE scaled int (DEC64)
+}  // namespace pax_kind
+
+/**
+ * @brief Computes PAX cell widths, kinds, and scales for the encoded row
+ * fields of `table`.
+ *
+ * @details LineairDB rows store each MySQL field as the string payload
+ * produced by Field::val_str(). The returned vector contains one maximum
+ * payload width per encoded row field: entry 0 is the row null-flags field,
+ * and the remaining entries follow TABLE::field order. For an UNTYPED field
+ * the width is a safe upper bound on the val_str bytes; for a typed field
+ * (INT family, DATE) the width is the fixed binary payload width (4/8) and
+ * the kind tells the engine to parse val_str once at scatter and reformat it
+ * at gather. A table with any field wider than the PAX cell cap returns an
+ * empty vector; CREATE TABLE then keeps the ordinary row layout instead of
+ * reserving very wide cells for every row.
+ *
+ * The computation is a pure function of TABLE metadata: any two calls under
+ * an unchanged schema yield identical widths/kinds/scales. CREATE TABLE
+ * installs these values server-side; a caller that needs to describe the
+ * stored PAX cells recomputes them rather than reading them back from the
+ * server.
+ *
+ * @param table Table whose encoded row fields are described.
+ * @param kinds When non-null, receives one pax_kind value per returned width.
+ * @param scales When non-null, receives one decimal scale per returned width
+ * (nonzero only for DEC64).
+ * @return Per-field maximum payload widths, or an empty vector when the table
+ * should not use PAX storage.
+ */
+std::vector<uint32_t> compute_pax_field_widths(
+    TABLE *table, std::vector<uint32_t> *kinds = nullptr,
+    std::vector<int32_t> *scales = nullptr);
+
+/**
+ * @brief LineairDB-internal classification of MySQL field types.
  */
 enum class LineairDBFieldType {
   // Numeric types
@@ -21,10 +72,10 @@ enum class LineairDBFieldType {
 };
 
 /**
- * Convert MySQL field type to LineairDB field type
+ * @brief Maps a MySQL field type to its LineairDB field type.
  *
- * @param mysql_type MySQL's enum_field_types
- * @return Corresponding LineairDB field type
+ * @param mysql_type MySQL's enum_field_types.
+ * @return Corresponding LineairDB field type.
  */
 inline LineairDBFieldType
 convert_mysql_type_to_lineairdb(enum_field_types mysql_type) {
@@ -79,10 +130,10 @@ convert_mysql_type_to_lineairdb(enum_field_types mysql_type) {
 }
 
 /**
- * Get string representation of LineairDB field type
+ * @brief Returns the display name of a LineairDB field type.
  *
- * @param type LineairDB field type
- * @return Type name as string
+ * @param type LineairDB field type.
+ * @return Type name as a string constant.
  */
 inline const char *lineairdb_field_type_name(LineairDBFieldType type) {
   switch (type) {
@@ -99,4 +150,4 @@ inline const char *lineairdb_field_type_name(LineairDBFieldType type) {
   }
 }
 
-#endif /* LINEAIRDB_FIELD_TYPES_INCLUDED */
+#endif  // LINEAIRDB_FIELD_TYPES_H

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -449,6 +449,25 @@ bool LineairDBProxy::tx_execute_query_block(
     return true;
 }
 
+bool LineairDBProxy::tx_execute_sql_duckdb(
+    const LineairDB::Protocol::TxExecuteSqlDuckdb::Request& request,
+    LineairDB::Protocol::TxExecuteSqlDuckdb::Response* response) {
+    if (!connected_) {
+        LOG_ERROR("RPC failed: Not connected to server");
+        return false;
+    }
+    if (response == nullptr) {
+        LOG_ERROR("RPC failed: duckdb bridge response is null");
+        return false;
+    }
+    if (!send_protobuf_message(request, *response,
+                               MessageType::TX_EXECUTE_SQL_DUCKDB)) {
+        LOG_ERROR("RPC failed: duckdb bridge message");
+        return false;
+    }
+    return true;
+}
+
 LineairDBProxy::ReadPlanResult LineairDBProxy::tx_execute_read_plan(
     const std::vector<ReadPlanStep>& steps) {
     ReadPlanResult result;

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -262,6 +262,12 @@ public:
     bool tx_execute_query_block(
         const LineairDB::Protocol::TxExecuteQueryBlock::Request& request,
         LineairDB::Protocol::TxExecuteQueryBlock::Response* response);
+    // DuckDB bridge: send verbatim SQL text plus per-table PAX column
+    // metadata to the LineairDB server. Gated by HELIOS_DUCKDB_BRIDGE on the
+    // caller side; this method itself is unconditional plumbing.
+    bool tx_execute_sql_duckdb(
+        const LineairDB::Protocol::TxExecuteSqlDuckdb::Request& request,
+        LineairDB::Protocol::TxExecuteSqlDuckdb::Response* response);
     bool tx_validate_and_commit(
         const std::vector<StatelessReadKey>& reads,
         const std::vector<uint64_t>& read_tids,

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -83,7 +83,10 @@ enum class MessageType : uint32_t {
     TX_GET_TABLE_STATS = 31,
 
     // Secondary-engine computation pushdown.
-    TX_EXECUTE_QUERY_BLOCK = 36
+    TX_EXECUTE_QUERY_BLOCK = 36,
+
+    // DuckDB SQL bridge (raw SQL text). See lineairdb.proto.
+    TX_EXECUTE_SQL_DUCKDB = 37
 };
 
 /**

--- a/proxy/rpc_trace.cc
+++ b/proxy/rpc_trace.cc
@@ -95,6 +95,8 @@ const char* message_type_name(MessageType t) {
       return "TX_GET_TABLE_STATS";
     case MessageType::TX_EXECUTE_QUERY_BLOCK:
       return "TX_EXECUTE_QUERY_BLOCK";
+    case MessageType::TX_EXECUTE_SQL_DUCKDB:
+      return "TX_EXECUTE_SQL_DUCKDB";
   }
   return "UNDEFINED";
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,6 +33,13 @@ mkdir -p build/data
 mkdir -p build/proxy
 mkdir -p build/server
 
+# Build DuckDB (third_party submodule) if its shared library is absent.
+# Artifacts stay inside the submodule and survive rebuilds of build/.
+if [ ! -f "third_party/duckdb/build/release/src/libduckdb.so" ]; then
+    echo "Building DuckDB (release)..."
+    (cd third_party/duckdb && GEN=ninja EXTRA_CMAKE_VARIABLES="-DBUILD_UNITTESTS=FALSE" make release)
+fi
+
 # Build configuration
 SERVER_BUILD_TYPE=${SERVER_BUILD_TYPE:-Release}
 MYSQL_BUILD_TYPE=${MYSQL_BUILD_TYPE:-Release}

--- a/scripts/build_partial.sh
+++ b/scripts/build_partial.sh
@@ -14,7 +14,7 @@ echo "Building proxy..."
 ROOT_DIR=$(pwd)
 SE_DIR="$ROOT_DIR/third_party/mysql-server/storage/lineairdb"
 echo "Syncing proxy sources into storage/lineairdb ..."
-cp -v "$ROOT_DIR"/proxy/*.cc "$ROOT_DIR"/proxy/*.hh "$ROOT_DIR"/proxy/CMakeLists.txt "$SE_DIR/"
+cp -v "$ROOT_DIR"/proxy/*.cc "$ROOT_DIR"/proxy/*.hh "$ROOT_DIR"/proxy/*.h "$ROOT_DIR"/proxy/CMakeLists.txt "$SE_DIR/"
 cp -v "$ROOT_DIR"/proto/lineairdb.proto "$SE_DIR/proto/"
 
 cd build

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -11,10 +11,16 @@ find_package(PkgConfig REQUIRED)
 # LineairDB library path
 set(LINEAIRDB_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/LineairDB")
 
+# DuckDB library path (third_party submodule). The shared library is a release
+# build produced inside the submodule; scripts/build.sh builds it when absent.
+set(DUCKDB_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/duckdb")
+set(DUCKDB_LIB_DIR "${DUCKDB_ROOT}/build/release/src")
+
 # Include directories
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../proto)
 include_directories(${LINEAIRDB_ROOT}/include)
+include_directories(${DUCKDB_ROOT}/src/include)
 
 # Generate protobuf files
 set(PROTO_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../proto")
@@ -98,10 +104,17 @@ target_link_libraries(lineairdb-server
     lineairdb
     ${Protobuf_LIBRARIES}
     pthread
+    ${DUCKDB_LIB_DIR}/libduckdb.so
 )
 
 # Additional include directories for generated files
 target_include_directories(lineairdb-server PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+# Embed an rpath to the DuckDB shared library. start_server.sh runs the binary
+# directly, without LD_LIBRARY_PATH.
+set_target_properties(lineairdb-server PROPERTIES
+    BUILD_RPATH "${DUCKDB_LIB_DIR}"
+    INSTALL_RPATH "${DUCKDB_LIB_DIR}")
 
 # Compiler flags to suppress warnings
 target_compile_options(lineairdb-server PRIVATE -O3 -Wno-error -Wno-unused-parameter)

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -82,6 +82,9 @@ set(SOURCES
     rpc/query_block_dispatch.cc
     rpc/query_block_executor.cc
     rpc/query_block_executor.hh
+    rpc/duckdb_bridge_dispatch.cc
+    rpc/duckdb_bridge_executor.cc
+    rpc/duckdb_bridge_executor.hh
     
     # Storage layer
     storage/database_manager.cc

--- a/server/protocol/message.hh
+++ b/server/protocol/message.hh
@@ -61,5 +61,8 @@ enum class MessageType : uint32_t {
     TX_GET_TABLE_STATS = 31,
 
     // Secondary-engine computation pushdown.
-    TX_EXECUTE_QUERY_BLOCK = 36
+    TX_EXECUTE_QUERY_BLOCK = 36,
+
+    // DuckDB SQL bridge (raw SQL text). See lineairdb.proto.
+    TX_EXECUTE_SQL_DUCKDB = 37
 };

--- a/server/rpc/duckdb_bridge_dispatch.cc
+++ b/server/rpc/duckdb_bridge_dispatch.cc
@@ -1,0 +1,43 @@
+#include "lineairdb_rpc.hh"
+
+#include <memory>
+#include <string>
+
+#include "duckdb_bridge_executor.hh"
+#include "lineairdb.pb.h"
+
+/**
+ * @brief Parses a TX_EXECUTE_SQL_DUCKDB request and hands it to
+ * duckdb_bridge::ExecuteSql.
+ *
+ * @details Follows query_block_dispatch.cc's handleTxExecuteQueryBlock: a
+ * request that fails to parse, and a request arriving while the database is
+ * unavailable, are answered with ok=false without reaching the executor.
+ *
+ * @param message Serialized TxExecuteSqlDuckdb::Request.
+ * @param result Receives the serialized TxExecuteSqlDuckdb::Response.
+ */
+void LineairDBRpc::handleTxExecuteSqlDuckdb(const std::string& message,
+                                            std::string& result) {
+    LineairDB::Protocol::TxExecuteSqlDuckdb::Request request;
+    LineairDB::Protocol::TxExecuteSqlDuckdb::Response response;
+
+    if (!request.ParseFromString(message)) {
+        response.set_ok(false);
+        response.set_error("failed to parse duckdb-bridge request");
+        result = response.SerializeAsString();
+        return;
+    }
+
+    std::shared_ptr<LineairDB::Database> db =
+        db_manager_ ? db_manager_->get_database() : nullptr;
+    if (!db) {
+        response.set_ok(false);
+        response.set_error("database is unavailable");
+        result = response.SerializeAsString();
+        return;
+    }
+
+    duckdb_bridge::ExecuteSql(db.get(), request, &response);
+    result = response.SerializeAsString();
+}

--- a/server/rpc/duckdb_bridge_executor.cc
+++ b/server/rpc/duckdb_bridge_executor.cc
@@ -1,0 +1,130 @@
+// DuckDB bridge executor: runs a TX_EXECUTE_SQL_DUCKDB request's verbatim SQL
+// text on the server's embedded DuckDB executor, whose table functions read
+// the live PaxStore instances in place (no data copy).
+// duckdb_bridge_dispatch.cc routes the opcode here.
+//
+// OCC contract, shared with query_block_executor.cc's PrepareTables /
+// TablesAreStillQuiet (duplicated here; that class is private to
+// query_block_executor.cc's anonymous namespace): per table, reject when any
+// heap-fallback (overflow) rows exist, then capture slots_allocated(),
+// overflow_count(), and every allocated group's write_counter, rejecting when
+// any counter is odd (a write is in progress). After the full result set has
+// been produced, the captured write state is re-checked; any difference means a
+// concurrent write raced the read, and the whole response is discarded as a
+// "concurrent modification" error rather than risking a torn read.
+
+#include "duckdb_bridge_executor.hh"
+
+#include <lineairdb/database.h>
+#include <lineairdb/pax_store.h>
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace duckdb_bridge {
+namespace {
+
+namespace pb = LineairDB::Protocol;
+namespace pax = LineairDB::Pax;
+using pax::PaxGroup;
+using pax::PaxStore;
+
+// ---------------------------------------------------------------------------
+// OCC write-state capture and quiescence re-check (see file header).
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Per-table write state captured before execution. Members mirror the
+ * PaxStore accessors they were read from.
+ */
+struct TableWriteState {
+  PaxStore* store = nullptr;  // live server storage, never owned here
+  uint64_t slots_allocated = 0;
+  uint64_t overflow_count = 0;
+  std::vector<uint64_t> write_counters;
+};
+
+/**
+ * @brief Resolves every requested table to its PaxStore and captures its
+ * write state.
+ *
+ * @details Rejects a table that has heap-fallback (overflow) rows or an odd
+ * write counter (a write is in progress); see the file header for the
+ * contract.
+ *
+ * @param db Live server database.
+ * @param request Request whose tables() list every base table.
+ * @param out Receives one TableWriteState per requested table.
+ * @param error Receives the rejection reason.
+ * @return false when any table cannot be captured; *out is incomplete.
+ */
+bool CaptureTableWriteStates(LineairDB::Database* db,
+                             const pb::TxExecuteSqlDuckdb::Request& request,
+                             std::vector<TableWriteState>* out,
+                             std::string* error) {
+  out->clear();
+  out->reserve(request.tables_size());
+  for (const auto& table_desc : request.tables()) {
+    PaxStore* store = db->GetPaxStore(table_desc.table_name());
+    if (store == nullptr) {
+      *error = "table has no PAX store: " + table_desc.table_name();
+      return false;
+    }
+    const uint64_t overflow_count = store->overflow_count();
+    if (overflow_count > 0) {
+      *error = "table has heap fallback rows: " + table_desc.table_name();
+      return false;
+    }
+
+    TableWriteState write_state;
+    write_state.store = store;
+    write_state.slots_allocated = store->slots_allocated();
+    write_state.overflow_count = overflow_count;
+    write_state.write_counters.resize(store->group_count());
+    for (size_t group_index = 0;
+         group_index < write_state.write_counters.size(); group_index++) {
+      PaxGroup* group = store->group(group_index);
+      const uint64_t write_counter =
+          group == nullptr ? 0
+                          : group->write_counter.load(std::memory_order_acquire);
+      write_state.write_counters[group_index] = write_counter;
+      if ((write_counter & 1u) != 0) {
+        *error = "table has in-progress PAX writes: " + table_desc.table_name();
+        return false;
+      }
+    }
+    out->push_back(std::move(write_state));
+  }
+  return true;
+}
+
+}  // namespace
+
+void ExecuteSql(LineairDB::Database* db,
+                const pb::TxExecuteSqlDuckdb::Request& request,
+                pb::TxExecuteSqlDuckdb::Response* response) {
+  if (response == nullptr) return;
+  response->Clear();
+
+  if (db == nullptr) {
+    response->set_ok(false);
+    response->set_error("database is unavailable");
+    return;
+  }
+
+  std::vector<TableWriteState> captured_tables;
+  std::string error;
+  if (!CaptureTableWriteStates(db, request, &captured_tables, &error)) {
+    response->set_ok(false);
+    response->set_error(error);
+    return;
+  }
+
+  response->set_ok(false);
+  response->set_error("duckdb bridge: execution stage is not present");
+}
+
+}  // namespace duckdb_bridge

--- a/server/rpc/duckdb_bridge_executor.cc
+++ b/server/rpc/duckdb_bridge_executor.cc
@@ -1,7 +1,8 @@
 // DuckDB bridge executor: runs a TX_EXECUTE_SQL_DUCKDB request's verbatim SQL
-// text on the server's embedded DuckDB executor, whose table functions read
-// the live PaxStore instances in place (no data copy).
-// duckdb_bridge_dispatch.cc routes the opcode here.
+// text on the embedded DuckDB executor, whose table functions read the live
+// PaxStore instances in place (no data copy). DuckDB contributes its parser,
+// planner, and vectorized execution runtime; no table data ever lives inside
+// DuckDB. duckdb_bridge_dispatch.cc routes the opcode here.
 //
 // OCC contract, shared with query_block_executor.cc's PrepareTables /
 // TablesAreStillQuiet (duplicated here; that class is private to
@@ -18,19 +19,84 @@
 #include <lineairdb/database.h>
 #include <lineairdb/pax_store.h>
 
+#include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
 #include <string>
+#include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
+
+#include <duckdb.hpp>
+#include <duckdb/parser/parsed_data/create_table_function_info.hpp>
 
 namespace duckdb_bridge {
 namespace {
 
 namespace pb = LineairDB::Protocol;
 namespace pax = LineairDB::Pax;
+using pax::FK_DATE;
+using pax::FK_DEC64;
+using pax::FK_INT32;
+using pax::FK_INT64;
+using pax::FK_UNTYPED;
 using pax::PaxGroup;
 using pax::PaxStore;
+
+// ---------------------------------------------------------------------------
+// Proxy row-format encoding.
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Number of little-endian bytes needed to encode `length`.
+ */
+uint32_t LengthPrefixBytes(uint32_t length) {
+  uint32_t prefix_bytes = 0;
+  for (uint32_t value = length; value > 0; value /= 256) prefix_bytes++;
+  return prefix_bytes;
+}
+
+/**
+ * @brief Appends one field in the proxy row format (matches
+ * proxy/ha_lineairdb_columnar.cc's DecodeRowFields).
+ *
+ * @details One byte length-width tag (0xFF = SQL NULL), then that many
+ * little-endian length bytes, then the payload. NULL and empty string are
+ * distinct and must not be conflated: `is_null` is the only signal for the
+ * 0xFF sentinel. An empty-but-non-null payload (e.g. a genuine VARCHAR ''
+ * result) takes the normal path with length 0 -- exactly one tag byte 0x00,
+ * no length bytes, no payload -- which DecodeRowFields reads as {ptr, len=0,
+ * empty=false}, distinct from the {nullptr, 0, empty=true} it produces for
+ * the sentinel. Nullness is never inferred from payload.empty(); this
+ * mirrors query_block_executor.cc's append_result_field(), which takes the
+ * same explicit `is_null` bool.
+ *
+ * @param out Destination row buffer.
+ * @param payload Field bytes; ignored when is_null.
+ * @param is_null True encodes the SQL NULL sentinel.
+ */
+void AppendProxyField(std::string& out, std::string_view payload,
+                      bool is_null) {
+  if (is_null) {
+    out.push_back(static_cast<char>(0xFF));
+    return;
+  }
+  const uint32_t length = static_cast<uint32_t>(payload.size());
+  const uint32_t prefix_bytes = LengthPrefixBytes(length);
+  out.push_back(static_cast<char>(prefix_bytes));
+  for (uint32_t i = 0; i < prefix_bytes; i++) {
+    out.push_back(static_cast<char>((length >> (8 * i)) & 0xFF));
+  }
+  out.append(payload.data(), payload.size());
+}
 
 // ---------------------------------------------------------------------------
 // OCC write-state capture and quiescence re-check (see file header).
@@ -101,6 +167,607 @@ bool CaptureTableWriteStates(LineairDB::Database* db,
   return true;
 }
 
+/**
+ * @brief Re-reads every captured counter and compares against the capture.
+ *
+ * @details An odd counter or any changed value means a write overlapped the
+ * read window; the caller must discard the result.
+ *
+ * @param captured_tables Write states captured before execution.
+ * @return true when no referenced table changed since capture.
+ */
+bool WriteStateUnchanged(const std::vector<TableWriteState>& captured_tables) {
+  for (const TableWriteState& state : captured_tables) {
+    if (state.store->slots_allocated() != state.slots_allocated ||
+        state.store->overflow_count() != state.overflow_count) {
+      return false;
+    }
+    for (size_t group_index = 0; group_index < state.write_counters.size();
+         group_index++) {
+      PaxGroup* group = state.store->group(group_index);
+      const uint64_t current =
+          group == nullptr ? 0
+                          : group->write_counter.load(std::memory_order_acquire);
+      if ((current & 1u) != 0 || current != state.write_counters[group_index]) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Per-table view over live PAX storage.
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief PAX cell metadata for one column, from the request's ColumnDesc.
+ */
+struct ColumnSpec {
+  std::string name;
+  uint8_t kind = FK_UNTYPED;
+  uint32_t width = 0;
+  int8_t scale = 0;
+};
+
+/**
+ * @brief Per-request description of one live PAX table.
+ *
+ * @details Column metadata comes from the request: the proxy recomputes
+ * kind/width/scale from TABLE::field[] with the pure function used at CREATE
+ * TABLE time (see proxy/lineairdb_field_types.h), matching what the server
+ * stored while the schema is unchanged.
+ */
+struct PaxTableView {
+  std::string sql_name;  // bare name the SQL text references, e.g. "lineitem"
+  PaxStore* store = nullptr;
+  std::vector<ColumnSpec> columns;
+  size_t group_count = 0;  // fixed at capture time, not live store state
+};
+
+// ---------------------------------------------------------------------------
+// DuckDB table function over PaxTableView: parallel scan, projection
+// pushdown, bulk decode for typed columns, inline string_t for short strings.
+// ---------------------------------------------------------------------------
+
+using duckdb::ClientContext;
+using duckdb::column_t;
+using duckdb::Connection;
+using duckdb::DataChunk;
+using duckdb::Date;
+using duckdb::date_t;
+using duckdb::ExecutionContext;
+using duckdb::FlatVector;
+using duckdb::FunctionData;
+using duckdb::GlobalTableFunctionState;
+using duckdb::hugeint_t;
+using duckdb::idx_t;
+using duckdb::LocalTableFunctionState;
+using duckdb::LogicalType;
+using duckdb::PhysicalType;
+using duckdb::string;
+using duckdb::StringVector;
+using duckdb::TableFunction;
+using duckdb::TableFunctionBindInput;
+using duckdb::TableFunctionInfo;
+using duckdb::TableFunctionInitInput;
+using duckdb::TableFunctionInput;
+using duckdb::unique_ptr;
+using duckdb::Vector;
+using duckdb::vector;
+
+/**
+ * @brief Registration-time handle carrying the request's PaxTableView into
+ * PaxBind.
+ */
+struct PaxTableInfo : public TableFunctionInfo {
+  PaxTableView* table = nullptr;
+};
+
+/**
+ * @brief Bound function data; refers to the request-owned PaxTableView.
+ */
+struct PaxBindData : public FunctionData {
+  PaxTableView* table = nullptr;
+
+  unique_ptr<FunctionData> Copy() const override {
+    auto copy = duckdb::make_uniq<PaxBindData>();
+    copy->table = table;
+    return std::move(copy);
+  }
+  bool Equals(const FunctionData& other) const override {
+    return this == &other;
+  }
+};
+
+/**
+ * @brief Shared scan state: the group claim counter and the projected column
+ * ids.
+ */
+struct PaxGlobalState : public GlobalTableFunctionState {
+  std::atomic<uint64_t> next_group{0};
+  size_t group_count = 0;
+  idx_t threads = 1;
+  std::vector<column_t> column_ids;
+
+  idx_t MaxThreads() const override { return threads; }
+};
+
+/**
+ * @brief Per-thread scan cursor over the currently claimed group.
+ */
+struct PaxLocalState : public LocalTableFunctionState {
+  uint32_t current_group = UINT32_MAX;
+  uint32_t current_slot = 0;
+  PaxGroup* group_ptr = nullptr;
+};
+
+/**
+ * @brief Maps a PAX FieldKind to the DuckDB column type.
+ */
+LogicalType FieldKindToLogicalType(uint8_t kind, int8_t scale) {
+  switch (kind) {
+    case FK_INT32:
+      return LogicalType::INTEGER;
+    case FK_INT64:
+      return LogicalType::BIGINT;
+    case FK_DATE:
+      return LogicalType::DATE;
+    case FK_DEC64:
+      // Width 15 matches the DEC64 typing rule (precision <= 15); see
+      // LineairDB::Pax::FieldKind.
+      return LogicalType::DECIMAL(15, static_cast<uint8_t>(scale));
+    default:
+      return LogicalType::VARCHAR;
+  }
+}
+
+/**
+ * @brief Declares the table's column names and types from its ColumnSpec
+ * list.
+ */
+unique_ptr<FunctionData> PaxBind(ClientContext&, TableFunctionBindInput& input,
+                                 vector<LogicalType>& return_types,
+                                 vector<string>& names) {
+  auto& info = input.info->Cast<PaxTableInfo>();
+  auto bind_data = duckdb::make_uniq<PaxBindData>();
+  bind_data->table = info.table;
+  for (const auto& column : info.table->columns) {
+    return_types.push_back(FieldKindToLogicalType(column.kind, column.scale));
+    names.push_back(column.name);
+  }
+  return std::move(bind_data);
+}
+
+/**
+ * @brief Builds the shared scan state: the projected column ids and a thread
+ * count of min(hardware threads, group count).
+ */
+unique_ptr<GlobalTableFunctionState> PaxInitGlobal(
+    ClientContext&, TableFunctionInitInput& input) {
+  const auto& bind_data = input.bind_data->Cast<PaxBindData>();
+  PaxTableView& table_view = *bind_data.table;
+  auto global_state = duckdb::make_uniq<PaxGlobalState>();
+  global_state->group_count = table_view.group_count;
+  global_state->next_group = 0;
+
+  const size_t column_count = table_view.columns.size();
+  if (!input.column_ids.empty()) {
+    for (auto column_id : input.column_ids) {
+      if (column_id < column_count) {
+        global_state->column_ids.push_back(static_cast<column_t>(column_id));
+      }
+    }
+    if (global_state->column_ids.empty()) {
+      for (column_t column = 0; column < column_count; column++) {
+        global_state->column_ids.push_back(column);
+      }
+    }
+  } else {
+    for (column_t column = 0; column < column_count; column++) {
+      global_state->column_ids.push_back(column);
+    }
+  }
+
+  const unsigned hardware_threads =
+      std::max(1u, std::thread::hardware_concurrency());
+  global_state->threads = static_cast<idx_t>(std::max<size_t>(
+      1, std::min<size_t>(hardware_threads,
+                          std::max<size_t>(1, table_view.group_count))));
+  return std::move(global_state);
+}
+
+/**
+ * @brief Creates the per-thread scan cursor.
+ */
+unique_ptr<LocalTableFunctionState> PaxInitLocal(ExecutionContext&,
+                                                 TableFunctionInitInput&,
+                                                 GlobalTableFunctionState*) {
+  return duckdb::make_uniq<PaxLocalState>();
+}
+
+/**
+ * @brief Writes a scaled DEC64 mantissa through the vector's physical type.
+ *
+ * @details DuckDB stores DECIMAL(p, s) in the narrowest integer type that
+ * fits p; the mantissa is written as that type.
+ */
+inline void WriteDecimalPhysical(Vector& output_vector, idx_t row,
+                                 int64_t mantissa, PhysicalType physical_type) {
+  switch (physical_type) {
+    case PhysicalType::INT16:
+      FlatVector::GetData<int16_t>(output_vector)[row] =
+          static_cast<int16_t>(mantissa);
+      break;
+    case PhysicalType::INT32:
+      FlatVector::GetData<int32_t>(output_vector)[row] =
+          static_cast<int32_t>(mantissa);
+      break;
+    case PhysicalType::INT64:
+      FlatVector::GetData<int64_t>(output_vector)[row] = mantissa;
+      break;
+    default:
+      FlatVector::GetData<hugeint_t>(output_vector)[row] =
+          hugeint_t(mantissa < 0 ? -1 : 0, static_cast<uint64_t>(mantissa));
+      break;
+  }
+}
+
+/**
+ * @brief Bulk-decodes one typed (non-UNTYPED) column across a contiguous run
+ * of visible slots.
+ *
+ * @details A typed cell is [u16 len][fixed-width LE payload]; a length equal
+ * to the column width means the payload is present, any other length (an
+ * empty cell) is SQL NULL.
+ */
+void BulkDecodeTyped(uint8_t kind, const PaxGroup& group, size_t field,
+                     uint32_t width, uint32_t slot_start, uint32_t count,
+                     Vector& output_vector, idx_t out_base,
+                     PhysicalType decimal_physical_type) {
+  const std::byte* strip_base = group.strip(field);
+  const uint32_t stride = group.stride(field);
+  const std::byte* src = strip_base + static_cast<size_t>(stride) * slot_start;
+  constexpr uint32_t kCellLenBytes = PaxGroup::kCellLenBytes;
+
+  switch (kind) {
+    case FK_INT32: {
+      int32_t* dst = FlatVector::GetData<int32_t>(output_vector) + out_base;
+      for (uint32_t i = 0; i < count; i++, src += stride) {
+        uint16_t cell_length;
+        std::memcpy(&cell_length, src, sizeof(cell_length));
+        if (cell_length == width) {
+          std::memcpy(&dst[i], src + kCellLenBytes, sizeof(int32_t));
+        } else {
+          dst[i] = 0;
+          FlatVector::SetNull(output_vector, out_base + i, true);
+        }
+      }
+      break;
+    }
+    case FK_INT64: {
+      int64_t* dst = FlatVector::GetData<int64_t>(output_vector) + out_base;
+      for (uint32_t i = 0; i < count; i++, src += stride) {
+        uint16_t cell_length;
+        std::memcpy(&cell_length, src, sizeof(cell_length));
+        if (cell_length == width) {
+          std::memcpy(&dst[i], src + kCellLenBytes, sizeof(int64_t));
+        } else {
+          dst[i] = 0;
+          FlatVector::SetNull(output_vector, out_base + i, true);
+        }
+      }
+      break;
+    }
+    case FK_DATE: {
+      date_t* dst = FlatVector::GetData<date_t>(output_vector) + out_base;
+      for (uint32_t i = 0; i < count; i++, src += stride) {
+        uint16_t cell_length;
+        std::memcpy(&cell_length, src, sizeof(cell_length));
+        if (cell_length == width) {
+          int32_t ymd;
+          std::memcpy(&ymd, src + kCellLenBytes, sizeof(ymd));
+          dst[i] = Date::FromDate(ymd / 10000, (ymd / 100) % 100, ymd % 100);
+        } else {
+          FlatVector::SetNull(output_vector, out_base + i, true);
+        }
+      }
+      break;
+    }
+    case FK_DEC64: {
+      for (uint32_t i = 0; i < count; i++, src += stride) {
+        uint16_t cell_length;
+        std::memcpy(&cell_length, src, sizeof(cell_length));
+        if (cell_length == width) {
+          int64_t mantissa;
+          std::memcpy(&mantissa, src + kCellLenBytes, sizeof(mantissa));
+          WriteDecimalPhysical(output_vector, out_base + i, mantissa,
+                               decimal_physical_type);
+        } else {
+          FlatVector::SetNull(output_vector, out_base + i, true);
+        }
+      }
+      break;
+    }
+    default:
+      break;  // FK_UNTYPED never reaches here
+  }
+}
+
+/**
+ * @brief Decodes one untyped cell into a VARCHAR vector slot.
+ *
+ * @details An empty untyped cell is SQL NULL; short payloads inline into
+ * string_t, longer ones copy into the vector's string heap.
+ */
+inline void DecodeUntypedCell(const PaxGroup& group, size_t field,
+                              uint32_t slot, Vector& output_vector,
+                              idx_t out_row) {
+  const std::string_view cell_value = group.cell(field, slot);
+  if (cell_value.empty()) {
+    FlatVector::SetNull(output_vector, out_row, true);
+  } else if (cell_value.size() <= duckdb::string_t::INLINE_LENGTH) {
+    FlatVector::GetData<duckdb::string_t>(output_vector)[out_row] =
+        duckdb::string_t(cell_value.data(),
+                         static_cast<uint32_t>(cell_value.size()));
+  } else {
+    FlatVector::GetData<duckdb::string_t>(output_vector)[out_row] =
+        StringVector::AddString(output_vector, cell_value.data(),
+                                cell_value.size());
+  }
+}
+
+/**
+ * @brief Scan worker: fills one output chunk from claimed PAX groups.
+ *
+ * @details Threads claim whole groups from the shared next_group counter and
+ * decode contiguous visible-slot runs column-at-a-time.
+ */
+void PaxScan(ClientContext&, TableFunctionInput& data, DataChunk& output) {
+  const auto& bind_data = data.bind_data->Cast<PaxBindData>();
+  auto& global_state = data.global_state->Cast<PaxGlobalState>();
+  auto& local_state = data.local_state->Cast<PaxLocalState>();
+
+  PaxTableView& table_view = *bind_data.table;
+  PaxStore* store = table_view.store;
+  const idx_t max_rows = output.GetCapacity();
+  idx_t rows_emitted = 0;
+
+  struct ColumnContext {
+    uint8_t kind;
+    size_t field;
+    uint32_t width;
+    PhysicalType decimal_physical_type;
+  };
+  std::vector<ColumnContext> scan_columns(global_state.column_ids.size());
+  for (idx_t i = 0; i < global_state.column_ids.size(); i++) {
+    const column_t column = global_state.column_ids[i];
+    const ColumnSpec& spec = table_view.columns[column];
+    scan_columns[i].kind = spec.kind;
+    scan_columns[i].field = static_cast<size_t>(column) + 1;  // field 0 is null flags
+    scan_columns[i].width = spec.width;
+    scan_columns[i].decimal_physical_type =
+        (spec.kind == FK_DEC64) ? output.data[i].GetType().InternalType()
+                                : PhysicalType::INVALID;
+  }
+
+  while (rows_emitted < max_rows) {
+    if (local_state.group_ptr == nullptr ||
+        local_state.current_slot >= PaxGroup::kRows) {
+      uint32_t claimed = UINT32_MAX;
+      const uint64_t next =
+          global_state.next_group.fetch_add(1, std::memory_order_relaxed);
+      if (next < global_state.group_count) {
+        claimed = static_cast<uint32_t>(next);
+      }
+      if (claimed == UINT32_MAX) break;
+      local_state.group_ptr = store->group(claimed);
+      local_state.current_group = claimed;
+      local_state.current_slot = 0;
+      if (local_state.group_ptr == nullptr) continue;
+    }
+
+    PaxGroup* group = local_state.group_ptr;
+    const uint32_t slot = local_state.current_slot;
+    if (slot >= PaxGroup::kRows) {
+      local_state.group_ptr = nullptr;
+      continue;
+    }
+    if (!group->IsVisible(slot)) {
+      local_state.current_slot = slot + 1;
+      continue;
+    }
+
+    const uint32_t max_run_length = std::min<uint32_t>(
+        PaxGroup::kRows - slot, static_cast<uint32_t>(max_rows - rows_emitted));
+    uint32_t run_length = 1;
+    while (run_length < max_run_length && group->IsVisible(slot + run_length)) {
+      run_length++;
+    }
+
+    for (idx_t i = 0; i < scan_columns.size(); i++) {
+      const ColumnContext& column = scan_columns[i];
+      if (column.kind == FK_UNTYPED) {
+        for (uint32_t row = 0; row < run_length; row++) {
+          DecodeUntypedCell(*group, column.field, slot + row, output.data[i],
+                            rows_emitted + row);
+        }
+      } else {
+        BulkDecodeTyped(column.kind, *group, column.field, column.width, slot,
+                        run_length, output.data[i], rows_emitted,
+                        column.decimal_physical_type);
+      }
+    }
+
+    rows_emitted += run_length;
+    local_state.current_slot = slot + run_length;
+  }
+
+  output.SetCardinality(rows_emitted);
+}
+
+// ---------------------------------------------------------------------------
+// Per-request catalog registration. Serialized by GlobalCatalogMutex().
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Registers the scan table function for one table.
+ *
+ * @details `nonce` disambiguates the function name across requests sharing
+ * the runtime's system catalog: each request's PaxTableView objects live
+ * only for that request's stack frame, and a stale function entry from a
+ * prior request must never be reachable by name again.
+ *
+ * @return The registered function name.
+ */
+std::string RegisterPaxFunction(Connection& connection,
+                                PaxTableView& table_view, size_t table_index,
+                                uint64_t nonce) {
+  auto info = duckdb::make_shared_ptr<PaxTableInfo>();
+  info->table = &table_view;
+
+  const std::string function_name =
+      "pax_scan_" + std::to_string(nonce) + "_" + std::to_string(table_index);
+  TableFunction function(function_name, {}, PaxScan, PaxBind, PaxInitGlobal,
+                         PaxInitLocal);
+  function.projection_pushdown = true;
+  function.filter_pushdown = false;
+  function.function_info = info;
+
+  connection.context->RunFunctionInTransaction([&]() {
+    auto& catalog = duckdb::Catalog::GetSystemCatalog(*connection.context);
+    duckdb::CreateTableFunctionInfo create_info(function);
+    catalog.CreateTableFunction(*connection.context, create_info);
+  });
+  // RunFunctionInTransaction starts a transaction when the connection is in
+  // auto-commit mode but does not commit it. Committing explicitly here,
+  // immediately after the mutation that opened it, keeps every subsequent
+  // statement in this request looking at a clean, fully-committed catalog
+  // state instead of an open transaction carried across statements.
+  if (connection.HasActiveTransaction()) connection.Commit();
+  return function_name;
+}
+
+/**
+ * @brief Creates the bare view for one table's already-registered function.
+ *
+ * @details The view name is NOT nonce-disambiguated: it must equal the table
+ * name the client SQL references, hence CREATE OR REPLACE (idempotent across
+ * requests, and GlobalCatalogMutex() already serializes this section).
+ *
+ * Only the bare, unqualified name may be registered here. A schema-qualified
+ * sibling view ("db"."table") must not be added: with two or more different
+ * custom table-function-backed tables in one query, a qualified view makes
+ * DuckDB's (v1.5.4) binder intermittently fail to resolve the second table
+ * ("Catalog Error: Table ... does not exist"). Db-qualified table references
+ * are instead stripped from the SQL text on the proxy side.
+ */
+void RegisterPaxView(Connection& connection, PaxTableView& table_view,
+                     const std::string& function_name) {
+  // sql_name is a MySQL identifier straight from TABLE_SHARE, not
+  // attacker-controlled SQL text; double-quoting it is a safe-identifier
+  // quoting step, not string-built SQL from client input.
+  const std::string view_sql = "CREATE OR REPLACE VIEW \"" +
+                               table_view.sql_name + "\" AS SELECT * FROM " +
+                               function_name + "();";
+  auto view_result = connection.Query(view_sql);
+  if (view_result->HasError()) {
+    throw std::runtime_error("CREATE VIEW " + table_view.sql_name +
+                             " failed: " + view_result->GetError());
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Result -> proxy row format.
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Encodes one result row into the proxy row format.
+ *
+ * @details Uses DuckDB's own Value::ToString(): an exact fixed-point
+ * representation for DECIMAL (no precision loss) and ISO "YYYY-MM-DD" for
+ * DATE, matching this codebase's ASCII row-value convention.
+ *
+ * DECIMAL division / AVG: DuckDB resolves AVG() of a DECIMAL column (and any
+ * DECIMAL/DECIMAL division) to DOUBLE by design
+ * (https://duckdb.org/docs/stable/sql/data_types/numeric). Value::ToString()
+ * on that DOUBLE uses shortest-round-trip formatting; the proxy reformats it
+ * to MySQL's decimals convention with exact string/integer rounding once the
+ * row crosses the wire.
+ *
+ * KNOWN LIMITATION: that proxy-side reformatting corrects display scale
+ * only. The value itself went through DOUBLE division, and at large enough
+ * magnitudes double's ~15-17 significant decimal digits could place the true
+ * value on the wrong side of a rounding boundary relative to MySQL's exact
+ * fixed-point computation. An exact fix would compute DECIMAL division in
+ * integer arithmetic (DuckDB extension or server-side) instead of trusting
+ * the DOUBLE result.
+ */
+void EncodeRow(duckdb::MaterializedQueryResult& result, idx_t row_index,
+               std::string* out) {
+  out->clear();
+  // Field 0 mirrors the row null-flags field of the proxy row format; the
+  // proxy does not read it for bridge results.
+  AppendProxyField(*out, "", /*is_null=*/true);
+  for (idx_t column_index = 0; column_index < result.ColumnCount();
+       column_index++) {
+    const duckdb::Value value = result.GetValue(column_index, row_index);
+    // Check is_null BEFORE looking at the text: a genuine empty-string result
+    // (value.ToString() == "") is a valid non-null value, not a signal for
+    // the NULL sentinel. The text is only computed in the non-null case.
+    if (value.IsNull()) {
+      AppendProxyField(*out, "", /*is_null=*/true);
+    } else {
+      const std::string text = value.ToString();
+      AppendProxyField(*out, text, /*is_null=*/false);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Process-lifetime state.
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Process-lifetime DuckDB runtime.
+ *
+ * @details The bridge borrows DuckDB's parser, planner, and vectorized
+ * executor; the in-memory duckdb::DuckDB instance holds no table data, and
+ * its system catalog only ever contains this bridge's table functions and
+ * views. The function-local static gives thread-safe, exactly-once
+ * construction: the first request pays the construction cost, every later
+ * request on any thread reuses the instance. This follows DuckDB's
+ * documented concurrency model
+ * (https://duckdb.org/docs/stable/connect/concurrency): one shared instance,
+ * one fresh Connection per request/thread.
+ */
+duckdb::DuckDB& GlobalRuntime() {
+  static duckdb::DuckDB runtime(nullptr);  // nullptr: in-memory, no db file
+  return runtime;
+}
+
+/**
+ * @brief Serializes each request's register-views/run-query/encode-results
+ * section against the shared system catalog.
+ *
+ * @details View names must equal the table names the client SQL references
+ * (e.g. "lineitem"), and the runtime has one shared system catalog; two
+ * concurrent requests touching the same table would race on CREATE OR
+ * REPLACE VIEW. There is no per-request schema isolation; single-statement
+ * callers do not contend, and the whole response is bounded by the OCC
+ * re-check regardless.
+ */
+std::mutex& GlobalCatalogMutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+/**
+ * @brief Disambiguates table-function names (not view names, see
+ * RegisterPaxView) across requests sharing the runtime's system catalog.
+ */
+std::atomic<uint64_t> g_request_nonce{0};
+
 }  // namespace
 
 void ExecuteSql(LineairDB::Database* db,
@@ -115,16 +782,116 @@ void ExecuteSql(LineairDB::Database* db,
     return;
   }
 
-  std::vector<TableWriteState> captured_tables;
-  std::string error;
-  if (!CaptureTableWriteStates(db, request, &captured_tables, &error)) {
-    response->set_ok(false);
-    response->set_error(error);
-    return;
-  }
+  // Stage timing, off by default: ENABLE_DUCKDB_BRIDGE_TRACE logs a
+  // one-line stderr breakdown per request (write-state capture / view build /
+  // catalog-mutex wait + registration / query / row encoding).
+  // Enabled when set to anything but empty or "0", matching ENABLE_RPC_TRACE
+  static const bool trace = [] {
+    const char* value = std::getenv("ENABLE_DUCKDB_BRIDGE_TRACE");
+    return value != nullptr && value[0] != '\0' &&
+           std::string_view(value) != "0";
+  }();
+  using Clock = std::chrono::steady_clock;
+  Clock::time_point trace_start, after_capture, after_view_build,
+      after_register, after_query, after_encode;
 
-  response->set_ok(false);
-  response->set_error("duckdb bridge: execution stage is not present");
+  try {
+    if (trace) trace_start = Clock::now();
+    std::vector<TableWriteState> captured_tables;
+    std::string error;
+    if (!CaptureTableWriteStates(db, request, &captured_tables, &error)) {
+      response->set_ok(false);
+      response->set_error(error);
+      return;
+    }
+    if (trace) after_capture = Clock::now();
+
+    std::vector<PaxTableView> table_views(
+        static_cast<size_t>(request.tables_size()));
+    for (int i = 0; i < request.tables_size(); i++) {
+      const pb::TxExecuteSqlDuckdb::TableDesc& table_desc = request.tables(i);
+      PaxTableView& table_view = table_views[static_cast<size_t>(i)];
+      table_view.sql_name = table_desc.sql_name();
+      table_view.store = captured_tables[static_cast<size_t>(i)].store;
+      table_view.group_count =
+          captured_tables[static_cast<size_t>(i)].write_counters.size();
+      table_view.columns.reserve(static_cast<size_t>(table_desc.columns_size()));
+      for (const auto& column : table_desc.columns()) {
+        ColumnSpec spec;
+        spec.name = column.name();
+        spec.kind = static_cast<uint8_t>(column.pax_kind());
+        spec.width = column.pax_width();
+        spec.scale = static_cast<int8_t>(column.pax_scale());
+        table_view.columns.push_back(std::move(spec));
+      }
+    }
+
+    if (trace) after_view_build = Clock::now();
+    const uint64_t nonce =
+        g_request_nonce.fetch_add(1, std::memory_order_relaxed);
+
+    std::unique_ptr<duckdb::MaterializedQueryResult> result;
+    {
+      // This section touches the runtime's shared system catalog (table
+      // functions and fixed-name views); see GlobalCatalogMutex.
+      std::lock_guard<std::mutex> catalog_lock(GlobalCatalogMutex());
+      Connection connection(GlobalRuntime());
+      for (size_t i = 0; i < table_views.size(); i++) {
+        const std::string function_name =
+            RegisterPaxFunction(connection, table_views[i], i, nonce);
+        RegisterPaxView(connection, table_views[i], function_name);
+      }
+      if (trace) after_register = Clock::now();
+
+      result = connection.Query(request.sql());
+      if (trace) after_query = Clock::now();
+      if (result->HasError()) {
+        response->set_ok(false);
+        response->set_error(result->GetError());
+        return;
+      }
+
+      std::string row;
+      for (idx_t row_index = 0; row_index < result->RowCount(); row_index++) {
+        EncodeRow(*result, row_index, &row);
+        response->add_rows(row);
+      }
+    }
+    if (trace) after_encode = Clock::now();
+
+    if (!WriteStateUnchanged(captured_tables)) {
+      response->Clear();
+      response->set_ok(false);
+      response->set_error("concurrent modification");
+      return;
+    }
+
+    if (trace) {
+      auto milliseconds = [](Clock::time_point from, Clock::time_point to) {
+        return std::chrono::duration<double, std::milli>(to - from).count();
+      };
+      std::fprintf(
+          stderr,
+          "[duckdb_bridge] capture=%.1fms view_build=%.1fms "
+          "lock_wait+register=%.1fms query=%.1fms encode=%.1fms rows=%llu\n",
+          milliseconds(trace_start, after_capture),
+          milliseconds(after_capture, after_view_build),
+          milliseconds(after_view_build, after_register),
+          milliseconds(after_register, after_query),
+          milliseconds(after_query, after_encode),
+          static_cast<unsigned long long>(result->RowCount()));
+    }
+
+    response->set_ok(true);
+  } catch (const std::exception& exception) {
+    response->Clear();
+    response->set_ok(false);
+    response->set_error(exception.what());
+  } catch (...) {
+    response->Clear();
+    response->set_ok(false);
+    response->set_error("duckdb bridge execution failed");
+  }
 }
 
 }  // namespace duckdb_bridge

--- a/server/rpc/duckdb_bridge_executor.hh
+++ b/server/rpc/duckdb_bridge_executor.hh
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "lineairdb.pb.h"
+
+namespace LineairDB {
+class Database;
+}
+
+namespace duckdb_bridge {
+
+/**
+ * @brief Executes a TX_EXECUTE_SQL_DUCKDB request.
+ *
+ * @details Runs the request's verbatim SQL text on the server's embedded
+ * DuckDB executor. Table functions registered per request read the live
+ * LineairDB::Database PAX storage in place; the request carries every base
+ * table's PAX cell metadata (kind/width/scale), and the server keeps no
+ * schema registry for this path. Every referenced table's write state is
+ * captured before execution and re-checked after (OCC quiescence): a
+ * concurrent write discards the result. Coverage is not limited to the query
+ * shapes the query-block executor recognizes.
+ *
+ * @param db Live server database; source of the PaxStore instances.
+ * @param request Parsed TX_EXECUTE_SQL_DUCKDB request.
+ * @param response Filled with ok/error and result rows in the proxy row
+ * format.
+ */
+void ExecuteSql(LineairDB::Database* db,
+                const LineairDB::Protocol::TxExecuteSqlDuckdb::Request& request,
+                LineairDB::Protocol::TxExecuteSqlDuckdb::Response* response);
+
+}  // namespace duckdb_bridge

--- a/server/rpc/lineairdb_rpc.cc
+++ b/server/rpc/lineairdb_rpc.cc
@@ -73,6 +73,10 @@ void LineairDBRpc::handle_rpc(uint64_t sender_id, MessageType message_type,
             handleTxExecuteQueryBlock(message, result);
             release_masstree_thread_epoch();
             return;
+        case MessageType::TX_EXECUTE_SQL_DUCKDB:
+            handleTxExecuteSqlDuckdb(message, result);
+            release_masstree_thread_epoch();
+            return;
 
         // Table statistics
         case MessageType::TX_GET_TABLE_STATS:

--- a/server/rpc/lineairdb_rpc.hh
+++ b/server/rpc/lineairdb_rpc.hh
@@ -85,6 +85,9 @@ private:
     // Query-block execution
     void handleTxExecuteQueryBlock(const std::string& message, std::string& result);
 
+    // DuckDB SQL bridge (raw SQL text over live PAX storage).
+    void handleTxExecuteSqlDuckdb(const std::string& message, std::string& result);
+
     // Secondary index operations
     void handleTxReadSecondaryIndex(const std::string& message, std::string& result);
     void handleTxWriteSecondaryIndex(const std::string& message, std::string& result);

--- a/test/unit/test_convert_backtick_identifiers.cc
+++ b/test/unit/test_convert_backtick_identifiers.cc
@@ -1,0 +1,270 @@
+// Regression suite for ConvertBacktickIdentifiers
+// (proxy/duckdb_sql_rewrite.cc), the backtick-to-doublequote /
+// qualifier-stripping rewrite the DuckDB bridge applies to MySQL-printed view
+// bodies. See the function's header for the classification rules.
+//
+// Failure modes pinned by this suite:
+// - collapsing an alias-qualified 2-part column ref (`t2`.`x`) the way a
+//   table ref is collapsed turns a correlated predicate into the tautology
+//   x = x;
+// - EXTRACT/TRIM/SUBSTRING's FROM-as-argument-separator syntax must not read
+//   as a table position;
+// - only the innermost open call suppresses FROM: a subquery nested inside
+//   EXTRACT(... FROM (SELECT ...)) contains ordinary table positions again;
+// - MySQL's printer wraps multi-table FROM lists in parens directly after
+//   from/join (`from (`t1` `a` join `t2` `b` ...)`) with no intervening
+//   word, and the first table in the list must still be stripped;
+// - identifier lexing includes '_' and digits: my_join / date_from /
+//   straight_join must not truncate to the keywords join/from.
+//
+// Build and run (from the repository root):
+//   g++ -std=c++17 -Wall -Wextra -I proxy
+//       test/unit/test_convert_backtick_identifiers.cc
+//       proxy/duckdb_sql_rewrite.cc -o /tmp/test_convert_backtick
+//   /tmp/test_convert_backtick   (one command; wrapped here for width)
+//
+// Exit code is the number of failed cases (0 = all green).
+
+#include <cstdio>
+#include <string>
+
+#include "duckdb_sql_rewrite.hh"
+
+namespace {
+
+int g_failures = 0;
+int g_total = 0;
+
+void Check(const std::string &name, const std::string &input,
+           const std::string &expected) {
+  g_total++;
+  const std::string actual = ConvertBacktickIdentifiers(input);
+  if (actual == expected) {
+    std::printf("[PASS] %s\n", name.c_str());
+    return;
+  }
+  g_failures++;
+  std::printf("[FAIL] %s\n", name.c_str());
+  std::printf("  input:    %s\n", input.c_str());
+  std::printf("  expected: %s\n", expected.c_str());
+  std::printf("  actual:   %s\n", actual.c_str());
+}
+
+}  // namespace
+
+int main() {
+  // --- Baseline: plain table refs -----------------------------------
+  Check("plain table ref, db-qualified",
+        "select * from `benchbase`.`lineitem`",
+        "select * from \"lineitem\"");
+
+  Check("plain table ref, bare (1-part)",
+        "select * from `t1`",
+        "select * from \"t1\"");
+
+  Check("plain table ref after JOIN keyword",
+        "select * from `benchbase`.`t1` join `benchbase`.`t2`",
+        "select * from \"t1\" join \"t2\"");
+
+  // --- 2-part and 3-part column refs ---------------------------------
+  Check("3-part column ref: drop only leading db",
+        "select `benchbase`.`lineitem`.`l_orderkey` from `benchbase`.`lineitem`",
+        "select \"lineitem\".\"l_orderkey\" from \"lineitem\"");
+
+  Check("2-part column ref (table-alias qualified) left untouched",
+        "select `l`.`l_orderkey` from `benchbase`.`lineitem` `l`",
+        "select \"l\".\"l_orderkey\" from \"lineitem\" \"l\"");
+
+  // --- Correlated subquery ---------------------------------------------
+  Check("correlated EXISTS: alias-qualified columns not collapsed to x=x",
+        "select * from `benchbase`.`t1` where exists (select 1 from "
+        "`benchbase`.`t2` where `t2`.`x` = `t1`.`x`)",
+        "select * from \"t1\" where exists (select 1 from \"t2\" where "
+        "\"t2\".\"x\" = \"t1\".\"x\")");
+
+  // --- JOIN ... ON -----------------------------------------------------
+  Check("JOIN ... ON: table refs stripped, ON columns (2-part) untouched",
+        "select * from `benchbase`.`t1` join `benchbase`.`t2` on "
+        "`t1`.`id` = `t2`.`id`",
+        "select * from \"t1\" join \"t2\" on \"t1\".\"id\" = \"t2\".\"id\"");
+
+  // --- Parenthesized join list: MySQL's printer wraps multi-table FROM --
+  // --- lists in parens right after from/join with no intervening word, --
+  // --- e.g. `from (`t1` `a` join `t2` `b` on (...))`. The first table  --
+  // --- right after "from (" must still be detected as a table position. -
+  Check("parenthesized join list: first table after 'from (' still "
+        "stripped to bare name",
+        "select `s`.`s_suppkey`,`n`.`n_name` from (`benchbase`.`supplier` "
+        "`s` join `benchbase`.`nation` `n` on(`s`.`s_nationkey` = "
+        "`n`.`n_nationkey`))",
+        "select \"s\".\"s_suppkey\",\"n\".\"n_name\" from (\"supplier\" "
+        "\"s\" join \"nation\" \"n\" on(\"s\".\"s_nationkey\" = "
+        "\"n\".\"n_nationkey\"))");
+
+  Check("parenthesized join list: three-way join, parens nested two deep, "
+        "every table in the list stripped",
+        "select 1 from ((`benchbase`.`t1` join `benchbase`.`t2` on(`t1`."
+        "`id` = `t2`.`id`)) join `benchbase`.`t3` on(`t2`.`id` = `t3`."
+        "`id`))",
+        "select 1 from ((\"t1\" join \"t2\" on(\"t1\".\"id\" = \"t2\"."
+        "\"id\")) join \"t3\" on(\"t2\".\"id\" = \"t3\".\"id\"))");
+
+  // --- FROM as a function-argument separator ---------------------------
+  Check("EXTRACT: FROM is an argument separator, not a table position",
+        "select extract(year from `benchbase`.`lineitem`.`l_shipdate`) "
+        "from `benchbase`.`lineitem`",
+        "select extract(year from \"lineitem\".\"l_shipdate\") from "
+        "\"lineitem\"");
+
+  Check("TRIM: FROM is an argument separator",
+        "select trim(both ' ' from `benchbase`.`t1`.`name`) from "
+        "`benchbase`.`t1`",
+        "select trim(both ' ' from \"t1\".\"name\") from \"t1\"");
+
+  Check("SUBSTRING FROM/FOR: guarded even though MySQL prints it as "
+        "substr(str,pos)",
+        "select substring(`benchbase`.`t1`.`s` from 1 for 5) from "
+        "`benchbase`.`t1`",
+        "select substring(\"t1\".\"s\" from 1 for 5) from \"t1\"");
+
+  // --- Innermost-call semantics of the paren stack ----------------------
+  Check("EXTRACT(... FROM (subquery)): subquery's own FROM is a table "
+        "position again",
+        "select extract(year from (select max(`benchbase`.`lineitem`."
+        "`l_shipdate`) from `benchbase`.`lineitem` where `benchbase`."
+        "`lineitem`.`l_orderkey` = 1)) from `benchbase`.`t1`",
+        "select extract(year from (select max(\"lineitem\".\"l_shipdate\") "
+        "from \"lineitem\" where \"lineitem\".\"l_orderkey\" = 1)) from "
+        "\"t1\"");
+
+  Check("nested EXTRACT inside subquery inside outer EXTRACT: inner "
+        "EXTRACT's own FROM suppressed, subquery's FROM not",
+        "select extract(year from (select extract(month from "
+        "`benchbase`.`t2`.`x`) from `benchbase`.`t2`)) from `benchbase`.`t1`",
+        "select extract(year from (select extract(month from "
+        "\"t2\".\"x\") from \"t2\")) from \"t1\"");
+
+  Check("TRIM with nested subquery in its FROM argument",
+        "select trim(from (select `benchbase`.`t2`.`s` from `benchbase`."
+        "`t2` limit 1)) from `benchbase`.`t1`",
+        "select trim(from (select \"t2\".\"s\" from \"t2\" limit 1)) from "
+        "\"t1\"");
+
+  Check("three levels of EXTRACT/subquery nesting",
+        "select extract(year from (select extract(month from (select "
+        "extract(day from `benchbase`.`t3`.`d`) from `benchbase`.`t3`)) "
+        "from `benchbase`.`t2`)) from `benchbase`.`t1`",
+        "select extract(year from (select extract(month from (select "
+        "extract(day from \"t3\".\"d\") from \"t3\")) from \"t2\")) from "
+        "\"t1\"");
+
+  Check("JOIN...ON with EXTRACT in the ON clause, followed by another real "
+        "JOIN: stack returns to empty between them",
+        "select * from `benchbase`.`t1` join `benchbase`.`t2` on "
+        "extract(year from `t1`.`d`) = extract(year from `t2`.`d`) join "
+        "`benchbase`.`t3` on `t2`.`id` = `t3`.`id`",
+        "select * from \"t1\" join \"t2\" on extract(year from \"t1\"."
+        "\"d\") = extract(year from \"t2\".\"d\") join \"t3\" on \"t2\"."
+        "\"id\" = \"t3\".\"id\"");
+
+  Check("two sibling EXTRACT(...FROM subquery...) calls: push/pop does not "
+        "leak state between them",
+        "select extract(year from (select 1 from `benchbase`.`a`)), "
+        "extract(month from (select 1 from `benchbase`.`b`)) from "
+        "`benchbase`.`t1`",
+        "select extract(year from (select 1 from \"a\")), extract(month "
+        "from (select 1 from \"b\")) from \"t1\"");
+
+  Check("plain function call (not EXTRACT/TRIM/SUBSTRING) opens a "
+        "non-keyword-fn paren: a later FROM inside it is not suppressed",
+        "select max(`benchbase`.`t1`.`x`) from `benchbase`.`t1` where "
+        "`benchbase`.`t1`.`id` in (select `benchbase`.`t2`.`id` from "
+        "`benchbase`.`t2`)",
+        "select max(\"t1\".\"x\") from \"t1\" where \"t1\".\"id\" in "
+        "(select \"t2\".\"id\" from \"t2\")");
+
+  Check("mixed-case FROM/JOIN/EXTRACT keywords recognized (word-building "
+        "lowercases)",
+        "select EXTRACT(YEAR From `benchbase`.`t1`.`d`) FROM "
+        "`benchbase`.`t1` JOIN `benchbase`.`t2`",
+        "select EXTRACT(YEAR From \"t1\".\"d\") FROM \"t1\" JOIN \"t2\"");
+
+  Check("escaped backtick inside identifier survives",
+        "select * from `benchbase`.`weird``name`",
+        "select * from \"weird`name\"");
+
+  Check("string literal containing FROM/EXTRACT/parens does not perturb "
+        "word-tracking for the backtick that follows",
+        "select * from `benchbase`.`t1` where `benchbase`.`t1`.`s` = "
+        "'from (extract) join'",
+        "select * from \"t1\" where \"t1\".\"s\" = 'from (extract) join'");
+
+  Check("embedded double-quote in identifier is escaped as ''",
+        "select * from `benchbase`.`weird\"name`",
+        "select * from \"weird\"\"name\"");
+
+  Check("EXTRACT followed at top level by a real FROM after its closing "
+        "paren: stack is empty again",
+        "select extract(year from `benchbase`.`t1`.`d`) from "
+        "`benchbase`.`t1` join `benchbase`.`t2`",
+        "select extract(year from \"t1\".\"d\") from \"t1\" join \"t2\"");
+
+  Check("backtick chain right after '(' of a non-keyword fn (preceding "
+        "word is \"max\", not from/join) is not a table position",
+        "select max(`benchbase`.`t1`.`x`)",
+        "select max(\"t1\".\"x\")");
+
+  // --- Identifier lexing: '_' and digits continue the token -------------
+  Check("UDF my_join(...): word is the full identifier, not truncated to "
+        "\"join\"; the argument column ref is not a table position",
+        "select my_join(`benchbase`.`t1`.`x`) from `benchbase`.`t1`",
+        "select my_join(\"t1\".\"x\") from \"t1\"");
+
+  Check("UDF date_from(...): word is \"date_from\", not truncated to "
+        "\"from\"",
+        "select date_from(`benchbase`.`t1`.`d`) from `benchbase`.`t1`",
+        "select date_from(\"t1\".\"d\") from \"t1\"");
+
+  Check("STRAIGHT_JOIN SELECT-option keyword: \"straight_join\" does not "
+        "truncate to \"join\" and strip the next column ref",
+        "select straight_join `t1`.`x`, `t2`.`y` from `benchbase`.`t1` "
+        "join `benchbase`.`t2` on `t1`.`id` = `t2`.`id`",
+        "select straight_join \"t1\".\"x\", \"t2\".\"y\" from \"t1\" join "
+        "\"t2\" on \"t1\".\"id\" = \"t2\".\"id\"");
+
+  // --- from/join as a substring of ordinary identifiers -----------------
+  Check("\"join\" as suffix in a bare identifier (SELECT-list alias) is "
+        "inert",
+        "select `benchbase`.`t1`.`x` as outer_join_flag from "
+        "`benchbase`.`t1`",
+        "select \"t1\".\"x\" as outer_join_flag from \"t1\"");
+
+  Check("\"join\" as prefix of a function name: joins_table(...) is inert",
+        "select joins_table(`benchbase`.`t1`.`x`) from `benchbase`.`t1`",
+        "select joins_table(\"t1\".\"x\") from \"t1\"");
+
+  Check("\"from\" as prefix of a function name: from_date(...) is inert",
+        "select from_date(`benchbase`.`t1`.`d`) from `benchbase`.`t1`",
+        "select from_date(\"t1\".\"d\") from \"t1\"");
+
+  Check("\"join\" as a middle segment of a function name: "
+        "x_outer_join_flag_y(...) is inert",
+        "select x_outer_join_flag_y(`benchbase`.`t1`.`x`) from "
+        "`benchbase`.`t1`",
+        "select x_outer_join_flag_y(\"t1\".\"x\") from \"t1\"");
+
+  Check("genuine from clause followed by lookalike function date_from "
+        "later in the same query: both resolve independently",
+        "select date_from(`benchbase`.`t2`.`d`) from `benchbase`.`t1` join "
+        "`benchbase`.`t2` on `t1`.`id` = `t2`.`id`",
+        "select date_from(\"t2\".\"d\") from \"t1\" join \"t2\" on \"t1\"."
+        "\"id\" = \"t2\".\"id\"");
+
+  Check("digits mixed into an identifier: md5_from_col does not truncate "
+        "to \"from\"",
+        "select md5_from_col(`benchbase`.`t1`.`x`) from `benchbase`.`t1`",
+        "select md5_from_col(\"t1\".\"x\") from \"t1\"");
+
+  std::printf("\n%d / %d passed\n", g_total - g_failures, g_total);
+  return g_failures;
+}


### PR DESCRIPTION
## Summary
- Adds an opt-in execution path (`HELIOS_DUCKDB_BRIDGE=1`): the proxy ships the client's SQL text to an embedded DuckDB inside lineairdb-server, which plans and executes it directly over live PAX storage.
- With the gate unset (default) behavior is unchanged: the full TPC-H SF=1 md5 gate reproduces byte-identical results on both existing paths (row store and query-block offload).
- With the gate on, all 22 TPC-H queries return byte-identical results, with confirmed bridge engagement on every query. In the single verification run the bridge was faster on 20 of 22 queries (for example q21 688 ms → 133 ms against the query-block executor); two light queries regressed (see known limits).
- DuckDB v1.5.4 is vendored as a git submodule and built from source; no prebuilt binary is checked in.

## Why
- The query-block executor re-implements vectorized execution one technique at a time, and its plan IR limits which query shapes can offload. Handing the SQL text to a mature engine removes that ceiling: DuckDB plans and executes, Helios provides the storage and the OCC read contract.

## Details
- Server: a per-request DuckDB table function reads live PaxStore groups during the scan (parallel scan, projection pushdown, typed-cell bulk decode); no table is imported or materialized into DuckDB storage. The same write-state capture and re-check contract as the query-block executor guards concurrent writes; on any change the whole result is discarded and an error is returned.
- Proxy: the secondary-engine optimize hook builds the request from the verbatim statement text plus per-table PAX column metadata. Referenced views are expanded into WITH clauses from their stored definitions, in dependency order. Only those expanded view bodies get their identifiers rewritten from MySQL backtick to DuckDB double-quote convention (`proxy/duckdb_sql_rewrite.cc`, 34-case unit suite linking the real function; standalone build, not yet wired into CTest); the client statement itself is shipped unmodified.
- DECIMAL division output (including AVG) comes back from DuckDB as DOUBLE text; the proxy reformats those columns to MySQL's authoritative scale by exact string rounding. Display scale is exact at the tested scale factor; exact-value division inside DuckDB remains future work.
- Result rows reuse the existing proxy row format, so the decode path is shared with the query-block response.
- Known limits, tracked for the validation program (the gate stays opt-in until it completes): validated on the TPC-H query shapes only; concurrent bridge requests serialize on a catalog mutex; server-side prepared statements are untested; light queries can regress from the fixed per-request overhead (q2 35 → 74 ms, q5 90 → 123 ms in the verification run).
- Correctness gap, confirmed by code inspection and shared with the query-block executor: the write-state check can accept a half-applied multi-row transaction when the bridge run falls between two row installs (per-row write counters return to even between installs). A fix lands before the gate can default on. Concurrent-write stress has not run yet, and the retry/fallback policy for reads aborted by concurrent writes is undecided.
- Offload requires `autocommit=1`: MySQL core refuses secondary-engine execution inside a multi-statement transaction, so under `autocommit=0` (a common JDBC/ORM default) neither columnar path engages and queries take the row store — results stay correct but much slower. This is a MySQL-core rule that also affects the existing path.
