### PR TITLE
bench: fan BenchBase out across MySQL endpoints without HAProxy

### DIFF
--- a/bench/bin/benchrun.py
+++ b/bench/bin/benchrun.py
@@ -196,6 +196,32 @@ def update_xml(config_path, **kwargs):
     config_path.write_text(text)
 
 
+def _parse_mysql_endpoints(host_arg, default_port):
+    """Parse --mysql-host into [(host, port), ...].
+
+    Accepts a single host or a comma-separated list of endpoints; each
+    entry is either a bare host (uses default_port) or host:port.
+    """
+    endpoints = []
+    for entry in host_arg.split(","):
+        entry = entry.strip()
+        if not entry:
+            sys.exit(f"Empty endpoint in --mysql-host: {host_arg!r}")
+        if "[" in entry or "]" in entry:
+            sys.exit(f"Bracketed IPv6 is not supported in --mysql-host: {entry!r}")
+        host, sep, port = entry.rpartition(":")
+        if sep and ":" not in host:
+            if not host:
+                sys.exit(f"Empty host in --mysql-host entry: {entry!r}")
+            if not port.isdigit():
+                sys.exit(f"Bad port in --mysql-host entry: {entry!r}")
+            endpoints.append((host, int(port)))
+        else:
+            # No port suffix, or a bare IPv6 literal: use the default port.
+            endpoints.append((entry, default_port))
+    return endpoints
+
+
 def _benchbase_plugin(benchmark):
     """BenchBase plugin name for a benchrun benchmark name.
 
@@ -698,8 +724,11 @@ def main():
     parser.add_argument("--scalefactor", type=float, default=1, help="Scale factor (default: 1)")
     parser.add_argument("--time", type=int, default=60, help="Execute time in seconds (default: 60)")
     parser.add_argument("--profile", type=str, default="a", help="YCSB profile: a,b,c,e,f (default: a)")
-    parser.add_argument("--mysql-host", type=str, default="127.0.0.1")
-    parser.add_argument("--mysql-port", type=int, default=3307)
+    parser.add_argument("--mysql-host", type=str, default="127.0.0.1",
+                        help="MySQL host, or comma-separated host[:port] endpoints for BenchBase "
+                             "loadbalance (control-plane operations always target the first endpoint)")
+    parser.add_argument("--mysql-port", type=int, default=3307,
+                        help="Default port for --mysql-host entries without an explicit port (default: 3307)")
     parser.add_argument("--loader-threads", type=int, default=1, help="Number of parallel loader threads (default: 1)")
     parser.add_argument("--exclude-queries", type=str, help="TPC-H: comma-separated query numbers to exclude (e.g. 15,21)")
     parser.add_argument("--no-setup", action="store_true", help="Skip setup (DROP+CREATE+LOAD), assume data exists")
@@ -740,14 +769,32 @@ def main():
 
     # Update config: scalefactor, time, and JDBC URL (host:port)
     update_xml(config_work, scalefactor=str(args.scalefactor), time=str(args.time))
-    # Rewrite JDBC URL to match --mysql-host/--mysql-port
+    # Rewrite the JDBC URL. --mysql-host may be comma-separated endpoints;
+    # more than one switches to the loadbalance scheme for the execute phase
+    # while control-plane operations keep targeting the first endpoint.
+    endpoints = _parse_mysql_endpoints(args.mysql_host, args.mysql_port)
     text = config_work.read_text()
-    text = re.sub(
-        r"jdbc:mysql://[^/]+/",
-        f"jdbc:mysql://{args.mysql_host}:{args.mysql_port}/",
-        text,
-    )
+    if len(endpoints) > 1:
+        hostports = ",".join(f"{h}:{p}" for h, p in endpoints)
+        print(f"  Multi-endpoint MySQL: {hostports} (control-plane -> {endpoints[0][0]}:{endpoints[0][1]})")
+        text = re.sub(
+            r"jdbc:mysql://[^/]+/",
+            f"jdbc:mysql:loadbalance://{hostports}/",
+            text,
+        )
+    else:
+        host, port = endpoints[0]
+        text = re.sub(
+            r"jdbc:mysql://[^/]+/",
+            f"jdbc:mysql://{host}:{port}/",
+            text,
+        )
     config_work.write_text(text)
+    # Collapse args.mysql_host/port to the first endpoint so every downstream
+    # control-plane use (mysql_cmd calls, local-mode detection) is scoped to
+    # it automatically. No-op for the single-endpoint case.
+    args.mysql_endpoints = endpoints
+    args.mysql_host, args.mysql_port = endpoints[0]
     # TPC-H with multiple terminals needs parallel mode (serial=false + time tag)
     if args.benchmark == "tpch" and (args.sweep or args.terminals > 1):
         text = config_work.read_text()
@@ -813,6 +860,16 @@ def main():
     if managed and _is_port_open("127.0.0.1", args.mysql_port):
         print(f"  mysqld already listening on port {args.mysql_port}, switching to external mode")
         managed = False
+    # stop_mysql.sh kills every local mysqld, not just the one started here.
+    if managed and len(args.mysql_endpoints) > 1:
+        sys.exit("Multi-endpoint --mysql-host requires --external-server: "
+                 "the managed lifecycle starts one mysqld but stops them all.")
+    # Setup through the loadbalance URL spreads DDL across endpoints, and an
+    # index created on a non-loader node is silently absent elsewhere.
+    if len(args.mysql_endpoints) > 1 and not args.no_setup:
+        sys.exit("Multi-endpoint --mysql-host requires --no-setup: "
+                 "set up the loader endpoint first, then create the schema "
+                 "on each remaining endpoint, then rerun with --no-setup.")
 
     if managed:
         # Wipe any WAL left by a previous run before starting a fresh server,
@@ -837,10 +894,15 @@ def main():
 def _run_bench(args, config_work, thread_list, result_base):
     """Setup + execute sweep + summary + plots. Extracted so main() can wrap it."""
     # Toggle Prefetch sysvar explicitly to avoid stale state from prior runs.
+    # The master sysvar is per-mysqld and volatile, so set it on every endpoint
+    # and fail fast: an endpoint left on the wrong mode corrupts the run.
     prefetch_value = "ON" if (args.prefetch or args.prefetch_stmt) else "OFF"
     print(f"  Setting lineairdb_prefetch_execution={prefetch_value}")
-    mysql_cmd(args.mysql_port, args.mysql_host,
-              f"SET GLOBAL lineairdb_prefetch_execution={prefetch_value};")
+    for host, port in args.mysql_endpoints:
+        result = mysql_cmd(port, host,
+                           f"SET GLOBAL lineairdb_prefetch_execution={prefetch_value};")
+        if result.returncode != 0:
+            sys.exit(f"Failed to set lineairdb_prefetch_execution on {host}:{port}")
 
     # Setup phase
     load_time = None

--- a/bench/bin/benchrun.py
+++ b/bench/bin/benchrun.py
@@ -334,6 +334,25 @@ def _stop_metrics(samplers):
         fh.close()
 
 
+def run_analyze(benchmark, mysql_host, mysql_port):
+    """Refresh optimizer statistics with ANALYZE TABLE."""
+    # Tx-scoped prefetch requires MySQL's chosen plan to match the @_tx_plan
+    # DSL; without fresh stats MySQL can pick PRIMARY where the DSL expects a
+    # secondary index and retry forever, so those runs analyze automatically.
+    analyze_sql = {
+        "tpcc":   "ANALYZE TABLE customer, district, history, item, new_order, oorder, order_line, stock, warehouse;",
+        "tpcc-np": "ANALYZE TABLE customer, district, history, item, new_order, oorder, order_line, stock, warehouse;",
+        "ycsb":   "ANALYZE TABLE usertable;",
+        "tpch":   "ANALYZE TABLE customer, lineitem, nation, orders, part, partsupp, region, supplier;",
+    }.get(benchmark)
+    if not analyze_sql:
+        return
+    print("  Refreshing MySQL stats (ANALYZE TABLE)...")
+    result = mysql_cmd(mysql_port, mysql_host, f"USE benchbase; {analyze_sql}")
+    if result.returncode != 0:
+        sys.exit(f"ANALYZE TABLE failed on {mysql_host}:{mysql_port}")
+
+
 def setup_benchmark(benchmark, config_path, mysql_host, mysql_port, log_dir=None):
     """Reset DB, create schema, load data. Returns load_time or None on failure."""
     db_name = "benchbase"
@@ -361,22 +380,6 @@ def setup_benchmark(benchmark, config_path, mysql_host, mysql_port, log_dir=None
     load_time = float(load_match.group(1)) if load_match else None
     if load_time:
         print(f"  Load time: {load_time:.1f}s")
-
-    # Prefetch mode requires MySQL's chosen plan to match the @_tx_plan DSL.
-    # Without fresh stats, MySQL can pick PRIMARY for queries the DSL expects
-    # to take via a secondary index (e.g. OrderStatus customerByNameSQL),
-    # leading to plan/DSL mismatch and infinite prefetch retry. Refresh stats
-    # unconditionally so stateful and prefetch runs see the same optimizer
-    # decisions.
-    analyze_sql = {
-        "tpcc":   "ANALYZE TABLE customer, district, history, item, new_order, oorder, order_line, stock, warehouse;",
-        "tpcc-np": "ANALYZE TABLE customer, district, history, item, new_order, oorder, order_line, stock, warehouse;",
-        "ycsb":   "ANALYZE TABLE usertable;",
-        "tpch":   "ANALYZE TABLE customer, lineitem, nation, orders, part, partsupp, region, supplier;",
-    }.get(benchmark)
-    if analyze_sql:
-        print("  Refreshing MySQL stats (ANALYZE TABLE)...")
-        mysql_cmd(mysql_port, mysql_host, f"USE {db_name}; {analyze_sql}")
 
     return load_time
 
@@ -702,6 +705,8 @@ def main():
     parser.add_argument("--no-setup", action="store_true", help="Skip setup (DROP+CREATE+LOAD), assume data exists")
     parser.add_argument("--no-load", action="store_true", help="Run setup with CREATE only, skip LOAD")
     parser.add_argument("--no-exec", action="store_true", help="Run setup only, skip execute phase")
+    parser.add_argument("--analyze", action="store_true",
+                        help="Run ANALYZE TABLE after load (automatic for tx-scoped --prefetch runs)")
     parser.add_argument("--external-server", action="store_true",
                         help="Skip auto start/stop of lineairdb-server and mysqld (assume already running)")
     parser.add_argument("--keep-lineairdb-logs", action="store_true",
@@ -857,6 +862,10 @@ def _run_bench(args, config_work, thread_list, result_base):
         if load_time is None:
             print("Setup failed.", file=sys.stderr)
             sys.exit(1)
+
+    # A separate step so staged runs (--no-setup, --no-load) still get it.
+    if args.analyze or args.prefetch:
+        run_analyze(args.benchmark, args.mysql_host, args.mysql_port)
 
     if args.no_exec:
         print("  Skipping execute (--no-exec)")

--- a/bench/bin/benchrun.py
+++ b/bench/bin/benchrun.py
@@ -156,7 +156,10 @@ def cleanup_lineairdb_logs():
     if not LINEAIRDB_LOG_DIR.exists():
         return
 
-    if _find_pid("/build/server/lineairdb-server"):
+    # Match start_lineairdb_server()'s reuse predicate (port) and catch a
+    # relative-path launch that is not listening yet. A launch racing the
+    # unlink below stays possible; the bench launcher does not do that.
+    if _find_pid("build/server/lineairdb-server") or _is_port_open("127.0.0.1", 9999):
         print("  Skipping lineairdb_logs cleanup: lineairdb-server is still running")
         return
 
@@ -807,6 +810,10 @@ def main():
         managed = False
 
     if managed:
+        # Wipe any WAL left by a previous run before starting a fresh server,
+        # so stale logs never trigger recovery. No-op if lineairdb-server is
+        # already running (reuse case, handled inside the function).
+        cleanup_lineairdb_logs()
         if not start_lineairdb_server():
             sys.exit(1)
         if not start_mysql_server(args.mysql_port, "127.0.0.1", 9999):


### PR DESCRIPTION
## Summary

Let `benchrun.py` drive several MySQL query nodes directly, without HAProxy in front of them: `--mysql-host` takes a comma-separated list of endpoints and the BenchBase JDBC URL switches to the Connector/J loadbalance scheme when more than one is given.
Alongside it, the post-load `ANALYZE TABLE` becomes opt-in outside tx-scoped prefetch, a managed run wipes any stale WAL before starting the server, and the LineairDB submodule moves to `research/helios` at the merge that indexes the point lookups on a transaction's read and write sets instead of scanning them.

## Why

HAProxy acted only as a connection balancer in the TPC-C scale-out runs; it offered no statement-level retry or failover, and it added one network hop to every statement while costing a dedicated node.
Connector/J can spread terminals across nodes by itself: a load-balanced connection pins each transaction to one host and re-balances at commit boundaries, which is the granularity the benchmark needs.
The post-load ANALYZE was added when the optimizer had no other source of index statistics, but the storage server has since supplied index statistics on demand as well (row counts were already piggybacked on commit replies), so for prefetch-off and statement-prefetch runs the step only repeats a full index scan whose cost grows with the warehouse count.
A stale WAL left by an interrupted run made the next managed start replay it as recovery, which is never what a fresh benchmark wants.
The LineairDB change removes a quadratic scan that dominated single-transaction bulk loads.

## Details

### Multiple MySQL endpoints

`--mysql-host` accepts `host` or `host:port` entries separated by commas.
With one plain host entry the generated URL is unchanged, and a single `host:port` entry, which used to yield a malformed URL, now works; with several entries the URL becomes `jdbc:mysql:loadbalance://h1:p1,h2:p2,.../benchbase?...` with the existing query parameters preserved.
Control-plane operations (schema, load, ANALYZE, mysql-client calls) always target the first endpoint, while the volatile per-mysqld sysvar `lineairdb_prefetch_execution` is set on every endpoint and a failing endpoint aborts the run.
Two combinations are refused with an explanatory error: setup with several endpoints, because DDL issued through the balanced URL lands on an arbitrary node, and the managed lifecycle with several endpoints, because the stop script kills every local mysqld.
The parser rejects empty entries, empty hosts, non-numeric ports, and bracketed IPv6 literals; a bare IPv6 literal passes through whole with the default port, as before.

### ANALYZE as a separate, opt-in step

`run_analyze()` runs after setup, in the same place for full, create-only, and `--no-setup` runs, when `--analyze` is given or the run uses tx-scoped prefetch.
Tx-scoped prefetch keeps it automatically because MySQL's chosen plan must match the injected plan DSL; without fresh index statistics the customer-by-name lookup can fall back to the primary key and retry forever.
A failed ANALYZE aborts the run instead of leaving a silent gap.

### Pre-start WAL wipe

A managed run removes `lineairdb_logs` before starting the server.
The cleanup guard now matches the server start's reuse predicate (a listener on port 9999) in addition to a command-line pattern that also covers relative-path launches, so the WAL of a server the run is about to reuse is not removed; a launch racing the unlink remains possible and is noted in the code.
The end-of-run cleanup and `--keep-lineairdb-logs` are unchanged.

### Submodule bump

`third_party/LineairDB` moves to `research/helios` at the merge of Noxy3301/LineairDB#17: the point read and write lookups on a transaction's read and write sets go through a lazily built position index once a set reaches 64 entries, with the set entry still deciding every match.
The merge loops of the scan paths are not covered and stay linear.

## Verification

Two mysqld instances and one storage server on one box, TPC-C W=4, 8 terminals, 60 s, statement prefetch, no ANALYZE anywhere: 899.3 req/s throughput and 894.9 req/s goodput with zero unexpected errors, and the per-node commit counters split 33,574 to 33,830 (49.8% to 50.2%).
The loading node chose the secondary index for the customer-by-name lookup without ANALYZE, and the other node, whose dictionary lacks that index, returned the same rows through the primary key.
Both refusal guards were exercised from the command line and print their messages before any managed server is started; the endpoint parser was exercised ad hoc with plain hosts, host:port lists, bare IPv6, and each rejected form.
The single-endpoint URL was checked to be byte-identical to the previous output.
The wipe guard's reuse predicate was verified against the start path, and the submodule bump builds green for both the server and the storage-engine copy of the library.
These runs are functional checks on a development box without benchmark tuning; they make no performance claim.

## Limitations

- A load-balanced logical connection may hold a physical connection to every endpoint, so each mysqld needs `max_connections` sized for the full terminal count, not its share.
- Several endpoints need servers started outside `benchrun.py` and a prior single-endpoint setup.
- Schema must be created on the loading node first: a secondary index created through a node whose storage already holds that index is silently absent from that node's dictionary, and a node that has the index while the loader does not reads an index nobody maintains.
  That engine behavior is reported separately.
- Skipping ANALYZE by default changes the run conditions against earlier recorded reference runs, which included it; `--analyze` restores them.
- Plain `benchrun.py tpch` runs without ANALYZE are untested, while the TPC-H kit runs its own ANALYZE.
- The prefetch sysvar step hard-exits against a mysqld without the ha_lineairdb plugin.
- The TPC-H optimizer settings are still applied to the first endpoint only.
- IPv6 endpoints with an explicit port are not supported.
- The pre-start wipe ignores `--keep-lineairdb-logs`; a managed run can no longer start from a kept WAL.
