### PR TITLE
bench: harden the TPC-H kit and its result comparison

### DIFF
--- a/bench/bin/tpch_setup_sf1.sh
+++ b/bench/bin/tpch_setup_sf1.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Load TPC-H into a running helios stack, then apply the postload indexes,
-# ANALYZE statistics, and session settings used by the wall-clock runner.
+# ANALYZE statistics, session settings, and the secondary-engine attach
+# used by the wall-clock runner.
 # Usage: tpch_setup_sf1.sh [--sf 1] [--loader-threads 16] [--socket /tmp/mysql.sock]
 set -euo pipefail
 
@@ -33,24 +34,42 @@ done
 MYSQL="$ROOT/build/runtime_output_directory/mysql"
 [ -x "$MYSQL" ] || MYSQL=$(command -v mysql)
 
-echo "== [1/4] benchbase create+load (SF=$SF) =="
+echo "== [1/5] benchbase create+load (SF=$SF) =="
 python3 "$ROOT/bench/bin/benchrun.py" tpch --scalefactor "$SF" --no-exec \
   --external-server --loader-threads "$LOADERS"
 
-echo "== [2/4] postload 23-index set =="
+echo "== [2/5] postload 23-index set =="
 time "$MYSQL" -u root --socket="$SOCKET" benchbase \
   < "$ROOT/third_party/benchbase/src/main/resources/benchmarks/tpch/postload-mysql.sql"
 
-echo "== [3/4] ANALYZE =="
-"$MYSQL" -u root --socket="$SOCKET" benchbase \
-  -e "ANALYZE TABLE customer, lineitem, nation, orders, part, partsupp, region, supplier;" >/dev/null
+echo "== [3/5] ANALYZE =="
+# ANALYZE intermittently hits ERROR 1213 right after a bulk load; retry
+# instead of failing the whole setup under set -e.
+for attempt in 1 2 3 4 5; do
+  if "$MYSQL" -u root --socket="$SOCKET" benchbase \
+    -e "ANALYZE TABLE customer, lineitem, nation, orders, part, partsupp, region, supplier;" >/dev/null; then
+    break
+  fi
+  if [ "$attempt" = 5 ]; then
+    echo "ANALYZE failed after 5 attempts" >&2
+    exit 1
+  fi
+  echo "ANALYZE attempt $attempt failed; retrying"
+  sleep 2
+done
 
 "$MYSQL" -u root --socket="$SOCKET" -e "SELECT COUNT(*) AS lineitem_rows FROM benchbase.lineitem;"
 
-echo "== [4/4] measurement conditions =="
+echo "== [4/5] measurement conditions =="
 "$MYSQL" -u root --socket="$SOCKET" -e "
   SET GLOBAL lineairdb_prefetch_execution=ON;
   SET GLOBAL optimizer_switch='batched_key_access=on,mrr_cost_based=off,subquery_to_derived=off';
   SET GLOBAL join_buffer_size=1073741824;"
+
+echo "== [5/5] secondary engine attach =="
+for t in customer lineitem nation orders part partsupp region supplier; do
+  "$MYSQL" -u root --socket="$SOCKET" benchbase -e \
+    "ALTER TABLE $t SECONDARY_ENGINE = LINEAIRDB_COLUMNAR; ALTER TABLE $t SECONDARY_LOAD;"
+done
 
 echo "setup done"

--- a/bench/bin/tpch_wall.sh
+++ b/bench/bin/tpch_wall.sh
@@ -65,6 +65,13 @@ echo "# label=$LABEL runs=$RUNS db=$DB queries=$QDIR $(date -Is)" >> "$RESULT"
 
 QLIST=${ONLY:-$(seq 1 22)}
 for q in $QLIST; do
+  # q15 creates and drops a view; a killed run leaves it behind and every
+  # later q15 fails at CREATE. Clean up defensively before each query.
+  if ! "$MYSQL" -u root --socket="$SOCKET" "$DB" -e "DROP VIEW IF EXISTS revenue0;" \
+      2>"$OUT/${LABEL}_q${q}.err"; then
+    echo -e "q$q\tERR\tview-cleanup-failed: $(head -c 120 "$OUT/${LABEL}_q${q}.err" | tr '\t\n' '  ')" >> "$RESULT"
+    continue
+  fi
   SQL_FILE="$QDIR/q$q.sql"
   if [ ! -f "$SQL_FILE" ]; then
     echo "q$q MISSING" >> "$RESULT"

--- a/bench/bin/tpch_wall.sh
+++ b/bench/bin/tpch_wall.sh
@@ -2,6 +2,8 @@
 # Run per-query TPC-H wall-clock timing against a running mysqld.
 # Method: single stream, one discarded warm run, N timed runs, and external
 # mysql-client wall-clock timing.
+# The md5 is over sorted output lines: it checks result multiset equality and
+# deliberately ignores row order, which the spec leaves engine-defined among ties.
 # Usage: tpch_wall.sh <label> [--runs 3] [--db benchbase] [--socket /tmp/mysql.sock]
 #        [--queries bench/queries/tpch] [--out <dir>] [--timeout 120] [--only "1 6 18"]
 #        [--sf 1]
@@ -77,7 +79,7 @@ mkdir -p "$OUT"
 
 RESULT="$OUT/${LABEL}.tsv"
 : > "$RESULT"
-echo "# label=$LABEL runs=$RUNS db=$DB queries=$QDIR $(date -Is)" >> "$RESULT"
+echo "# label=$LABEL runs=$RUNS db=$DB queries=$QDIR sf=$SF $(date -Is)" >> "$RESULT"
 
 for q in $QLIST; do
   # q15 creates and drops a view; a killed run leaves it behind and every
@@ -119,7 +121,10 @@ for q in $QLIST; do
     continue
   fi
 
-  MD5=$(md5sum "$OUT/${LABEL}_q${q}.out" | cut -d' ' -f1)
+  if ! MD5=$(LC_ALL=C sort "$OUT/${LABEL}_q${q}.out" | md5sum | cut -d' ' -f1); then
+    echo -e "q$q\tERR\thash-failed" >> "$RESULT"
+    continue
+  fi
   echo -e "q$q\t$(IFS=,; echo "${TIMES[*]}")\tmd5=$MD5" >> "$RESULT"
   echo "[$LABEL] q$q: ${TIMES[*]} ms"
 done

--- a/bench/bin/tpch_wall.sh
+++ b/bench/bin/tpch_wall.sh
@@ -4,6 +4,7 @@
 # mysql-client wall-clock timing.
 # Usage: tpch_wall.sh <label> [--runs 3] [--db benchbase] [--socket /tmp/mysql.sock]
 #        [--queries bench/queries/tpch] [--out <dir>] [--timeout 120] [--only "1 6 18"]
+#        [--sf 1]
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -17,6 +18,7 @@ QDIR="$ROOT/bench/queries/tpch"
 OUT="$ROOT/bench/results/tpch_wall"
 TIMEOUT=120
 ONLY=""
+SF=1
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -48,12 +50,26 @@ while [ $# -gt 0 ]; do
       ONLY=$2
       shift 2
       ;;
+    --sf)
+      SF=$2
+      shift 2
+      ;;
     *)
       echo "unknown arg $1" >&2
       exit 1
       ;;
   esac
 done
+
+QLIST=${ONLY:-$(seq 1 22)}
+
+# Refuse rather than auto-substitute the fraction: the measured input must stay a checked-in file.
+case " $(echo $QLIST) " in *" 11 "*)
+  if [ "$SF" != "1" ] && [ -f "$QDIR/q11.sql" ] && sed 's/--.*//' "$QDIR/q11.sql" | grep -E '(^|[^0-9])0\.0001([^0-9]|$)' >/dev/null; then
+    echo "q11 in $QDIR is the SF=1 instantiation (FRACTION = 0.0001 / SF); pass an SF-adjusted --queries dir" >&2
+    exit 1
+  fi
+esac
 
 MYSQL="$ROOT/build/runtime_output_directory/mysql"
 [ -x "$MYSQL" ] || MYSQL=$(command -v mysql)
@@ -63,7 +79,6 @@ RESULT="$OUT/${LABEL}.tsv"
 : > "$RESULT"
 echo "# label=$LABEL runs=$RUNS db=$DB queries=$QDIR $(date -Is)" >> "$RESULT"
 
-QLIST=${ONLY:-$(seq 1 22)}
 for q in $QLIST; do
   # q15 creates and drops a view; a killed run leaves it behind and every
   # later q15 fails at CREATE. Clean up defensively before each query.

--- a/bench/queries/tpch/q11.sql
+++ b/bench/queries/tpch/q11.sql
@@ -15,7 +15,7 @@ GROUP BY
 HAVING
    SUM(ps_supplycost * ps_availqty) > (
    SELECT
-      SUM(ps_supplycost * ps_availqty) * 0.0001
+      SUM(ps_supplycost * ps_availqty) * 0.0001 -- FRACTION = 0.0001 / SF (this file is the SF=1 instantiation)
    FROM
       partsupp, supplier, nation
    WHERE

--- a/bench/queries/tpch/q18.sql
+++ b/bench/queries/tpch/q18.sql
@@ -20,7 +20,7 @@ WHERE
       GROUP BY
          l_orderkey
       HAVING
-         SUM(l_quantity) > 300
+         SUM(l_quantity) > 300 -- 300 is the qualification value (performance draws use 312-315)
    )
    AND c_custkey = o_custkey
    AND o_orderkey = l_orderkey

--- a/bench/queries/tpch/q6.sql
+++ b/bench/queries/tpch/q6.sql
@@ -6,5 +6,5 @@ FROM
 WHERE
    l_shipdate >= DATE '1994-01-01'
    AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' YEAR
-   AND l_discount BETWEEN '0.06' - 0.01 AND '0.06' + 0.01
+   AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
    AND l_quantity < 24;


### PR DESCRIPTION
## Summary

Harden the TPC-H measurement kit after a cross-reviewed audit of its 22 frozen queries: make the setup and runner failure paths loud or self-healing where they were silent, manual, or needlessly fatal, restore the spec predicate in q6, pin the two constants that are easy to misuse (q11's scale-factor fraction, backed by a runner guard; q18's qualification threshold, by annotation), and change the cross-system result gate from raw-output md5 to sorted-line md5 so it checks client-output line-multiset equality for the hashed execution instead of engine-defined row order.

## Why

The kit is the instrument for the three-way result-equivalence and wall-clock comparison (Helios bridge, TiDB, MySQL InnoDB), so a silent defect in it can invalidate or mislabel downstream runs.
The audit found missing or brittle harness steps plus three comparison-integrity defects: secondary-engine attachment was undocumented and manual, post-load ANALYZE could abort on an intermittent deadlock, an interrupted q15 could leave its view behind and make later q15 runs fail at CREATE, q6's string-quoted parameter evaluated a predicate one discount bucket narrower than the spec's, q11's fraction was only correct at scale factor 1 with nothing refusing other scale factors, and the raw-output hash turned spec-legal tie reordering into false mismatches (q11 produced a real one).
The governing policy: the official query text is never edited for the comparison's sake; the comparison and the harness are fixed instead.

## Details

### Setup and runner hardening

The setup script attaches the secondary engine and issues SECONDARY_LOAD for every table as an explicit final phase, tries the post-load ANALYZE up to five times before failing loudly, and the wall runner drops a leftover q15 view before each query, recording a failed cleanup as that query's ERR row.

### q6 spec predicate

On DuckDB, the quoted discount parameter forced the BETWEEN bounds into floating point and put the upper bound just below 0.07, excluding rows with l_discount = 0.07.
MySQL's documented coercion rules and the earlier three-way result agreement support the same diagnosis for MySQL and TiDB.
Unquoting the parameter keeps the arithmetic in exact decimal and restores the spec's inclusive 0.05 through 0.07 range.

### Scale-factor and qualification pinning

q11's fraction line now carries its scaling rule (FRACTION = 0.0001 / SF; the kit file is the SF=1 instantiation) and q18's threshold carries its status as the qualification value outside the performance draw range.
The wall runner gains an --sf flag and, when q11 is selected, refuses a declared scale factor other than 1 while q11 still carries the stock fraction, before anything is written.
The refusal is deliberate: the measured input must stay a checked-in file, so the runner never rewrites query text, and non-SF=1 runs must supply an SF-adjusted query directory.

### Order-independent result gate

The per-query hash is now taken over the final timed run's sorted client-output lines, so comparing systems checks textual row-multiset equality for that execution and deliberately ignores row order, since the spec prescribes the sort keys for every ordered result but leaves order among equal keys engine-defined.
A hash pipeline failure is recorded as that query's ERR row instead of a plausible-looking digest, and the declared scale factor is recorded in the result header.

## Verification

The --sf guard was exercised directly: a stock kit with a declared scale factor of 10 is refused before any output is created, an SF-adjusted q11 with its annotation kept passes, and a run that excludes q11 is not probed.
The hash path was fault-injected: a failing sort or md5sum produces the query's ERR row rather than a digest, and permuted or duplicated input lines were checked to hash order-independently and duplicate-sensitively.
The corrected q6 predicate was executed live on DuckDB, which admits 0.07 into the range; MySQL and TiDB were not live-tested, as stated under Limitations.
No full three-way wall run was performed for this PR.

## Limitations

- A tie exactly at a LIMIT boundary (possible in q3, q10, q18) can still legitimately change the returned row set; such a mismatch remains a manual check that the differing rows share the boundary sort key.
- The q6 coercion behavior was reproduced live only on DuckDB; neither MySQL nor TiDB was live-tested during the audit, so the first wall run after this change must check q6 across all three systems.
- Hashes recorded before this change are not comparable to the new sorted-line hashes.
- q6 now aggregates more rows than before, so its timings and results are not comparable to earlier runs; earlier cross-system hashes establish agreement only for the previous, narrower predicate, and this PR makes no performance claim.
- The --sf guard is one-directional: when q11 is selected, it rejects a declared non-1 scale factor only if the selected q11 file contains an uncommented 0.0001 token; it does not validate an adjusted fraction against the declared scale, cannot detect the database's loaded scale factor, and defaults the flag to 1.
- The 22 frozen qualification queries are a single parameter point, not a generated power or throughput stream; per-query wall-clock comparisons from this kit should not be generalized to overall TPC-H performance.
- The setup applies the existing post-load index set, which includes redundant composites that favor row-store paths; whether comparison peers received identical index DDL remains environment metadata to disclose with any three-way numbers.
- Only the final timed run is hashed, so result instability in earlier timed repetitions can go undetected; this includes nondeterministic row-set selection at a LIMIT boundary.
- The gate compares mysql-client text rather than typed values; it depends on the bridge's current MySQL-shaped numeric normalization and consistent client rendering, while the runner can fall back to the mysql client found on PATH.
- The sorted-line hash checks only the returned multiset; a cross-system disagreement in the prescribed sort order itself is no longer visible to the gate.
- BenchBase's own Q6 template shares the string-bind origin of the q6 defect and its Q11 template computes the fraction correctly at run time; aligning the fork is a separate follow-up.
- The q15 view lifecycle (CREATE and DROP inside the timed file) is the official query form and is kept; the DDL cost lands inside the timed window on all systems and is expected to weigh heaviest on TiDB, whose DDL runs through an owner job, but its magnitude has not been measured; the runner-side cleanup protects only runs driven by the wall runner, and the query file itself carries no guard.
