### PR TITLE
fix(proxy): bound endpoint scans and classify transport failures

### DIFF
--- a/proxy/ha_lineairdb.cc
+++ b/proxy/ha_lineairdb.cc
@@ -502,6 +502,10 @@ LineairDBTransaction *&ha_lineairdb::get_transaction(THD *thd) {
 }
 
 int ha_lineairdb::abort_errno(LineairDBTransaction *tx) {
+  if (tx != nullptr && tx->has_transport_error()) {
+    thd_mark_transaction_to_rollback(ha_thd(), 1);
+    return HA_ERR_NO_CONNECTION;
+  }
   // A prefetch cache miss is an unsupported access shape, not contention, so
   // reject it non-retryably -- retrying the same read cannot make it hit.
   if (tx != nullptr && tx->aborted_by_cache_miss()) {
@@ -528,12 +532,13 @@ static int lineairdb_commit(handlerton *hton, THD *thd, bool all) {
   if (!should_terminate_now)
     return 0;
 
-  const bool committed = ctx->tx->end_transaction();
+  bool transport_error = false;
+  const bool committed = ctx->tx->end_transaction(&transport_error);
   ctx->tx = nullptr;
 
   if (!committed) {
     thd_mark_transaction_to_rollback(thd, true);
-    return HA_ERR_LOCK_DEADLOCK;
+    return transport_error ? HA_ERR_NO_CONNECTION : HA_ERR_LOCK_DEADLOCK;
   }
   return 0;
 }

--- a/proxy/ha_lineairdb.hh
+++ b/proxy/ha_lineairdb.hh
@@ -168,6 +168,23 @@ private:
   std::unordered_map<std::string, size_t> scan_cache_;  // primary key -> index in scanned_values_
   std::vector<std::string> secondary_index_results_;
   std::vector<std::string> secondary_index_payloads_;
+
+  // MySQL uses index_first()/index_last() both for one-row endpoint lookups
+  // such as MIN()/MAX() and as the start of a continued index scan. The
+  // handler is not told whether index_next()/index_prev() will follow.
+  //
+  // Read ahead a bounded number of rows: endpoint-only queries use the first
+  // returned row, while continued scans consume the remainder and refill when
+  // the buffered rows are empty. This size trades memory for RPC frequency;
+  // it is not required for correctness.
+  static constexpr uint64_t INDEX_CURSOR_READ_AHEAD_SIZE = 1024;
+  bool index_cursor_active_{false};
+  bool index_cursor_reverse_{false};
+  bool index_cursor_secondary_{false};
+  bool index_cursor_at_eof_{false};
+  std::string index_cursor_start_key_;
+  std::string index_cursor_end_key_;
+
   // Set by get_matching_keys_and_values_in_range() when these materialized
   // rows are only a LIMIT-staged window. index_next()/index_next_same() consume
   // it and abort on over-read instead of returning a false EOF.
@@ -207,6 +224,10 @@ private:
   std::string generate_hidden_primary_key();
   std::string serialize_hidden_primary_key(uint64_t row_id) const;
   bool fetch_next_batch();
+
+  // Refill the rows buffered for index_next()/index_prev().
+  bool refill_index_cursor(LineairDBTransaction *tx);
+
   void reset_index_search_buffers();
   int fill_grouped_summary_buffers(LineairDBTransaction *tx);
 

--- a/proxy/index_scan.cc
+++ b/proxy/index_scan.cc
@@ -1,5 +1,6 @@
 #include "storage/lineairdb/ha_lineairdb.hh"
 
+#include <algorithm>
 #include <string>
 #include <utility>
 
@@ -17,6 +18,71 @@ void ha_lineairdb::reset_index_search_buffers() {
   secondary_index_payloads_.clear();
   current_position_in_index_ = 0;
   materialized_scan_truncated_ = false;
+  index_cursor_active_ = false;
+  index_cursor_reverse_ = false;
+  index_cursor_secondary_ = false;
+  index_cursor_at_eof_ = false;
+  index_cursor_start_key_.clear();
+  index_cursor_end_key_.clear();
+}
+
+bool ha_lineairdb::refill_index_cursor(LineairDBTransaction *tx) {
+  secondary_index_results_.clear();
+  secondary_index_payloads_.clear();
+  current_position_in_index_ = 0;
+
+  if (index_cursor_at_eof_) return false;
+
+  if (index_cursor_secondary_) {
+    // The existing tail-entry RPC returns one complete secondary-key group.
+    // Using that group as the next exclusive end preserves the original
+    // (secondary key, primary key) order without materializing the full index.
+    auto entry = tx->fetch_last_secondary_entry_in_range(
+        current_index_name, index_cursor_start_key_, index_cursor_end_key_);
+    if (!entry.has_value()) {
+      index_cursor_at_eof_ = true;
+      return false;
+    }
+    index_cursor_end_key_ = entry->secondary_key;
+    secondary_index_results_ = std::move(entry->primary_keys);
+    batch_fetch_secondary_payloads(tx);
+  } else {
+    auto key_values = tx->get_matching_keys_and_values_in_range(
+        index_cursor_start_key_, index_cursor_end_key_,
+        INDEX_CURSOR_READ_AHEAD_SIZE, index_cursor_reverse_);
+    if (key_values.empty()) {
+      index_cursor_at_eof_ = true;
+      return false;
+    }
+
+    const size_t fetched = key_values.size();
+    if (index_cursor_reverse_) {
+      // ScanReverse returns descending rows. The handler's established
+      // index_prev() cursor consumes an ascending vector from its tail.
+      std::reverse(key_values.begin(), key_values.end());
+      index_cursor_end_key_ = key_values.front().first;  // exclusive resume
+    } else {
+      index_cursor_start_key_ = key_values.back().first;
+      // LineairDB ranges are [start,end). Appending NUL is the smallest bound
+      // strictly greater than this complete serialized index key.
+      index_cursor_start_key_.push_back('\0');
+    }
+    index_cursor_at_eof_ = fetched < INDEX_CURSOR_READ_AHEAD_SIZE;
+
+    secondary_index_results_.reserve(fetched);
+    secondary_index_payloads_.reserve(fetched);
+    for (auto &kv : key_values) {
+      secondary_index_results_.push_back(std::move(kv.first));
+      secondary_index_payloads_.push_back(std::move(kv.second));
+    }
+  }
+
+  if (tx->is_aborted() || secondary_index_results_.empty()) return false;
+  current_position_in_index_ =
+      index_cursor_reverse_
+          ? static_cast<uint>(secondary_index_results_.size() - 1)
+          : 0;
+  return true;
 }
 
 int ha_lineairdb::change_active_index(uint keynr) {
@@ -166,6 +232,13 @@ int ha_lineairdb::index_next(uchar *buf) {
   }
   tx->choose_table(db_table_name);
 
+  if (index_cursor_active_ && !index_cursor_reverse_ &&
+      current_position_in_index_ >= secondary_index_results_.size()) {
+    if (!refill_index_cursor(tx)) {
+      return tx->is_aborted() ? abort_errno(tx) : HA_ERR_END_OF_FILE;
+    }
+  }
+
   // Consume materialized index results.
   if (secondary_index_results_.empty() ||
       current_position_in_index_ >= secondary_index_results_.size()) {
@@ -210,6 +283,14 @@ int ha_lineairdb::index_prev(uchar *buf) {
     return abort_errno(tx);
   }
   tx->choose_table(db_table_name);
+
+  if (index_cursor_active_ && index_cursor_reverse_ &&
+      (secondary_index_results_.empty() || current_position_in_index_ < 2)) {
+    if (!refill_index_cursor(tx)) {
+      return tx->is_aborted() ? abort_errno(tx) : HA_ERR_END_OF_FILE;
+    }
+    return fetch_and_set_current_result(buf, tx);
+  }
 
   // Consume materialized index results.
   if (secondary_index_results_.empty() || current_position_in_index_ < 2) {
@@ -257,16 +338,16 @@ int ha_lineairdb::index_last(uchar *buf) {
   }
 
   if (active_index == table->s->primary_key) {
-    auto key_values = tx->get_matching_keys_and_values_in_range("", "");
-    for (auto &kv : key_values) {
-      secondary_index_results_.push_back(kv.first);
-      secondary_index_payloads_.push_back(std::move(kv.second));
-    }
+    index_cursor_active_ = true;
+    index_cursor_reverse_ = true;
+    index_cursor_secondary_ = false;
   } else {
-    secondary_index_results_ =
-        tx->get_matching_primary_keys_in_range(current_index_name, "", "");
-    batch_fetch_secondary_payloads(tx);
+    index_cursor_active_ = true;
+    index_cursor_reverse_ = true;
+    index_cursor_secondary_ = true;
   }
+
+  (void)refill_index_cursor(tx);
 
   if (tx->is_aborted()) {
     return abort_errno(tx);
@@ -276,8 +357,6 @@ int ha_lineairdb::index_last(uchar *buf) {
     return HA_ERR_END_OF_FILE;
   }
 
-  current_position_in_index_ =
-      static_cast<uint>(secondary_index_results_.size() - 1);
   int error = fetch_and_set_current_result(buf, tx);
   if (error == HA_ERR_KEY_NOT_FOUND) {
     error = HA_ERR_END_OF_FILE;

--- a/proxy/lineairdb_index_search.cc
+++ b/proxy/lineairdb_index_search.cc
@@ -310,12 +310,21 @@ int ha_lineairdb::execute_plan(uchar *buf, LineairDBTransaction *tx) {
 int ha_lineairdb::execute_index_first(uchar *buf, LineairDBTransaction *tx) {
   std::string start_key = "";
   std::string end_key = current_plan_.end_key_serialized.empty()
-                            ? std::string(8, '\xFF')
+                            ? lineairdb_keyenc::scan_end_sentinel()
                             : current_plan_.end_key_serialized;
 
-  if (current_plan_.is_primary) {
-    auto key_values = tx->get_matching_keys_and_values_in_range(
-        start_key, end_key);
+  if (current_plan_.is_primary && !tx->is_prefetch_mode()) {
+    index_cursor_active_ = true;
+    index_cursor_reverse_ = false;
+    index_cursor_secondary_ = false;
+    index_cursor_start_key_ = start_key;
+    index_cursor_end_key_ = end_key;
+    (void)refill_index_cursor(tx);
+  } else if (current_plan_.is_primary) {
+    // Prefetch caches are keyed by the staged full-range shape. Keep that
+    // established path until index-first can stage a bounded autogen cursor.
+    auto key_values =
+        tx->get_matching_keys_and_values_in_range(start_key, end_key);
     for (auto &kv : key_values) {
       secondary_index_results_.push_back(kv.first);
       secondary_index_payloads_.push_back(std::move(kv.second));

--- a/proxy/lineairdb_proxy.cc
+++ b/proxy/lineairdb_proxy.cc
@@ -286,6 +286,7 @@ std::vector<LineairDBProxy::BatchReadResult> LineairDBProxy::tx_batch_read(
     int64_t tx_id = tx->get_tx_id();
     if (!connected_) {
         LOG_ERROR("RPC failed: Not connected to server");
+        tx->mark_transport_error();
         return {};
     }
 
@@ -300,6 +301,7 @@ std::vector<LineairDBProxy::BatchReadResult> LineairDBProxy::tx_batch_read(
 
     if (!send_protobuf_message(request, response, MessageType::TX_BATCH_READ)) {
         LOG_ERROR("RPC failed: Failed to send batch_read message to server");
+        tx->mark_transport_error();
         return {};
     }
 
@@ -637,10 +639,13 @@ bool LineairDBProxy::tx_validate_and_commit(
     const std::vector<BatchOp>& ops,
     const std::vector<std::pair<std::string, int64_t>>& row_deltas,
     bool isFence,
-    std::string* abort_reason) {
+    std::string* abort_reason,
+    bool* transport_error) {
     if (abort_reason != nullptr) abort_reason->clear();
+    if (transport_error != nullptr) *transport_error = false;
     if (!connected_) {
         LOG_ERROR("RPC failed: Not connected to server");
+        if (transport_error != nullptr) *transport_error = true;
         return false;
     }
     if (reads.size() != read_tids.size() || reads.size() != read_found.size()) {
@@ -712,6 +717,7 @@ bool LineairDBProxy::tx_validate_and_commit(
     if (!send_protobuf_message(request, response,
                                MessageType::TX_VALIDATE_AND_COMMIT)) {
         LOG_ERROR("RPC failed: Failed to send validate_and_commit message to server");
+        if (transport_error != nullptr) *transport_error = true;
         return false;
     }
 
@@ -903,6 +909,7 @@ std::vector<KeyValue> LineairDBProxy::tx_get_matching_keys_and_values_in_range(L
     LOG_DEBUG("CLIENT: tx_get_matching_keys_and_values_in_range called with tx_id=%ld", tx_id);
     if (!connected_) {
         LOG_ERROR("RPC failed: Not connected to server");
+        tx->mark_transport_error();
         return {};
     }
 
@@ -923,6 +930,7 @@ std::vector<KeyValue> LineairDBProxy::tx_get_matching_keys_and_values_in_range(L
     std::string raw_response;
     if (!send_protobuf_recv_binary(request, raw_response, MessageType::TX_GET_MATCHING_KEYS_AND_VALUES_IN_RANGE)) {
         LOG_ERROR("RPC failed: Failed to send message to server");
+        tx->mark_transport_error();
         return {};
     }
 
@@ -940,7 +948,7 @@ std::vector<KeyValue> LineairDBProxy::tx_get_matching_keys_and_values_from_prefi
     LOG_DEBUG("CLIENT: tx_get_matching_keys_and_values_from_prefix called with tx_id=%ld, prefix=%s", tx_id, prefix.c_str());
     if (!connected_) {
         LOG_ERROR("RPC failed: Not connected to server");
-        tx->set_aborted(true);  // fail closed: a dead connection is not "no rows"
+        tx->mark_transport_error();  // fail closed: a dead connection is not "no rows"
         return {};
     }
 
@@ -958,7 +966,7 @@ std::vector<KeyValue> LineairDBProxy::tx_get_matching_keys_and_values_from_prefi
     std::string raw_response;
     if (!send_protobuf_recv_binary(request, raw_response, MessageType::TX_GET_MATCHING_KEYS_AND_VALUES_FROM_PREFIX)) {
         LOG_ERROR("RPC failed: Failed to send message to server");
-        tx->set_aborted(true);  // fail closed: a transport failure is not "no rows"
+        tx->mark_transport_error();  // fail closed: a transport failure is not "no rows"
         return {};
     }
 
@@ -1266,6 +1274,7 @@ std::optional<SecondaryIndexEntry> LineairDBProxy::tx_fetch_last_secondary_entry
     LOG_DEBUG("CLIENT: tx_fetch_last_secondary_entry_in_range called with tx_id=%ld, index=%s", tx_id, index_name.c_str());
     if (!connected_) {
         LOG_ERROR("RPC failed: Not connected to server");
+        tx->mark_transport_error();
         return std::nullopt;
     }
 
@@ -1280,6 +1289,7 @@ std::optional<SecondaryIndexEntry> LineairDBProxy::tx_fetch_last_secondary_entry
 
     if (!send_protobuf_message(request, response, MessageType::TX_FETCH_LAST_SECONDARY_ENTRY_IN_RANGE)) {
         LOG_ERROR("RPC failed: Failed to send message to server");
+        tx->mark_transport_error();
         return std::nullopt;
     }
 
@@ -1379,11 +1389,14 @@ bool LineairDBProxy::db_create_secondary_index(const std::string& table_name,
 }
 
 bool LineairDBProxy::db_end_transaction(int64_t tx_id, bool isFence,
-                                        const std::vector<std::pair<std::string, int64_t>>& row_deltas) {
+                                        const std::vector<std::pair<std::string, int64_t>>& row_deltas,
+                                        bool *transport_error) {
+    if (transport_error != nullptr) *transport_error = false;
     LOG_DEBUG("CLIENT: db_end_transaction (with row_deltas) called with tx_id=%ld, fence=%s, deltas=%zu",
               tx_id, isFence ? "true" : "false", row_deltas.size());
     if (!connected_) {
         LOG_ERROR("RPC failed: Not connected to server");
+        if (transport_error != nullptr) *transport_error = true;
         return false;
     }
 
@@ -1400,6 +1413,7 @@ bool LineairDBProxy::db_end_transaction(int64_t tx_id, bool isFence,
 
     if (!send_protobuf_message(request, response, MessageType::DB_END_TRANSACTION)) {
         LOG_ERROR("RPC failed: Failed to send message to server");
+        if (transport_error != nullptr) *transport_error = true;
         return false;
     }
 

--- a/proxy/lineairdb_proxy.hh
+++ b/proxy/lineairdb_proxy.hh
@@ -268,7 +268,8 @@ public:
         const std::vector<BatchOp>& ops,
         const std::vector<std::pair<std::string, int64_t>>& row_deltas,
         bool isFence,
-        std::string* abort_reason = nullptr);
+        std::string* abort_reason = nullptr,
+        bool* transport_error = nullptr);
 
     // secondary index operations
     std::vector<std::string> tx_read_secondary_index(LineairDBTransaction* tx,
@@ -350,7 +351,8 @@ public:
 
     // database operations
     bool db_end_transaction(int64_t tx_id, bool isFence,
-                            const std::vector<std::pair<std::string, int64_t>>& row_deltas = {});
+                            const std::vector<std::pair<std::string, int64_t>>& row_deltas = {},
+                            bool *transport_error = nullptr);
     void db_fence();
 
     // statistics: cached table row counts, refreshed on BEGIN/END

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -1536,7 +1536,9 @@ bool LineairDBTransaction::fallback_to_normal_transaction(const char* reason) {
   return false;
 }
 
-bool LineairDBTransaction::prefetch_validate_and_commit() {
+bool LineairDBTransaction::prefetch_validate_and_commit(
+    bool *transport_error) {
+  if (transport_error != nullptr) *transport_error = transport_error_;
   bool was_aborted = is_aborted_;
 
   // Read-only fast path: no writes and no read validation to send.
@@ -1578,9 +1580,14 @@ bool LineairDBTransaction::prefetch_validate_and_commit() {
   bool committed = false;
   std::string abort_reason;
   if (!was_aborted) {
+    bool commit_transport_error = false;
     committed = lineairdb_proxy->tx_validate_and_commit(
         reads, read_tids, read_found, range_read_set_,
-        write_buffer_ops_, server_deltas, isFence, &abort_reason);
+        write_buffer_ops_, server_deltas, isFence, &abort_reason,
+        &commit_transport_error);
+    if (transport_error != nullptr) {
+      *transport_error = transport_error_ || commit_transport_error;
+    }
     if (!committed && !abort_reason.empty()) {
       rpc_trace_.record_local_view("abort_validate_" + abort_reason);
     }
@@ -1675,9 +1682,10 @@ void LineairDBTransaction::set_status_to_abort() {
   is_aborted_ = true;
 }
 
-bool LineairDBTransaction::end_transaction() {
+bool LineairDBTransaction::end_transaction(bool *transport_error) {
+  if (transport_error != nullptr) *transport_error = transport_error_;
   if (prefetch_mode_) {
-    return prefetch_validate_and_commit();
+    return prefetch_validate_and_commit(transport_error);
   }
 
   assert(tx_id != -1);
@@ -1694,7 +1702,12 @@ bool LineairDBTransaction::end_transaction() {
     }
   }
 
-  bool committed = lineairdb_proxy->db_end_transaction(tx_id, isFence, server_deltas);
+  bool end_rpc_transport_error = false;
+  bool committed = lineairdb_proxy->db_end_transaction(
+      tx_id, isFence, server_deltas, &end_rpc_transport_error);
+  if (transport_error != nullptr) {
+    *transport_error = transport_error_ || end_rpc_transport_error;
+  }
   if (!committed) {
     thd_mark_transaction_to_rollback(thread, 1);
   }

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -702,6 +702,12 @@ LineairDBTransaction::get_matching_keys_and_values_in_range(std::string start_ke
                                                             bool *served_truncated) {
   if (served_truncated != nullptr) *served_truncated = false;
   if (table_is_not_chosen()) return {};
+  // The current Masstree reverse walk does not reliably treat an absent upper
+  // bound as +infinity. Use the same sentinel as staged scans; real encoded
+  // keys begin with a null marker and therefore sort below it.
+  if (reverse_scan && end_key.empty()) {
+    end_key = lineairdb_keyenc::scan_end_sentinel();
+  }
   if (prefetch_mode_) {
     // Unbounded-upper: map an empty end to the sentinel the scan was staged with
     // so the [start, sentinel) slice keeps every row (see scan_end_sentinel).
@@ -899,7 +905,10 @@ LineairDBTransaction::fetch_last_secondary_entry_in_range(const std::string &ind
   if (!fallback_to_normal_transaction("fetch_last_secondary_entry_in_range")) return std::nullopt;
   flush_write_buffer_for_table(db_table_key);
 
-  return lineairdb_proxy->tx_fetch_last_secondary_entry_in_range(this, index_name, start_key, end_key);
+  const std::string effective_end =
+      end_key.empty() ? lineairdb_keyenc::scan_end_sentinel() : end_key;
+  return lineairdb_proxy->tx_fetch_last_secondary_entry_in_range(
+      this, index_name, start_key, effective_end);
 }
 
 // Row count delta tracking

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -97,7 +97,7 @@ public:
 
   void begin_transaction();
   void set_status_to_abort();
-  bool end_transaction();
+  bool end_transaction(bool *transport_error = nullptr);
   void fence() const;
   void set_prefetch_mode(bool enabled) { prefetch_mode_ = enabled; }
   bool is_prefetch_mode() const { return prefetch_mode_; }
@@ -159,6 +159,12 @@ public:
   }
 
   bool aborted_by_cache_miss() const { return aborted_by_cache_miss_; }
+  bool has_transport_error() const { return transport_error_; }
+
+  inline void mark_transport_error() {
+    transport_error_ = true;
+    is_aborted_ = true;
+  }
 
   inline void set_aborted(bool aborted) {
     // Once aborted, stay aborted (matches LineairDB's irreversible Abort semantics).
@@ -301,6 +307,9 @@ private:
   // Set when the abort came from a prefetch cache miss (an unstaged read
   // surface), so the handler returns a non-retryable error, not a deadlock.
   bool aborted_by_cache_miss_{false};
+  // A lost RPC connection is not OCC contention and must never be surfaced as
+  // a retryable deadlock (or as an empty scan result).
+  bool transport_error_{false};
 
   struct RowCountDelta {
     LineairDB_share *share;
@@ -469,7 +478,7 @@ private:
       const std::string& table_name, const std::string& index_name,
       const std::string& start_key, const std::string& end_key,
       bool reverse_scan, uint64_t row_limit) const;
-  bool prefetch_validate_and_commit();
+  bool prefetch_validate_and_commit(bool *transport_error);
   bool thd_is_transaction() const;
   void register_transaction_to_mysql();
   void register_single_statement_to_mysql();

--- a/test/pytest/index_cursor.py
+++ b/test/pytest/index_cursor.py
@@ -1,0 +1,95 @@
+import argparse
+import sys
+
+from utils.connection import get_connection
+
+
+ROW_COUNT = 2505  # crosses the 1024-row cursor boundary twice
+
+
+def test_index_cursor(db, cursor):
+    cursor.execute("DROP DATABASE IF EXISTS ha_lineairdb_test")
+    cursor.execute("CREATE DATABASE ha_lineairdb_test")
+    cursor.execute(
+        """
+        CREATE TABLE ha_lineairdb_test.index_cursor (
+            pk INT NOT NULL PRIMARY KEY,
+            sk INT NOT NULL,
+            payload VARCHAR(20) NOT NULL,
+            KEY idx_sk (sk)
+        ) ENGINE=LineairDB
+        """
+    )
+
+    rows = [(i, i // 3, f"v{i}") for i in range(ROW_COUNT)]
+    cursor.executemany(
+        "INSERT INTO ha_lineairdb_test.index_cursor VALUES (%s, %s, %s)",
+        rows,
+    )
+    db.commit()
+
+    cursor.execute(
+        "SELECT MIN(pk), MAX(pk) FROM ha_lineairdb_test.index_cursor"
+    )
+    if cursor.fetchone() != (0, ROW_COUNT - 1):
+        print("MIN/MAX did not return the index endpoints")
+        return 1
+
+    cursor.execute("SELECT MAX(sk) FROM ha_lineairdb_test.index_cursor")
+    if cursor.fetchone() != ((ROW_COUNT - 1) // 3,):
+        print("secondary-index MAX did not return the index tail")
+        return 1
+
+    cursor.execute("SELECT MIN(sk) FROM ha_lineairdb_test.index_cursor")
+    if cursor.fetchone() != (0,):
+        print("secondary-index MIN did not return the index head")
+        return 1
+
+    cursor.execute(
+        "SELECT pk FROM ha_lineairdb_test.index_cursor "
+        "FORCE INDEX(PRIMARY) ORDER BY pk"
+    )
+    ascending = [row[0] for row in cursor.fetchall()]
+    if ascending != list(range(ROW_COUNT)):
+        print(f"forward primary cursor mismatch: {len(ascending)} rows")
+        return 1
+
+    cursor.execute(
+        "SELECT pk FROM ha_lineairdb_test.index_cursor "
+        "FORCE INDEX(PRIMARY) ORDER BY pk DESC"
+    )
+    descending = [row[0] for row in cursor.fetchall()]
+    if descending != list(range(ROW_COUNT - 1, -1, -1)):
+        print(f"reverse primary cursor mismatch: {len(descending)} rows")
+        return 1
+
+    cursor.execute(
+        "SELECT sk FROM ha_lineairdb_test.index_cursor "
+        "FORCE INDEX(idx_sk) ORDER BY sk DESC"
+    )
+    secondary = [row[0] for row in cursor.fetchall()]
+    expected_secondary = sorted((i // 3 for i in range(ROW_COUNT)), reverse=True)
+    if secondary != expected_secondary:
+        print(f"reverse secondary cursor mismatch: {len(secondary)} rows")
+        return 1
+
+    print("INDEX CURSOR TEST PASSED")
+    return 0
+
+
+def main():
+    db = get_connection(user=args.user, password=args.password)
+    cursor = db.cursor()
+    try:
+        sys.exit(test_index_cursor(db, cursor))
+    finally:
+        cursor.close()
+        db.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="LineairDB index cursor test")
+    parser.add_argument("--user", default="root")
+    parser.add_argument("--password", default="")
+    args = parser.parse_args()
+    main()


### PR DESCRIPTION
## Summary
- Replace unbounded primary `index_first()` and `index_last()` materialization with a cursor that reads ahead at most 1024 rows and refills when MySQL continues through `index_next()` or `index_prev()`.
- Advance reverse secondary-index scans one secondary-key group at a time instead of materializing the complete index.
- Fail closed when range, batch-read, prefix, or secondary-tail RPCs lose their server connection.
- Propagate transport failures through both normal and prefetch commit paths, returning `HA_ERR_NO_CONNECTION` instead of retryable deadlock 149.
- Add a 2505-row regression test covering endpoint reads and cursor refills across two read-ahead boundaries.

## Why
MySQL uses `index_first()` and `index_last()` both for one-row endpoint lookups such as `MIN()` and `MAX()` and as the start of a continued index scan. The storage-engine handler is not told whether `index_next()` or `index_prev()` will follow.

The primary endpoint paths materialized every matching key and value before returning one row. At YCSB SF=5000, the response reached 5,243,888,895 bytes, exceeded the uint32 RPC frame limit, and caused lineairdb-server to close the socket. Both `SELECT MAX(ycsb_key)` and `SELECT MIN(ycsb_key)` then surfaced as error 149 during COMMIT.

The range proxy also returned an empty vector on transport failure without aborting the transaction. That made a dead connection indistinguishable from a valid empty result until commit, and could silently produce an empty aggregate result if no later RPC exposed the failure.

## Details
- Primary endpoint cursors read ahead at most 1024 rows.
- Endpoint-only queries consume one row and discard the unused read-ahead.
- Continued scans consume the buffered rows before issuing another RPC.
- Forward continuation resumes immediately after the last serialized key.
- Reverse continuation uses the smallest key in the previous read-ahead as its exclusive upper bound.
- Empty reverse upper bounds are normalized to `scan_end_sentinel()` because the current Masstree reverse walk does not reliably treat an absent bound as positive infinity.
- Reverse secondary scans use the existing tail-entry RPC and advance one complete secondary-key group at a time.
- `mark_transport_error()` aborts the transaction while preserving the transport-specific reason.
- Normal `DB_END_TRANSACTION` and prefetch `TX_VALIDATE_AND_COMMIT` both propagate transport failure to the MySQL handler.
- Genuine OCC aborts continue to return `HA_ERR_LOCK_DEADLOCK`; transport failures return `HA_ERR_NO_CONNECTION`.
