### PR TITLE
feat(proxy): serve key-less primary tails under prefetch

### DIFF
--- a/bench/bin/benchrun.py
+++ b/bench/bin/benchrun.py
@@ -331,7 +331,7 @@ def _stop_metrics(samplers):
         fh.close()
 
 
-def setup_benchmark(benchmark, config_path, mysql_host, mysql_port):
+def setup_benchmark(benchmark, config_path, mysql_host, mysql_port, log_dir=None):
     """Reset DB, create schema, load data. Returns load_time or None on failure."""
     db_name = "benchbase"
 
@@ -345,6 +345,11 @@ def setup_benchmark(benchmark, config_path, mysql_host, mysql_port):
 
     print("  Creating schema + Loading data...")
     result = run_benchbase(benchmark, config_path, create=True, load=True, execute=False)
+    if log_dir:
+        try:
+            (Path(log_dir) / "benchbase_load.log").write_text(result.stdout + result.stderr)
+        except OSError as e:
+            print(f"  WARNING: could not save load log: {e}", file=sys.stderr)
     if result.returncode != 0:
         print(f"  ERROR during create/load:\n{result.stdout[-500:]}\n{result.stderr[-500:]}", file=sys.stderr)
         return None
@@ -840,7 +845,8 @@ def _run_bench(args, config_work, thread_list, result_base):
             print(f"  WARNING: CREATE had errors (may be OK for shared-storage)")
         load_time = 0
     else:
-        load_time = setup_benchmark(args.benchmark, config_work, args.mysql_host, args.mysql_port)
+        load_time = setup_benchmark(args.benchmark, config_work, args.mysql_host, args.mysql_port,
+                                    log_dir=result_base)
         if load_time is None:
             print("Setup failed.", file=sys.stderr)
             sys.exit(1)

--- a/proxy/index_scan.cc
+++ b/proxy/index_scan.cc
@@ -33,6 +33,16 @@ bool ha_lineairdb::refill_index_cursor(LineairDBTransaction *tx) {
 
   if (index_cursor_at_eof_) return false;
 
+  // A reverse prefetch cursor serves exactly one staged tail window, and a
+  // refill past it asks for rows the window never held. A complete walk of
+  // exactly the window size cannot be told apart from more, and rejects too.
+  if (tx->is_prefetch_mode() && index_cursor_reverse_ &&
+      !index_cursor_end_key_.empty()) {
+    prefetch_reject_unsupported(ha_thd(), tx,
+                                "reverse cursor past the staged tail window");
+    return false;
+  }
+
   if (index_cursor_secondary_) {
     // The existing tail-entry RPC returns one complete secondary-key group.
     // Using that group as the next exclusive end preserves the original
@@ -317,15 +327,22 @@ int ha_lineairdb::index_last(uchar *buf) {
 
   tx->choose_table(db_table_name);
 
-  // index_last seeks the index tail with no search key: it does not route
-  // through index_read_map and carries no range to build an autogen plan from,
-  // and a statement-scoped plan keyed by the QEP's range cannot cover it.
-  // Reject loudly under no-fallback rather than silently miss the local view.
-  // Range-driven reverse scans (ORDER BY ... DESC LIMIT) are supported; only
-  // this key-less tail seek is not.
-  // TODO: support index_last under prefetch (autogen reverse tail-scan).
+  // A key-less tail seek carries no range for QEP autogen to cover (an
+  // unbounded MAX reaches it straight from the optimizer). Stage the last-N
+  // window on demand; tx-scoped plans and secondary tails keep the loud reject.
   if (tx->is_prefetch_mode()) {
-    return prefetch_reject_unsupported(ha_thd(), tx, "index_last access");
+    if (tx->tx_plan_used()) {
+      return prefetch_reject_unsupported(ha_thd(), tx,
+                                         "index_last access (tx-scoped plan)");
+    }
+    if (active_index != table->s->primary_key) {
+      return prefetch_reject_unsupported(ha_thd(), tx,
+                                         "secondary index tail access");
+    }
+    if (int err = maybe_prefetch_for_index_tail(ha_thd(), tx, db_table_name,
+                                                INDEX_CURSOR_READ_AHEAD_SIZE)) {
+      return err;
+    }
   }
 
   if (active_index == table->s->primary_key) {

--- a/proxy/lineairdb_prefetch.cc
+++ b/proxy/lineairdb_prefetch.cc
@@ -555,6 +555,32 @@ int maybe_prefetch_for_legacy_dml_handler(
   return prefetch_abort_errno(thd, tx);
 }
 
+int maybe_prefetch_for_index_tail(THD *thd, LineairDBTransaction *tx,
+                                  const std::string &table_key,
+                                  uint64_t window_rows) {
+  if (tx == nullptr || !tx->is_prefetch_mode()) return 0;
+  if (tx->tx_plan_used()) return 0;
+
+  sync_autogen_statement(thd, tx);
+  if (tx->autogen_tail_staged(table_key)) return 0;
+  tx->mark_autogen_tail_staged(table_key);
+
+  // One plain primary scan step: last-N of the whole range. The server echoes
+  // the requested bounds as the staged entry's range, so the handler's
+  // ("", sentinel, reverse, N) lookup matches it exactly.
+  LineairDBProxy::ReadPlanStep step;
+  step.table_name = table_key;
+  step.is_scan = true;
+  step.reverse_scan = true;
+  step.scan_limit = window_rows;
+  step.end_key_prefix = lineairdb_keyenc::scan_end_sentinel();
+
+  std::vector<LineairDBProxy::ReadPlanStep> steps;
+  steps.push_back(std::move(step));
+  tx->execute_read_plan(steps);
+  return prefetch_abort_errno(thd, tx);
+}
+
 int prefetch_reject_unsupported(THD *thd, LineairDBTransaction *tx,
                                 const char *reason) {
   std::string msg = "LineairDB prefetch unsupported: ";

--- a/proxy/lineairdb_prefetch.hh
+++ b/proxy/lineairdb_prefetch.hh
@@ -1,6 +1,9 @@
 #ifndef LINEAIRDB_PREFETCH_HH
 #define LINEAIRDB_PREFETCH_HH
 
+#include <cstdint>
+#include <string>
+
 class THD;
 class LineairDBTransaction;
 struct IndexSearchPlan;
@@ -64,6 +67,22 @@ bool prefetch_needs_legacy_dml_handler(THD *thd,
 int maybe_prefetch_for_legacy_dml_handler(
     THD *thd, LineairDBTransaction *tx, TABLE *table, uint index,
     const IndexSearchPlan &search);
+
+/**
+ * @brief Stage the reverse tail window for a key-less primary index_last seek
+ *        under statement-scoped prefetch, at most once per statement and table.
+ *
+ * The handler consumes the window through the ordinary staged-scan lookup,
+ * which registers the reverse+limit range for commit-time replay. `table_key`
+ * must be the key the handler passed to choose_table() so the staged entry and
+ * the lookup agree.
+ *
+ * @return 0 on success or skip (not prefetch mode / tx-scoped plan active).
+ *         Non-zero HA_ERR_* when the staging RPC aborted; propagate it.
+ */
+int maybe_prefetch_for_index_tail(THD *thd, LineairDBTransaction *tx,
+                                  const std::string &table_key,
+                                  uint64_t window_rows);
 
 /**
  * @brief Fail, loudly, a read surface or statement that prefetch mode cannot

--- a/proxy/lineairdb_transaction.cc
+++ b/proxy/lineairdb_transaction.cc
@@ -1302,6 +1302,10 @@ LineairDBTransaction::lookup_range_scan_cache(
          ++rit) {
       const auto& e = range_scan_cache_[*rit];
       if (e.row_limit != 0 && pending_in_range) continue;
+      // A limited window holds K rows adjacent to one endpoint: forward from
+      // start_key (equal here by index key), reverse before end_key. Serving a
+      // reverse window at a different end reads as EOF over rows it never held.
+      if (e.row_limit != 0 && e.reverse_scan && end_key != e.end_key) continue;
       if (e.reverse_scan == reverse_scan && e.row_limit == row_limit &&
           end_key <= e.end_key) {
         // Copy and trim because the staged group may cover a wider range.
@@ -1334,9 +1338,15 @@ LineairDBTransaction::lookup_range_scan_cache(
     const bool same_table = it->table_name == table_name;
     const bool same_direction = it->reverse_scan == reverse_scan;
     const bool same_limit = it->row_limit == row_limit;
+    // A limited window is anchored at one endpoint and cannot serve a request
+    // that moves it. Forward needs the same start and may narrow the end,
+    // reverse the same end and may raise the start.
+    const bool anchored =
+        it->row_limit == 0 || (it->reverse_scan ? end_key == it->end_key
+                                                : start_key == it->start_key);
     const bool covers_range =
         it->start_key <= start_key && end_key <= it->end_key;
-    if (same_table && same_direction && same_limit && covers_range) {
+    if (same_table && same_direction && same_limit && anchored && covers_range) {
       LocalRangeScanEntry cached = *it;
       cached.start_key = start_key;
       cached.end_key = end_key;

--- a/proxy/lineairdb_transaction.hh
+++ b/proxy/lineairdb_transaction.hh
@@ -119,6 +119,7 @@ public:
     autogen_stmt_resolved_ = false;
     autogen_stmt_handler_deferred_ = false;
     autogen_staged_roots_.clear();
+    autogen_tail_staged_.clear();
   }
   bool autogen_stmt_resolved() const { return autogen_stmt_resolved_; }
   void mark_autogen_stmt_resolved() { autogen_stmt_resolved_ = true; }
@@ -129,6 +130,13 @@ public:
   }
   void mark_autogen_root_staged(const void *root) {
     autogen_staged_roots_.insert(root);
+  }
+  // Key-less index_last tail windows staged this statement, keyed by table.
+  bool autogen_tail_staged(const std::string &table_key) const {
+    return autogen_tail_staged_.count(table_key) != 0;
+  }
+  void mark_autogen_tail_staged(const std::string &table_key) {
+    autogen_tail_staged_.insert(table_key);
   }
   bool is_autogen_stmt_handler_deferred() const {
     return autogen_stmt_handler_deferred_;
@@ -199,6 +207,7 @@ private:
   uint64_t autogen_query_id_{0};
   bool autogen_stmt_resolved_{false};
   std::unordered_set<const void*> autogen_staged_roots_;
+  std::unordered_set<std::string> autogen_tail_staged_;
   // Set when this statement's plan is built from the handler index access
   // (deferred legacy-DML path) instead of the QEP; a second handler access
   // then means an index merge the single staged range cannot serve.

--- a/test/pytest/prefetch_index_tail.py
+++ b/test/pytest/prefetch_index_tail.py
@@ -1,0 +1,300 @@
+import argparse
+import sys
+import time
+
+import mysql.connector
+
+from utils.connection import get_connection
+
+
+DBNAME = f"ha_lineairdb_prefetch_index_tail_{int(time.time())}"
+
+# The staged tail window is INDEX_CURSOR_READ_AHEAD_SIZE (1024) rows; use a
+# table larger than one window so window-boundary behavior is exercised.
+ROWS = 2500
+
+_table_seq = 0
+
+
+def reset(cursor, db):
+    cursor.execute(f"DROP DATABASE IF EXISTS {DBNAME}")
+    cursor.execute(f"CREATE DATABASE {DBNAME}")
+    cursor.execute(f"USE {DBNAME}")
+    db.commit()
+
+
+def load_rows(cursor, db, n):
+    # DROP TABLE / DROP DATABASE do not purge LineairDB storage rows (known
+    # upstream bug): a same-name recreate still sees the old rows. Use a fresh
+    # table name per load so shrinking loads are not masked.
+    global _table_seq
+    _table_seq += 1
+    name = f"t{_table_seq}"
+    cursor.execute(
+        f"CREATE TABLE {name} (id INT NOT NULL PRIMARY KEY, v INT NOT NULL) "
+        "ENGINE=LineairDB"
+    )
+    batch = []
+    for i in range(1, n + 1):
+        batch.append(f"({i},{i * 10})")
+        if len(batch) == 500:
+            cursor.execute(f"INSERT INTO {name} VALUES " + ",".join(batch))
+            batch = []
+    if batch:
+        cursor.execute(f"INSERT INTO {name} VALUES " + ",".join(batch))
+    db.commit()
+    return name
+
+
+def stmt_prefetch_on(cursor):
+    # Statement-scoped autogen prefetch: prefetch ON, no @_tx_plan.
+    cursor.execute("SET GLOBAL lineairdb_prefetch_execution=ON")
+    cursor.execute("SET @_tx_plan=NULL")
+
+
+def prefetch_off(cursor):
+    cursor.execute("SET GLOBAL lineairdb_prefetch_execution=OFF")
+
+
+def recover(cursor):
+    try:
+        cursor.execute("ROLLBACK")
+    except mysql.connector.Error:
+        pass
+
+
+def test_max_under_stmt_prefetch(cursor, db):
+    print("PREFETCH INDEX TAIL: MAX under stmt-scoped prefetch")
+    t = load_rows(cursor, db, ROWS)
+    stmt_prefetch_on(cursor)
+    cursor.execute(f"SELECT MAX(id) FROM {t}")
+    got = cursor.fetchone()[0]
+    if got != ROWS:
+        print(f"\tFAILED: MAX(id) = {got}, want {ROWS}")
+        return 1
+    # MAX must also be correct when the statement runs inside an explicit tx.
+    cursor.execute("START TRANSACTION")
+    cursor.execute(f"SELECT MAX(id) FROM {t}")
+    got = cursor.fetchone()[0]
+    cursor.execute("COMMIT")
+    if got != ROWS:
+        print(f"\tFAILED: in-tx MAX(id) = {got}, want {ROWS}")
+        return 1
+    print("\tPassed!")
+    return 0
+
+
+def test_max_small_and_empty(cursor, db):
+    print("PREFETCH INDEX TAIL: MAX on small and empty tables")
+    stmt_prefetch_on(cursor)
+    t = load_rows(cursor, db, 0)
+    cursor.execute(f"SELECT MAX(id) FROM {t}")
+    if cursor.fetchone()[0] is not None:
+        print("\tFAILED: MAX on empty table is not NULL")
+        return 1
+    t = load_rows(cursor, db, 3)
+    cursor.execute(f"SELECT MAX(id) FROM {t}")
+    got = cursor.fetchone()[0]
+    if got != 3:
+        print(f"\tFAILED: MAX(id) = {got}, want 3")
+        return 1
+    print("\tPassed!")
+    return 0
+
+
+def test_desc_limit_within_window(cursor, db):
+    # This shape works under the staged tail window and must succeed.
+    print("PREFETCH INDEX TAIL: ORDER BY pk DESC LIMIT within window")
+    t = load_rows(cursor, db, ROWS)
+    stmt_prefetch_on(cursor)
+    cursor.execute(f"SELECT id FROM {t} ORDER BY id DESC LIMIT 5")
+    got = [r[0] for r in cursor.fetchall()]
+    want = list(range(ROWS, ROWS - 5, -1))
+    if got != want:
+        print(f"\tFAILED: got {got}, want {want}")
+        return 1
+    print("\tPassed!")
+    return 0
+
+
+ER_NOT_SUPPORTED_YET = 1235
+
+
+def test_desc_walk_past_window_never_silent(cursor, db):
+    # A derived-table COUNT would let the optimizer drop the ORDER BY and
+    # bypass index_last; force the backward index walk so the read really
+    # runs off the staged tail window.
+    print("PREFETCH INDEX TAIL: full DESC walk past window is loud or correct")
+    t = load_rows(cursor, db, ROWS)
+    stmt_prefetch_on(cursor)
+    try:
+        cursor.execute(f"SELECT id FROM {t} FORCE INDEX(PRIMARY) "
+                       "ORDER BY id DESC")
+        got = [r[0] for r in cursor.fetchall()]
+    except mysql.connector.Error as e:
+        recover(cursor)
+        if e.errno != ER_NOT_SUPPORTED_YET:
+            print(f"\tFAILED: unexpected error {e.errno}: {e}")
+            return 1
+        print(f"\tPassed (loud reject: {e.errno})")
+        return 0
+    if got != list(range(ROWS, 0, -1)):
+        print(f"\tFAILED: silent truncation, got {len(got)} rows, want {ROWS}")
+        return 1
+    print("\tPassed!")
+    return 0
+
+
+def test_own_write_then_max_never_stale(cursor, db):
+    print("PREFETCH INDEX TAIL: in-tx INSERT then MAX is loud or correct")
+    t = load_rows(cursor, db, ROWS)
+    stmt_prefetch_on(cursor)
+    cursor.execute("START TRANSACTION")
+    cursor.execute(f"INSERT INTO {t} VALUES ({ROWS + 1},0)")
+    failed = None
+    try:
+        cursor.execute(f"SELECT MAX(id) FROM {t}")
+        got = cursor.fetchone()[0]
+        if got != ROWS + 1:
+            failed = f"stale MAX(id) = {got}, want {ROWS + 1} or a loud reject"
+    except mysql.connector.Error as e:
+        if e.errno != ER_NOT_SUPPORTED_YET:
+            failed = f"unexpected error {e.errno}: {e}"
+        else:
+            print(f"\tloud reject mid-tx: {e.errno}")
+    recover(cursor)
+    if failed is not None:
+        print(f"\tFAILED: {failed}")
+        return 1
+    print("\tPassed!")
+    return 0
+
+
+def test_window_boundaries(cursor, db):
+    # INDEX_CURSOR_READ_AHEAD_SIZE is 1024; MAX must be right at 1, K-1, K, K+1.
+    print("PREFETCH INDEX TAIL: MAX at window-size boundaries")
+    stmt_prefetch_on(cursor)
+    for n in (1, 1023, 1024, 1025):
+        t = load_rows(cursor, db, n)
+        cursor.execute(f"SELECT MAX(id) FROM {t}")
+        got = cursor.fetchone()[0]
+        if got != n:
+            print(f"\tFAILED: rows={n}, MAX(id) = {got}")
+            return 1
+    print("\tPassed!")
+    return 0
+
+
+def test_all_tombstone(cursor, db):
+    # The staged tail scan skips tombstones server-side; MAX must be NULL.
+    print("PREFETCH INDEX TAIL: MAX after deleting every row")
+    t = load_rows(cursor, db, 200)
+    # A key-less DELETE is a full table scan, which stmt-prefetch rejects by
+    # design; run the cleanup in baseline mode, then query under prefetch.
+    prefetch_off(cursor)
+    cursor.execute(f"DELETE FROM {t}")
+    db.commit()
+    stmt_prefetch_on(cursor)
+    cursor.execute(f"SELECT MAX(id) FROM {t}")
+    got = cursor.fetchone()[0]
+    if got is not None:
+        print(f"\tFAILED: MAX over tombstones = {got}, want NULL")
+        return 1
+    print("\tPassed!")
+    return 0
+
+
+def test_exact_window_full_desc_walk(cursor, db):
+    # Exactly K live rows: a full backward walk cannot distinguish true EOF
+    # from window overrun (documented limitation), so a loud reject is
+    # acceptable; silent truncation is not.
+    print("PREFETCH INDEX TAIL: exactly-K full DESC walk is loud or correct")
+    t = load_rows(cursor, db, 1024)
+    stmt_prefetch_on(cursor)
+    try:
+        cursor.execute(f"SELECT id FROM {t} FORCE INDEX(PRIMARY) "
+                       "ORDER BY id DESC")
+        got = [r[0] for r in cursor.fetchall()]
+    except mysql.connector.Error as e:
+        recover(cursor)
+        if e.errno != ER_NOT_SUPPORTED_YET:
+            print(f"\tFAILED: unexpected error {e.errno}: {e}")
+            return 1
+        print(f"\tPassed (loud reject: {e.errno})")
+        return 0
+    if got != list(range(1024, 0, -1)):
+        print(f"\tFAILED: silent truncation, got {len(got)} rows, want 1024")
+        return 1
+    print("\tPassed!")
+    return 0
+
+
+def test_baseline_regression(cursor, db):
+    print("PREFETCH INDEX TAIL: baseline (prefetch OFF) MAX still works")
+    t = load_rows(cursor, db, ROWS)
+    prefetch_off(cursor)
+    cursor.execute(f"SELECT MAX(id) FROM {t}")
+    got = cursor.fetchone()[0]
+    if got != ROWS:
+        print(f"\tFAILED: baseline MAX(id) = {got}, want {ROWS}")
+        return 1
+    print("\tPassed!")
+    return 0
+
+
+TESTS = [
+    test_max_under_stmt_prefetch,
+    test_max_small_and_empty,
+    test_desc_limit_within_window,
+    test_desc_walk_past_window_never_silent,
+    test_own_write_then_max_never_stale,
+    test_window_boundaries,
+    test_all_tombstone,
+    test_exact_window_full_desc_walk,
+    test_baseline_regression,
+]
+
+
+def main():
+    db = get_connection(user=args.user, password=args.password)
+    cursor = db.cursor()
+    reset(cursor, db)
+
+    rc = 0
+    for test in TESTS:
+        try:
+            rc |= test(cursor, db)
+        except mysql.connector.Error as e:
+            # Never leave an aborted session behind; fail this test and go on.
+            print(f"\tFAILED (unexpected mysql error): {e}")
+            recover(cursor)
+            rc = 1
+
+    # Close the test connection first: with autocommit off its last SELECT
+    # holds an implicit transaction whose metadata lock would block the
+    # DROP DATABASE below forever.
+    try:
+        db.rollback()
+        cursor.close()
+        db.close()
+    except Exception:
+        pass
+    # Clean up on a fresh connection: the shared one may hold aborted state.
+    try:
+        db2 = get_connection(user=args.user, password=args.password)
+        c2 = db2.cursor()
+        c2.execute("SET GLOBAL lineairdb_prefetch_execution=OFF")
+        c2.execute(f"DROP DATABASE IF EXISTS {DBNAME}")
+        db2.commit()
+        db2.close()
+    except Exception:
+        pass
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--user", default="root")
+    parser.add_argument("--password", default="")
+    args = parser.parse_args()
+    main()


### PR DESCRIPTION
## Summary
- Stage the tail of the primary range as one reverse read-ahead window when a key-less `index_last()` reaches the engine under statement-scoped prefetch, and serve the reverse cursor from it.
- Keep the loud reject for transaction-scoped plans, secondary-index tails, and refills that run past the staged window.
- Require a limited staged window to match the endpoint it was fetched from before the range cache serves it.
- Save the create and load output of a BenchBase run instead of discarding it.
- Add a 9-case regression test for the staged window, its boundaries, tombstones, and forced backward walks.

## Why
MySQL resolves an unbounded `MAX()` by reading one index endpoint. The optimizer calls `index_last()` with no search key, so the call carries no range and the statement exposes no access path for plan autogeneration to read. Prefetch mode rejected it with `ER_NOT_SUPPORTED_YET` and rolled the transaction back. Prefetch has no fallback to the per-operation path, so `SELECT MAX(pk)` could not run at all while prefetch was on.

The staged window is a reverse limited scan, and the range cache accepted any contained sub-range. Such a window only holds the rows next to the endpoint it was counted from, so a request whose anchored endpoint had moved trimmed to rows the window never held and read as a false end of scan. That surfaced only as a retryable abort at commit replay, so the cache rule is tightened before the window is introduced.

The change covers the primary index only. A transaction-scoped plan is fixed when the transaction begins and cannot be patched afterwards, a reverse secondary scan advances one key group at a time through its own RPC and has no staged-cache surface, and a tail read after a pending row change in the same transaction cannot be served from a staged window. All three keep the loud reject, and an unbounded `MIN()` reaches `index_first()` and stays out of scope.

## Details
- The window is staged once per statement and table, on the first key-less `index_last()` that reaches the engine.
- The staged step is a single reverse primary scan over the whole range whose limit is the cursor read-ahead size, so the handler's own lookup matches the staged entry exactly.
- The handler consumes the window through the existing staged-scan lookup, which registers the reverse limited range for commit-time replay.
- An endpoint query consumes one row of the window, and the read set carries the whole staged range, so such a statement validates more rows than it returned.
- A refill past the staged window is rejected non-retryably. A complete backward walk over exactly the read-ahead size cannot be told apart from a longer one and is rejected as well.
- The range cache requires the anchored endpoint to match, the start for a forward window and the end for a reverse one, while the free endpoint may still narrow. A window whose anchor moved now misses the cache and aborts loudly instead of returning a short result.
- The create and load output carries the loader pool size and the OCC retry warnings, and was discarded after a successful load. It now goes to `benchbase_load.log` in the result directory, written before the return-code check so a failed load leaves the same record; a failed write only prints a warning.
